### PR TITLE
avoid doc['status'] failure when doc is nil

### DIFF
--- a/lib/geocoder/lookups/google.rb
+++ b/lib/geocoder/lookups/google.rb
@@ -7,7 +7,7 @@ module Geocoder::Lookup
     private # ---------------------------------------------------------------
 
     def result(query, reverse = false)
-      doc = fetch_data(query, reverse)
+      doc = fetch_data(query, reverse) || {}
       case doc['status']; when "OK" # OK status implies >0 results
         doc['results'].first
       when "OVER_QUERY_LIMIT"


### PR DESCRIPTION
If the lower level code has an error (ie time's out, no network connection etc) doc is nil. My change avoids crashing the app when referencing doc['status'].

I only use google.  This change might be required for the other geocoders.
