### PR TITLE
Add table_name to near scopes

### DIFF
--- a/lib/geocoder/stores/active_record.rb
+++ b/lib/geocoder/stores/active_record.rb
@@ -114,26 +114,26 @@ module Geocoder::Store
       # http://www.beginningspatial.com/calculating_bearing_one_point_another
       #
       def full_near_scope_options(latitude, longitude, radius, options)
-        lat_attr = "#{self.table_name}.#{geocoder_options[:latitude]}"
-        lon_attr = "#{self.table_name}.#{geocoder_options[:longitude]}"
+        lat_attr = geocoder_options[:latitude]
+        lon_attr = geocoder_options[:longitude]
         options[:bearing] = :linear unless options.include?(:bearing)
         bearing = case options[:bearing]
         when :linear
           "CAST(" +
             "DEGREES(ATAN2( " +
-              "RADIANS(#{lon_attr} - #{longitude}), " +
-              "RADIANS(#{lat_attr} - #{latitude})" +
+              "RADIANS(#{table_name}.#{lon_attr} - #{longitude}), " +
+              "RADIANS(#{table_name}.#{lat_attr} - #{latitude})" +
             ")) + 360 " +
           "AS decimal) % 360"
         when :spherical
           "CAST(" +
             "DEGREES(ATAN2( " +
-              "SIN(RADIANS(#{lon_attr} - #{longitude})) * " +
-              "COS(RADIANS(#{lat_attr})), (" +
-                "COS(RADIANS(#{latitude})) * SIN(RADIANS(#{lat_attr}))" +
+              "SIN(RADIANS(#{table_name}.#{lon_attr} - #{longitude})) * " +
+              "COS(RADIANS(#{table_name}.#{lat_attr})), (" +
+                "COS(RADIANS(#{latitude})) * SIN(RADIANS(#{table_name}.#{lat_attr}))" +
               ") - (" +
-                "SIN(RADIANS(#{latitude})) * COS(RADIANS(#{lat_attr})) * " +
-                "COS(RADIANS(#{lon_attr} - #{longitude}))" +
+                "SIN(RADIANS(#{latitude})) * COS(RADIANS(#{table_name}.#{lat_attr})) * " +
+                "COS(RADIANS(#{table_name}.#{lon_attr} - #{longitude}))" +
               ")" +
             ")) + 360 " +
           "AS decimal) % 360"
@@ -154,8 +154,8 @@ module Geocoder::Store
       # http://www.scribd.com/doc/2569355/Geo-Distance-Search-with-MySQL
 
       def full_distance_from_sql(latitude, longitude, options)
-        lat_attr = "#{self.table_name}.#{geocoder_options[:latitude]}"
-        lon_attr = "#{self.table_name}.#{geocoder_options[:longitude]}"
+        lat_attr = geocoder_options[:latitude]
+        lon_attr = geocoder_options[:longitude]
 
         earth = Geocoder::Calculations.earth_radius(options[:units] || :mi)
 
@@ -189,8 +189,8 @@ module Geocoder::Store
       # only exist for interface consistency--not intended for production!
       #
       def approx_near_scope_options(latitude, longitude, radius, options)
-        lat_attr = "#{self.table_name}.#{geocoder_options[:latitude]}"
-        lon_attr = "#{self.table_name}.#{geocoder_options[:longitude]}"
+        lat_attr = geocoder_options[:latitude]
+        lon_attr = geocoder_options[:longitude]
         options[:bearing] = :linear unless options.include?(:bearing)
         if options[:bearing]
           bearing = "CASE " +


### PR DESCRIPTION
I had an issue with a near() scopes and some gnarly custom joins, where mysql had an issue with the ambiguity of the lat/lng attributes. I didn't run the tests and I'm unfamiliar with the geocoder codebase, but I followed the pattern from other parts of the same class and it's working for my specific examples.
