### PR TITLE
Yandex geocoding limitations

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -312,9 +312,8 @@ Limitations:: Please limit request rate to 1 per second and include your contact
 
 ==== Yandex (<tt>:yandex</tt>)
 
-API key:: required
-Key signup:: http://api.yandex.ru/maps/intro/concepts/intro.xml#apikey
-Quota:: ?
+API key:: none
+Quota:: 25000 requests / day
 Region:: Russia
 SSL support:: no
 Languages:: Russian, Belarusian, and Ukrainian


### PR DESCRIPTION
Recently Yandex proposed [new API](http://api.yandex.ru/maps/new_api.xml) which [doesn't need API key](http://api.yandex.ru/maps/new_api.xml#keys).

I [asked](http://clubs.ya.ru/mapsapi/replies.xml?item_no=27561&with_parent=1&parent_id=27570&for_reply=text) about limitations at Yandex.Maps dev forum an the answer was 25000 requests/day and key is no longer needed. As you can see it works without key http://pastie.org/private/qtvsnburiniebhq2qwpgw, I also sent 25000 requests and always got 200 response.
