### PR TITLE
Add precision attribute to Result

### DIFF
--- a/lib/geocoder/results/google.rb
+++ b/lib/geocoder/results/google.rb
@@ -82,5 +82,9 @@ module Geocoder::Result
     def geometry
       @data['geometry']
     end
+
+    def precision
+      geometry['location_type'] if geometry
+    end
   end
 end

--- a/test/services_test.rb
+++ b/test/services_test.rb
@@ -26,6 +26,12 @@ class ServicesTest < Test::Unit::TestCase
     assert_equal nil, result.city
   end
 
+  def test_google_precision
+    result = Geocoder.search("Madison Square Garden, New York, NY").first
+    assert_equal "ROOFTOP",
+      result.precision
+  end
+
 
   # --- Yahoo ---
 


### PR DESCRIPTION
This adds (Googles') data['geocoder']['location_type'] as an attribute called precision to the Result object
