### PR TITLE
remove top level klass method in rake task

### DIFF
--- a/lib/tasks/geocoder.rake
+++ b/lib/tasks/geocoder.rake
@@ -1,13 +1,10 @@
-def klass
-  class_name = ENV['CLASS'] || ENV['class']
-  raise "Please specify a CLASS (model)" unless class_name
-  Object.const_get(class_name)
-end
-
 namespace :geocode do
-
   desc "Geocode all objects without coordinates."
   task :all => :environment do
+    class_name = ENV['CLASS'] || ENV['class']
+    raise "Please specify a CLASS (model)" unless class_name
+    klass = Object.const_get(class_name)
+
     klass.not_geocoded.each do |obj|
       obj.geocode; obj.save
     end


### PR DESCRIPTION
I have an ActiveRecord class with an attribute named klass.  I have some FactoryGirl factory definitions which set the klass attribute.  When trying to use rake, it raises an argument error because the top-level klass method in lib/tasks/geocoder.rake is conflicting with FactoryGirl's DSL.  This patch inlines the method into the rake task which fixes my issue.
