### PR TITLE
Ensure all do_lookup blocks have empty list protection

### DIFF
--- a/lib/geocoder/stores/active_record.rb
+++ b/lib/geocoder/stores/active_record.rb
@@ -266,11 +266,12 @@ module Geocoder::Store
     #
     def reverse_geocode
       do_lookup(true) do |o,rs|
-        r = rs.first
-        unless r.address.nil?
-          o.send :write_attribute, self.class.geocoder_options[:fetched_address], r.address
+        if r = rs.first
+          unless r.address.nil?
+            o.send :write_attribute, self.class.geocoder_options[:fetched_address], r.address
+          end
+          r.address
         end
-        r.address
       end
     end
 

--- a/lib/geocoder/stores/mongo_base.rb
+++ b/lib/geocoder/stores/mongo_base.rb
@@ -71,11 +71,12 @@ module Geocoder::Store
     #
     def reverse_geocode
       do_lookup(true) do |o,rs|
-        r = rs.first
-        unless r.address.nil?
-          o.send :write_attribute, self.class.geocoder_options[:fetched_address], r.address
+        if r = rs.first
+          unless r.address.nil?
+            o.send :write_attribute, self.class.geocoder_options[:fetched_address], r.address
+          end
+          r.address
         end
-        r.address
       end
     end
   end


### PR DESCRIPTION
Changes introduced with always_execute_geocode_block would cause nil object errors if there were no results.  In my case, it was causing rake db:seeds to blow up.
