### PR TITLE
Add Rake Task: Geocode objects without coordinates with a limit

### DIFF
--- a/lib/tasks/geocoder.rake
+++ b/lib/tasks/geocoder.rake
@@ -12,4 +12,16 @@ namespace :geocode do
       obj.geocode; obj.save
     end
   end
+  
+  desc "Geocode objects without coordinates with a limit."
+  task :with_limit => :environment do
+    limit = ENV['LIMIT'] || ENV['limit']
+    raise "Please specify a LIMIT" unless limit
+
+    klass.not_geocoded.limit(limit).each do |obj|
+      puts "Processing #{obj.class.name} ID##{obj.id}"
+      obj.geocode; obj.save
+    end
+  end
+
 end


### PR DESCRIPTION
I add this task because Google Map API limit basic account to 2500 request by day. 

The optimus solution can by stop rake task geocode:all when status code return 620 (this diff of request status, is part of JSON response). see http://code.google.com/intl/en/apis/maps/documentation/javascript/v2/reference.html#GGeoStatusCode.G_GEO_TOO_MANY_QUERIES.
