### PR TITLE
Updated Geocoder Mongoid to work with Mongoid 3.0.0rc

### DIFF
--- a/lib/geocoder/models/mongoid.rb
+++ b/lib/geocoder/models/mongoid.rb
@@ -18,7 +18,7 @@ module Geocoder
         super(options)
         if options[:skip_index] == false
           
-          if ::Mongoid::VERSION == "3.0.0.rc"
+          if ::Mongoid::VERSION.to_i == 3
             
             # Updated to work with new Mongoid 3.0.0rc
             # Refer to http://mongoid.org/en/mongoid/docs/upgrading.html 


### PR DESCRIPTION
This issue came about with the new Mongoid 3.0.0rc that deals with the new Geospatial indexing format, this was fixed by following the new format, but this does not include the previous :min => -180, :max => 180 as these were not valid parameters with the new Geospatial indexing release.

Reference http://mongoid.org/en/mongoid/docs/upgrading.html

Original issue #240
