### PR TITLE
Google api key config

### DIFF
--- a/lib/geocoder/configuration.rb
+++ b/lib/geocoder/configuration.rb
@@ -24,12 +24,17 @@ module Geocoder
     # cache object (must respond to #[], #[]=, and #keys
     def self.cache_prefix; @@cache_prefix; end
     def self.cache_prefix=(obj); @@cache_prefix = obj; end
+
+    # API Key (if ysing Google geocoding service)
+    def self.google_api_key; @@google_api_key; end
+    def self.google_api_key=(obj); @@google_api_key = obj; end
   end
 end
 
-Geocoder::Configuration.timeout      = 3
-Geocoder::Configuration.lookup       = :google
-Geocoder::Configuration.language     = :en
-Geocoder::Configuration.yahoo_appid  = ""
-Geocoder::Configuration.cache        = nil
-Geocoder::Configuration.cache_prefix = "geocoder:"
+Geocoder::Configuration.timeout        = 3
+Geocoder::Configuration.lookup         = :google
+Geocoder::Configuration.language       = :en
+Geocoder::Configuration.yahoo_appid    = ""
+Geocoder::Configuration.cache          = nil
+Geocoder::Configuration.cache_prefix   = "geocoder:"
+Geocoder::Configuration.google_api_key = ""

--- a/lib/geocoder/lookups/google.rb
+++ b/lib/geocoder/lookups/google.rb
@@ -23,7 +23,8 @@ module Geocoder::Lookup
       params = {
         (reverse ? :latlng : :address) => query,
         :sensor => "false",
-        :language => Geocoder::Configuration.language
+        :language => Geocoder::Configuration.language,
+				:key => Geocoder::Configuration.google_api_key
       }
       "http://maps.google.com/maps/api/geocode/json?" + hash_to_query(params)
     end

--- a/test/geocoder_test.rb
+++ b/test/geocoder_test.rb
@@ -220,6 +220,13 @@ class GeocoderTest < Test::Unit::TestCase
     assert_equal "a=1&b=2", g.send(:hash_to_query, {:a => 1, :b => 2})
   end
 
+	def test_has_to_query_with_google_api_key
+		Geocoder::Configuration.google_api_key = "MY_KEY"
+    g = Geocoder::Lookup::Google.new
+    assert_match "key=MY_KEY", g.send(:query_url, {:a => 1, :b => 2})
+		Geocoder::Configuration.google_api_key = nil
+	end
+
 
   private # ------------------------------------------------------------------
 


### PR DESCRIPTION
Added the ability to specify a google api-key for geocoding, and include it in the query. This is covered in the test file, and tested against production in Heroku (which wouldn't geocode without it).
