### PR TITLE
allows default unit to be configured

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,14 @@
+PATH
+  remote: .
+  specs:
+    geocoder (1.1.0)
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  geocoder!

--- a/lib/geocoder/calculations.rb
+++ b/lib/geocoder/calculations.rb
@@ -24,7 +24,7 @@ module Geocoder
     ##
     # Distance spanned by one degree of latitude in the given units.
     #
-    def latitude_degree_distance(units = :mi)
+    def latitude_degree_distance(units = Geocoder::Configuration.units)
       2 * Math::PI * earth_radius(units) / 360
     end
 
@@ -32,7 +32,7 @@ module Geocoder
     # Distance spanned by one degree of longitude at the given latitude.
     # This ranges from around 69 miles at the equator to zero at the poles.
     #
-    def longitude_degree_distance(latitude, units = :mi)
+    def longitude_degree_distance(latitude, units = Geocoder::Configuration.units)
       latitude_degree_distance(units) * Math.cos(to_radians(latitude))
     end
 
@@ -54,7 +54,7 @@ module Geocoder
     def distance_between(point1, point2, options = {})
 
       # set default options
-      options[:units] ||= :mi
+      options[:units] ||= Geocoder::Configuration.units
 
       # convert to coordinate arrays
       point1 = extract_coordinates(point1)
@@ -182,7 +182,7 @@ module Geocoder
     def bounding_box(point, radius, options = {})
       lat,lon = extract_coordinates(point)
       radius  = radius.to_f
-      units   = options[:units] || :mi
+      units   = options[:units] || Geocoder::Configuration.units
       [
         lat - (radius / latitude_degree_distance(units)),
         lon - (radius / longitude_degree_distance(lat, units)),
@@ -219,11 +219,11 @@ module Geocoder
       end
     end
 
-    def distance_to_radians(distance, units = :mi)
+    def distance_to_radians(distance, units = Geocoder::Configuration.units)
       distance.to_f / earth_radius(units)
     end
 
-    def radians_to_distance(radians, units = :mi)
+    def radians_to_distance(radians, units = Geocoder::Configuration.units)
       radians * earth_radius(units)
     end
 
@@ -244,7 +244,7 @@ module Geocoder
     ##
     # Radius of the Earth in the given units (:mi or :km). Default is :mi.
     #
-    def earth_radius(units = :mi)
+    def earth_radius(units = Geocoder::Configuration.units)
       units == :km ? EARTH_RADIUS : to_miles(EARTH_RADIUS)
     end
 

--- a/lib/geocoder/configuration.rb
+++ b/lib/geocoder/configuration.rb
@@ -12,6 +12,9 @@ module Geocoder
         # ISO-639 language code
         [:language, :en],
 
+        # :mi for miles or :km for kilometers
+        [:units, :mi],
+
         # use HTTPS for lookup requests? (if supported)
         [:use_https, false],
 

--- a/lib/geocoder/stores/active_record.rb
+++ b/lib/geocoder/stores/active_record.rb
@@ -157,7 +157,7 @@ module Geocoder::Store
         lat_attr = geocoder_options[:latitude]
         lon_attr = geocoder_options[:longitude]
 
-        earth = Geocoder::Calculations.earth_radius(options[:units] || :mi)
+        earth = Geocoder::Calculations.earth_radius(options[:units] || Geocoder::Configuration.units)
 
         "#{earth} * 2 * ASIN(SQRT(" +
           "POWER(SIN((#{latitude} - #{table_name}.#{lat_attr}) * PI() / 180 / 2), 2) + " +
@@ -169,8 +169,8 @@ module Geocoder::Store
         lat_attr = geocoder_options[:latitude]
         lon_attr = geocoder_options[:longitude]
 
-        dx = Geocoder::Calculations.longitude_degree_distance(30, options[:units] || :mi)
-        dy = Geocoder::Calculations.latitude_degree_distance(options[:units] || :mi)
+        dx = Geocoder::Calculations.longitude_degree_distance(30, options[:units] || Geocoder::Configuration.units)
+        dy = Geocoder::Calculations.latitude_degree_distance(options[:units] || Geocoder::Configuration.units)
 
         # sin of 45 degrees = average x or y component of vector
         factor = Math.sin(Math::PI / 4)

--- a/lib/geocoder/stores/base.rb
+++ b/lib/geocoder/stores/base.rb
@@ -22,7 +22,7 @@ module Geocoder
       # the point. Also takes a symbol specifying the units
       # (:mi or :km; default is :mi).
       #
-      def distance_to(point, units = :mi)
+      def distance_to(point, units = Geocoder::Configuration.units)
         return nil unless geocoded?
         Geocoder::Calculations.distance_between(
           to_coordinates, point, :units => units)

--- a/lib/geocoder/stores/mongo_base.rb
+++ b/lib/geocoder/stores/mongo_base.rb
@@ -30,7 +30,7 @@ module Geocoder::Store
           conds[field] = empty.clone
           conds[field]["$nearSphere"]  = coords.reverse
           conds[field]["$maxDistance"] = \
-            Geocoder::Calculations.distance_to_radians(radius, options[:units] || :mi)
+            Geocoder::Calculations.distance_to_radians(radius, options[:units] || Geocoder::Configuration.units)
 
           if obj = options[:exclude]
             conds[:_id.ne] = obj.id


### PR DESCRIPTION
Now you can do

```
Geocoder::Configuration.units = :km
```

to override the current default of `:mi`
