### PR TITLE
Language settings

### DIFF
--- a/lib/geocoder/configuration.rb
+++ b/lib/geocoder/configuration.rb
@@ -5,12 +5,16 @@ module Geocoder
 
     def self.lookup; @@lookup; end
     def self.lookup=(obj); @@lookup = obj; end
+    
+    def self.google_language; @@google_language; end
+    def self.google_language=(obj); @@google_language = obj; end
 
     def self.yahoo_appid; @@yahoo_appid; end
     def self.yahoo_appid=(obj); @@yahoo_appid = obj; end
   end
 end
 
-Geocoder::Configuration.timeout     = 3
-Geocoder::Configuration.lookup      = :google
-Geocoder::Configuration.yahoo_appid = ""
+Geocoder::Configuration.timeout         = 3
+Geocoder::Configuration.lookup          = :google
+Geocoder::Configuration.google_language = :en
+Geocoder::Configuration.yahoo_appid     = ""

--- a/lib/geocoder/lookups/google.rb
+++ b/lib/geocoder/lookups/google.rb
@@ -22,7 +22,8 @@ module Geocoder::Lookup
     def query_url(query, reverse = false)
       params = {
         (reverse ? :latlng : :address) => query,
-        :sensor => "false"
+        :sensor => "false",
+        :language => Geocoder::Configuration.google_language
       }
       "http://maps.google.com/maps/api/geocode/json?" + hash_to_query(params)
     end


### PR DESCRIPTION
The language of the google geocoder results default to english. So I get "Cologne" as city name instead of "Köln" for example.

I added the "google_language" parameter to the geocoder configuration so you can pass a language code as mentioned in http://googlegeodevelopers.blogspot.com/2009/10/maps-api-v3-now-speaks-your-language.html

A single "language" parameter would be the better approach to this, but the Google geocoder is the only one I'm in at the moment. So I don't know if the language codes are consistent across the different geocoding services.
