### PR TITLE
Choosing the format of the address

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -11,7 +11,7 @@ Geocoder is compatible with Rails 2.x and 3.x. <b>This is the README for the 3.x
 
 Add this to your Gemfile:
 
-  gem "rails-geocoder", :require => "geocoder"
+  gem "geocoder"
 
 and run this at the command prompt:
 
@@ -71,7 +71,7 @@ Some utility methods are also available:
   Geocoder::Calculations.distance_between( 48.858205,2.294359,  40.748433,-73.985655 )
 
   # look up coordinates of some location (like searching Google Maps)
-  Geocoder.fetch_coordinates("25 Main St, Cooperstown, NY")
+  Geocoder::Lookup.coordinates("25 Main St, Cooperstown, NY")
 
   # find the geographic center (aka center of gravity) of objects or points
   Geocoder::Calculations.geographic_center([ city1, city2, city3, [40.22,-73.99], city4 ])

--- a/Rakefile
+++ b/Rakefile
@@ -1,43 +1,12 @@
 require 'rubygems'
 require 'rake'
 
-begin
-  require 'jeweler'
-  Jeweler::Tasks.new do |gem|
-    gem.name        = "rails-geocoder"
-    gem.summary     = %Q{Add geocoding functionality to Rails models.}
-    gem.description = %Q{Geocoder adds object geocoding and database-agnostic distance calculations to Ruby on Rails. It does not rely on proprietary database functions so finding geocoded objects in a given area is easily done using out-of-the-box MySQL or even SQLite.}
-    gem.email       = "alex@alexreisner.com"
-    gem.homepage    = "http://github.com/alexreisner/geocoder"
-    gem.authors     = ["Alex Reisner"]
-    # gem is a Gem::Specification... see http://www.rubygems.org/read/chapter/20 for additional settings
-  end
-  Jeweler::GemcutterTasks.new
-rescue LoadError
-  puts "Jeweler (or a dependency) not available. Install it with: sudo gem install jeweler"
-end
-
 require 'rake/testtask'
 Rake::TestTask.new(:test) do |test|
   test.libs << 'lib' << 'test'
   test.pattern = 'test/**/*_test.rb'
   test.verbose = true
 end
-
-begin
-  require 'rcov/rcovtask'
-  Rcov::RcovTask.new do |test|
-    test.libs << 'test'
-    test.pattern = 'test/**/*_test.rb'
-    test.verbose = true
-  end
-rescue LoadError
-  task :rcov do
-    abort "RCov is not available. In order to run rcov, you must: sudo gem install spicycode-rcov"
-  end
-end
-
-task :test => :check_dependencies
 
 task :default => :test
 

--- a/geocoder.gemspec
+++ b/geocoder.gemspec
@@ -1,0 +1,16 @@
+# -*- encoding: utf-8 -*-
+Gem::Specification.new do |s|
+  s.name        = "geocoder"
+  s.version     = File.read(File.join(File.dirname(__FILE__), 'VERSION'))
+  s.platform    = Gem::Platform::RUBY
+  s.authors     = ["Alex Reisner"]
+  s.email       = ["alex@alexreisner.com"]
+  s.homepage    = "http://github.com/alexreisner/geocoder"
+  s.date        = Date.today.to_s
+  s.summary     = "Simple, database-agnostic geocoding and distance calculations for Rails."
+  s.description = "Geocoder adds object geocoding and distance calculations to ActiveRecord models. It does not rely on proprietary database functions so finding geocoded objects in a given area is easily done using out-of-the-box MySQL, PostgreSQL, or SQLite."
+
+  s.files         = Dir.glob("{lib,lib/geocoder,lib/tasks,test}/*") + %w(CHANGELOG.rdoc Rakefile README.rdoc LICENSE)
+  s.require_paths = ["lib"]
+end
+

--- a/lib/geocoder/lookup.rb
+++ b/lib/geocoder/lookup.rb
@@ -31,7 +31,7 @@ module Geocoder
     # or nil if not found or if network error.
     #
     def search(*args)
-      return nil if args[0].blank?
+      return [] if args[0].blank?
       doc = parsed_response(args.join(","), args.size == 2)
       [].tap do |results|
         if doc

--- a/test/geocoder_test.rb
+++ b/test/geocoder_test.rb
@@ -46,4 +46,11 @@ class GeocoderTest < Test::Unit::TestCase
     result = Geocoder::Lookup.address(40.750354, -73.993371, :house_number)
     assert_equal nil, result
   end
+
+  def test_does_not_choke_on_nil_address
+    v = Venue.new("Venue", nil)
+    assert_nothing_raised do
+      v.fetch_coordinates
+    end
+  end
 end


### PR DESCRIPTION
I've came to this limitation when in my project I needed to store only a city and a country name in my model's address column, but existing geocoder implementation always uses full address.

So I added an optional parameter :format to reverse geocoding, which allows you to pick one of the google's address types and have a proper address in your database.

I thought that some people might need this feature like I did, so you might want to include it in the original repo.

Some tests are included as well.
