### PR TITLE
Put in full_column_name to avoid ambiguous column errors

### DIFF
--- a/lib/geocoder/stores/active_record.rb
+++ b/lib/geocoder/stores/active_record.rb
@@ -202,10 +202,10 @@ module Geocoder::Store
         end
         if options[:bearing]
           bearing = "CASE " +
-            "WHEN (#{lat_attr} >= #{latitude} AND #{lon_attr} >= #{longitude}) THEN  45.0 " +
-            "WHEN (#{lat_attr} <  #{latitude} AND #{lon_attr} >= #{longitude}) THEN 135.0 " +
-            "WHEN (#{lat_attr} <  #{latitude} AND #{lon_attr} <  #{longitude}) THEN 225.0 " +
-            "WHEN (#{lat_attr} >= #{latitude} AND #{lon_attr} <  #{longitude}) THEN 315.0 " +
+            "WHEN (#{full_column_name(lat_attr)} >= #{latitude} AND #{full_column_name(lon_attr)} >= #{longitude}) THEN  45.0 " +
+            "WHEN (#{full_column_name(lat_attr)} <  #{latitude} AND #{full_column_name(lon_attr)} >= #{longitude}) THEN 135.0 " +
+            "WHEN (#{full_column_name(lat_attr)} <  #{latitude} AND #{full_column_name(lon_attr)} <  #{longitude}) THEN 225.0 " +
+            "WHEN (#{full_column_name(lat_attr)} >= #{latitude} AND #{full_column_name(lon_attr)} <  #{longitude}) THEN 315.0 " +
           "END"
         else
           bearing = false
@@ -216,7 +216,7 @@ module Geocoder::Store
 
         b = Geocoder::Calculations.bounding_box([latitude, longitude], radius, options)
         conditions = [
-          "#{lat_attr} BETWEEN ? AND ? AND #{lon_attr} BETWEEN ? AND ?"] +
+          "#{full_column_name(lat_attr)} BETWEEN ? AND ? AND #{full_column_name(lon_attr)} BETWEEN ? AND ?"] +
           [b[0], b[2], b[1], b[3]
         ]
         default_near_scope_options(latitude, longitude, radius, options).merge(


### PR DESCRIPTION
Small change but is required if you want to have a self join on a geocoded table that you called "nearbys" on. For example, in Class Address which is geocoded:

```
nearby_addresses = nearbys(NEARBY_DISTANCE, bearing: false).joins("LEFT JOIN addresses t2 on addresses.vendor_id=t2.vendor_id AND ...)
```

The original code caused the ambiguous column errors on latitude and longitude because of the self join.

If you're curious, I'm doing this because I want to get addresses ordered by distance but unique for a particular column. I'm using the technique in this article: http://www.williambharding.com/blog/uncategorized/mysql-use-distinct-and-order-by-with-multiple-columns-aka-apply-order-by-before-group/
