### PR TITLE
Adding HTTPS option for Google geocode api lookups

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,14 @@
+PATH
+  remote: .
+  specs:
+    geocoder (0.9.10)
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  geocoder!

--- a/lib/geocoder/configuration.rb
+++ b/lib/geocoder/configuration.rb
@@ -24,6 +24,10 @@ module Geocoder
     # cache object (must respond to #[], #[]=, and #keys
     def self.cache_prefix; @@cache_prefix; end
     def self.cache_prefix=(obj); @@cache_prefix = obj; end
+
+    # Use HTTPS for lookup requests (true or false)
+    def self.use_https; @@use_https; end
+    def self.use_https=(obj); @@use_https = obj; end
   end
 end
 
@@ -33,3 +37,4 @@ Geocoder::Configuration.language     = :en
 Geocoder::Configuration.yahoo_appid  = ""
 Geocoder::Configuration.cache        = nil
 Geocoder::Configuration.cache_prefix = "geocoder:"
+Geocoder::Configuration.use_https    = false

--- a/lib/geocoder/lookups/base.rb
+++ b/lib/geocoder/lookups/base.rb
@@ -79,6 +79,19 @@ module Geocoder
       end
 
       ##
+      # Determines protocol (http/https) to use based on use_https configuration
+      # Only working with Google, as I haven't researched if the other services offer https
+      #
+      def protocol
+        case Geocoder::Configuration.use_https
+        when true
+          "https"
+        else
+          "http"
+        end
+      end
+
+      ##
       # Fetches a raw search result (JSON string).
       #
       def fetch_raw_data(query, reverse = false)

--- a/lib/geocoder/lookups/google.rb
+++ b/lib/geocoder/lookups/google.rb
@@ -25,7 +25,7 @@ module Geocoder::Lookup
         :sensor => "false",
         :language => Geocoder::Configuration.language
       }
-      "http://maps.google.com/maps/api/geocode/json?" + hash_to_query(params)
+      "#{protocol}://maps.google.com/maps/api/geocode/json?" + hash_to_query(params)
     end
   end
 end

--- a/test/geocoder_test.rb
+++ b/test/geocoder_test.rb
@@ -53,6 +53,17 @@ class GeocoderTest < Test::Unit::TestCase
     $VERBOSE = orig
   end
 
+  def test_using_https_for_secure_query
+    g = Geocoder::Lookup::Google.new
+    Geocoder::Configuration.use_https = true
+    assert_match "https:", g.send(:query_url, {:a => 1, :b => 2})
+  end
+
+  def test_using_http_by_default
+    g = Geocoder::Lookup::Google.new
+    assert_match "http:", g.send(:query_url, {:a => 1, :b => 2})
+  end
+
   def test_distance_to_returns_float
     v = Venue.new(*venue_params(:msg))
     v.latitude, v.longitude = [40.750354, -73.993371]


### PR DESCRIPTION
Hey, I hope I'm doing this right, as it's my first pull request-

I added a configuration boolean for use_https, and modified the Google locator to use a "protocol" method to determine whether to form the query with http/https. I covered Google in the accompanying test.

 I wasn't sure if there was an easy way to iterate through all the actual children of Geocoder::Base so I just did Google (plus I don't know if the other services offer https, but Google's the one I'd like to use).

Does this make sense? 
