### PR TITLE
STI models can't be geocoded

### DIFF
--- a/lib/geocoder/models/base.rb
+++ b/lib/geocoder/models/base.rb
@@ -28,7 +28,7 @@ module Geocoder
       private # ----------------------------------------------------------------
 
       def geocoder_init(options)
-        unless geocoder_initialized?
+        unless @geocoder_options
           @geocoder_options = {}
           require "geocoder/stores/#{geocoder_file_name}"
           include eval("Geocoder::Store::" + geocoder_module_name)


### PR DESCRIPTION
Hey alexreisner, in geocoder 1.0.0 an STI model whose parent is `geocoded_by` can't be geocoded. Doing so raises 

```
NoMethodError: undefined method `merge!' for nil:NilClass
```

The fix is a one-liner.
