### PR TITLE
Fix ambiguous column error when joining to a near scope

### DIFF
--- a/lib/geocoder.rb
+++ b/lib/geocoder.rb
@@ -115,7 +115,7 @@ module Geocoder
         conditions << obj.id
       end
       {
-        :group  => columns.map{ |c| c.name}.join(','),
+        :group  => columns.map{ |c| "#{table_name}.#{c.name}" }.join(','),
         :order  => options[:order],
         :limit  => options[:limit],
         :offset => options[:offset],


### PR DESCRIPTION
When using the near scope joined to another model, I hit the error "Column 'id' in group statement is ambiguous", since the GROUP BY clause just listed column names, and, therefore, it wasn't sure which model the ID applied to.

I wrote a quick patch that includes the table name in the grouping clause, and that took care of things for me :)
