### PR TITLE
In lookups/base, invalid JSON needs to be rescued for ActiveSupport::JSON

### DIFF
--- a/lib/geocoder/lookups/base.rb
+++ b/lib/geocoder/lookups/base.rb
@@ -120,14 +120,14 @@ module Geocoder
       # Parses a raw search result (returns hash or array).
       #
       def parse_raw_data(raw_data)
-        if defined?(ActiveSupport::JSON)
-          ActiveSupport::JSON.decode(raw_data)
-        else
-          begin
+        begin
+          if defined?(ActiveSupport::JSON)
+            ActiveSupport::JSON.decode(raw_data)
+          else
             JSON.parse(raw_data)
-          rescue
-            warn "Geocoding API's response was not valid JSON."
           end
+        rescue
+          warn "Geocoding API's response was not valid JSON."
         end
       end
 


### PR DESCRIPTION
Currently when not using ActiveSupport::JSON,

The barebones json parse call gets rescued and throws out the following warning:

"Geocoding API's response was not valid JSON."

However, if ActiveSupport::JSON is detected, ActiveSupport::JSON call runs the parse w/o any begin / rescue blocks. We ran into this issue when running db migrations within rails w/ the Yahoo provider sporadically throwing out parse errors, stopping our db migrations dead in its tracks.
