### PR TITLE
Let developers handle errors with freegeoip.net

### DIFF
--- a/lib/geocoder/lookups/freegeoip.rb
+++ b/lib/geocoder/lookups/freegeoip.rb
@@ -11,7 +11,8 @@ module Geocoder::Lookup
       return [reserved_result(query)] if loopback_address?(query)
       begin
         return (doc = fetch_data(query, reverse)) ? [doc] : []
-      rescue StandardError # Freegeoip.net returns HTML on bad request
+      rescue StandardError => err # Freegeoip.net returns HTML on bad request
+        raise_error(err)
         return []
       end
     end


### PR DESCRIPTION
I needed to handle timeout errors from freegeoip.net but couldn't because they were being eaten by StandardError.
