### PR TITLE
updated cli to accept google premier key

### DIFF
--- a/lib/geocoder/cli.rb
+++ b/lib/geocoder/cli.rb
@@ -20,7 +20,6 @@ module Geocoder
           else
             Geocoder::Configuration.api_key = key
           end
-          puts Geocoder::Configuration.api_key.inspect
         end
 
         opts.on("-l <language>", "--language <language>",
@@ -36,7 +35,6 @@ module Geocoder
         opts.on("-s <service>", Geocoder.street_lookups, "--service <service>",
           "Geocoding service: #{Geocoder.street_lookups * ', '}") do |service|
           Geocoder::Configuration.lookup = service.to_sym
-          puts Geocoder::Configuration.lookup.inspect
         end
 
         opts.on("-t <seconds>", "--timeout <seconds>",


### PR DESCRIPTION
Hey Alex,

We needed to test our Google Premier credentials and the easiest way to do that was via the command line implementation. This is the change we made to allow generating the three element array for the Google Premier key.
