### PR TITLE
Fix "Mysql2::Error: Unknown column 'NaN' in 'where clause'" error

### DIFF
--- a/lib/geocoder/stores/active_record.rb
+++ b/lib/geocoder/stores/active_record.rb
@@ -33,7 +33,7 @@ module Geocoder::Store
         #
         scope :near, lambda{ |location, *args|
           latitude, longitude = Geocoder::Calculations.extract_coordinates(location)
-          if latitude and longitude
+          if latitude and longitude and ![latitude, longitude].include?(Geocoder::Calculations::NAN)
             near_scope_options(latitude, longitude, *args)
           else
             where(false_condition) # no results if no lat/lon given


### PR DESCRIPTION
Trying to search near places for unknown locations leads to this error.

This pull address fixes the problem adding a condition that returns false if one between `latitude` and `longitude` from `Geocoder::Calculations.extract_coordinates` is `NaN`.
