### PR TITLE
Make https support really work:

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,11 +4,17 @@ Bundler::GemHelper.install_tasks
 require 'rake/testtask'
 Rake::TestTask.new(:test) do |test|
   test.libs << 'lib' << 'test'
-  test.pattern = 'test/**/*_test.rb'
+  test.pattern = 'test/*_test.rb'
   test.verbose = true
 end
 
-task :default => :test
+Rake::TestTask.new(:integration) do |test|
+  test.libs << 'lib' << 'test'
+  test.pattern = 'test/integration/*_test.rb'
+  test.verbose = true
+end
+
+task :default => [:test, :integration]
 
 require 'rdoc/task'
 Rake::RDocTask.new do |rdoc|

--- a/lib/geocoder/lookups/base.rb
+++ b/lib/geocoder/lookups/base.rb
@@ -141,8 +141,11 @@ module Geocoder
       def fetch_raw_data(query, reverse = false)
         timeout(Geocoder::Configuration.timeout) do
           url = query_url(query, reverse)
+          uri = URI.parse(url)
           unless cache and response = cache[url]
-            response = http_client.get_response(URI.parse(url)).body
+            client = http_client.new(uri.host, uri.port)
+            client.use_ssl = true if Geocoder::Configuration.use_https
+            response = client.get(uri.request_uri).body
             if cache
               cache[url] = response
             end

--- a/test/integration/smoke_test.rb
+++ b/test/integration/smoke_test.rb
@@ -1,0 +1,24 @@
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), *%w[ .. .. lib]))
+require 'pathname'
+require 'rubygems'
+require 'test/unit'
+require 'geocoder'
+
+class SmokeTest < Test::Unit::TestCase
+
+  def test_simple_zip_code_search
+    result = Geocoder.search "27701"
+    assert_equal "Durham", result.first.city
+    assert_equal "North Carolina", result.first.state
+  end
+
+  def test_simple_zip_code_search_with_ssl
+    Geocoder::Configuration.use_https = true
+    result = Geocoder.search "27701"
+    assert_equal "Durham", result.first.city
+    assert_equal "North Carolina", result.first.state
+  ensure
+    Geocoder::Configuration.use_https = false
+  end
+
+end


### PR DESCRIPTION
- need to set `use_ssl` to true
- also cannot use `get_response` class method for https requests
- add a smoke_test that calls out to google for real, to make sure
  things work end to end (not using test_helper for this, because it's invasive
  and opens code under test to do it's mocking)
- add smoke_test to default test run
- fixes issue #126
