### PR TITLE
Change configuration options in the README from lat and lon to latitude and longitude

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -50,7 +50,7 @@ Next, your model must tell Geocoder which method returns your object's geocodabl
 
 For reverse geocoding, tell Geocoder which attributes store latitude and longitude:
 
-  reverse_geocoded_by :lat, :lon
+  reverse_geocoded_by :latitude, :longitude
   after_validation :reverse_geocode  # auto-fetch address
 
 === Mongoid
@@ -190,7 +190,7 @@ If your model has +street+, +city+, +state+, and +country+ attributes you might 
 
 For reverse geocoding you can also specify an alternate name attribute where the address will be stored, for example:
 
-  reverse_geocoded_by :lat, :lon, :address => :location  # ActiveRecord
+  reverse_geocoded_by :latitude, :longitude, :address => :location  # ActiveRecord
   reverse_geocoded_by :coordinates, :address => :loc     # MongoDB
 
 
@@ -198,7 +198,7 @@ For reverse geocoding you can also specify an alternate name attribute where the
 
 So far we have looked at shortcuts for assigning geocoding results to object attributes. However, if you need to do something fancy you can skip the auto-assignment by providing a block (takes the object to be geocoded and an array of <tt>Geocoder::Result</tt> objects) in which you handle the parsed geocoding result any way you like, for example:
 
-  reverse_geocoded_by :lat, :lon do |obj,results|
+  reverse_geocoded_by :latitude, :longitude do |obj,results|
     if geo = results.first
       obj.city    = geo.city
       obj.zipcode = geo.postal_code


### PR DESCRIPTION
In the README there is:

```
rails generate migration AddLatitudeAndLongitudeToModel latitude:float longitude:float
rake db:migrate
```

then shortly after:

```
reverse_geocoded_by :lat, :lon
after_validation :reverse_geocode  # auto-fetch address
```

I ran into a problem when I followed the README to setup the gem and was getting errors about lat and lon not existing on the table. 

I have changed the model configurations in the README from lat and lon to latitude and longitude so it's consistent for someone who is following along.
