### PR TITLE
call method using last reference e.g. "shops.latitude" => "latitude" in c

### DIFF
--- a/lib/geocoder/stores/active_record.rb
+++ b/lib/geocoder/stores/active_record.rb
@@ -196,8 +196,11 @@ module Geocoder::Store
       do_lookup(false) do |o,rs|
         r = rs.first
         unless r.latitude.nil? or r.longitude.nil?
-          o.send :write_attribute, self.class.geocoder_options[:latitude],  r.latitude
-          o.send :write_attribute, self.class.geocoder_options[:longitude], r.longitude
+          # call method using last reference e.g. "shops.latitude" => "latitude" in case
+          # a user specified "shops.latitude" in "geocoded_by" in order to support joins with
+          # other tables having "latitude/longitude" attributes
+          o.send :write_attribute, self.class.geocoder_options[:latitude].split('.')[-1],  r.latitude
+          o.send :write_attribute, self.class.geocoder_options[:longitude].split('.')[-1], r.longitude
         end
         r.coordinates
       end


### PR DESCRIPTION
call method using last reference e.g. "shops.latitude" => "latitude" in case a user specified "shops.latitude" in "geocoded_by" in order to support joins with other tables having "latitude/longitude" attributes

In my case I have a "company" and "shop" model both with a "latitude/longitude". When I need query shops and joining with company I'm able to use

geocoded_by :address, :latitude => "shops.latitude", :longitude => "shops.longitude"

this will work for joins but fails to do actual geocoding because it's trying to call a method "shops.latitude"
