### PR TITLE
scopes geocoded & not_geocoded use geocoder_options before definition

### DIFF
--- a/lib/geocoder/orms/active_record.rb
+++ b/lib/geocoder/orms/active_record.rb
@@ -17,14 +17,14 @@ module Geocoder::Orm
       base.class_eval do
 
         # scope: geocoded objects
-        scope :geocoded,
-          :conditions => "#{geocoder_options[:latitude]} IS NOT NULL " +
-            "AND #{geocoder_options[:longitude]} IS NOT NULL"
+        scope :geocoded, lambda {
+          {:conditions => "#{geocoder_options[:latitude]} IS NOT NULL " +
+            "AND #{geocoder_options[:longitude]} IS NOT NULL"}}
 
         # scope: not-geocoded objects
-        scope :not_geocoded,
-          :conditions => "#{geocoder_options[:latitude]} IS NULL " +
-            "OR #{geocoder_options[:longitude]} IS NULL"
+        scope :not_geocoded, lambda {
+          {:conditions => "#{geocoder_options[:latitude]} IS NULL " +
+            "OR #{geocoder_options[:longitude]} IS NULL"}}
 
         ##
         # Find all objects within a radius (in miles) of the given location


### PR DESCRIPTION
In geocoder_init you include active_record before initializing geocoder_options. as a consequence the scopes geocoded & not_geocoded use an empty hash for geocoder_options, and the generated sql is broken.

I delay the evaluation of geocoder_options to avoid this.

Maybe it would be better to rewrite geocoder_init?
