### PR TITLE
within_bounding_box scope takes field names from options

### DIFF
--- a/lib/geocoder/stores/active_record.rb
+++ b/lib/geocoder/stores/active_record.rb
@@ -50,11 +50,11 @@ module Geocoder::Store
         scope :within_bounding_box, lambda{ |bounds|
           sw_lat, sw_lng, ne_lat, ne_lng = bounds.flatten if bounds
           return where(:id => false) unless sw_lat && sw_lng && ne_lat && ne_lng
-          spans = "latitude BETWEEN #{sw_lat} AND #{ne_lat} AND "
+          spans = "#{geocoder_options[:latitude]} BETWEEN #{sw_lat} AND #{ne_lat} AND "
           spans << if sw_lng > ne_lng   # Handle a box that spans 180
-            "longitude BETWEEN #{sw_lng} AND 180 OR longitude BETWEEN -180 AND #{ne_lng}"
+            "#{geocoder_options[:longitude]} BETWEEN #{sw_lng} AND 180 OR #{geocoder_options[:longitude]} BETWEEN -180 AND #{ne_lng}"
           else
-            "longitude BETWEEN #{sw_lng} AND #{ne_lng}"
+            "#{geocoder_options[:longitude]} BETWEEN #{sw_lng} AND #{ne_lng}"
           end
           { :conditions => spans }
         }


### PR DESCRIPTION
within_bounding_box used "latitude" and "longitude" fields previously unlike other scopes that use geocoder_options.
