### PR TITLE
Added the option to pass in group by clause to near in active record

### DIFF
--- a/lib/geocoder/stores/active_record.rb
+++ b/lib/geocoder/stores/active_record.rb
@@ -120,7 +120,7 @@ module Geocoder::Store
           :select => "#{options[:select] || '*'}, " +
             "#{distance} AS distance" +
             (bearing ? ", #{bearing} AS bearing" : ""),
-          :having => "#{distance} <= #{radius}"
+          :conditions => "#{distance} <= #{radius}"
         )
       end
 


### PR DESCRIPTION
Not sure if this is the proper way to do it, but it makes my code work when i do this:

Location.approved.near([params[:lat].to_f, params[:lng].to_f], within, 
                                   :group => 'categories.name', 
                                   :select => 'COUNT(*) AS locations_count, categories.name AS categories_name,
                                    categories.id AS categories_id')
                                   .joins(:business => [:category, :unexpired_cards])

All your tests still pass and I couldn't find a specific test for default_near_scope_options, so I didn't write any.
