### PR TITLE
Support for #near(..., :select => :ignore)

### DIFF
--- a/lib/geocoder/stores/active_record.rb
+++ b/lib/geocoder/stores/active_record.rb
@@ -142,7 +142,7 @@ module Geocoder::Store
         distance = full_distance_from_sql(latitude, longitude, options)
         conditions = ["#{distance} <= ?", radius]
         default_near_scope_options(latitude, longitude, radius, options).merge(
-          :select => "#{options[:select] || full_column_name("*")}, " +
+          :select => select_addon(options) +
             "#{distance} AS distance" +
             (bearing ? ", #{bearing} AS bearing" : ""),
           :conditions => add_exclude_condition(conditions, options[:exclude])
@@ -211,11 +211,18 @@ module Geocoder::Store
           [b[0], b[2], b[1], b[3]
         ]
         default_near_scope_options(latitude, longitude, radius, options).merge(
-          :select => "#{options[:select] || full_column_name("*")}, " +
+          :select => select_addon(options) +
             "#{distance} AS distance" +
             (bearing ? ", #{bearing} AS bearing" : ""),
           :conditions => add_exclude_condition(conditions, options[:exclude])
         )
+      end
+
+      ##
+      # Select string to add
+      #
+      def select_addon(options)
+        options[:select] == :ignore ? "" : "#{options[:select] || full_column_name("*")}, "
       end
 
       ##


### PR DESCRIPTION
I had the problem that using #near within a ActiveRelation#merge for a different table added <table_name>.\* for the geocoded table to the select part of the sql statement. I ended up with table1._, table2._, resulting in a bug that was really hard to test. As a quick fix for this, i added support for using :ignore as a :select option value and not adding any fields/tables (other than distance and bearing) to the select part.
Do you have a better way to get around this issue?

This is also a fix for issue #202

Usage:
  #near(...., :select => :ignore)
