### PR TITLE
Enable ShowPostal for GeocoderCA Lookup

### DIFF
--- a/lib/geocoder/lookups/geocoder_ca.rb
+++ b/lib/geocoder/lookups/geocoder_ca.rb
@@ -33,6 +33,7 @@ module Geocoder::Lookup
         params[:reverse] = 1
       else
         params[:locate] = query
+        params[:showpostal] = 1
       end
       "http://geocoder.ca/?" + hash_to_query(params)
     end

--- a/test/lookup_test.rb
+++ b/test/lookup_test.rb
@@ -27,4 +27,11 @@ class LookupTest < Test::Unit::TestCase
     g = Geocoder::Lookup::Yahoo.new
     assert_match "appid=MY_KEY", g.send(:query_url, "Madison Square Garden, New York, NY  10001, United States")
   end
+
+  def test_geocoder_ca_showpostal
+    Geocoder::Configuration.api_key = "MY_KEY"
+    g = Geocoder::Lookup::GeocoderCa.new
+    assert_match "showpostal=1", g.send(:query_url, "Madison Square Garden, New York, NY  10001, United States")
+  end
+
 end


### PR DESCRIPTION
GeocoderCA Lookup has an option to include the postal code along with coordinates that is off by default.  Change just turns this feature on, with tests showing it coming through in the query.
