### PR TITLE
NameError (uninitialized constant Geocoder::Net)

### DIFF
--- a/lib/geocoder/lookup.rb
+++ b/lib/geocoder/lookup.rb
@@ -1,5 +1,6 @@
 module Geocoder
   module Lookup
+    require 'net/http'
     extend self
 
     ##


### PR DESCRIPTION
Adding a require for net/http solved my problem. I tried adding the :: before Net like you said but it didn't seem to work. 
I hope that helps a bit!
