### PR TITLE
Adding auth token to geocoder.ca params

### DIFF
--- a/lib/geocoder/lookups/geocoder_ca.rb
+++ b/lib/geocoder/lookups/geocoder_ca.rb
@@ -24,6 +24,7 @@ module Geocoder::Lookup
         :jsonp    => 1,
         :callback => "test"
       }
+      params.update({:auth => Geocoder::Configuration.api_key}) if Geocoder::Configuration.api_key.present?
       if reverse
         lat,lon = query.split(',')
         params[:latt] = lat


### PR DESCRIPTION
Here is a quick addition that adds the geocoder auth token to the params to use the paid version of geocoder.ca.
