### PR TITLE
Update code to account for Mongoid 3.0.x changes with backwards compatibility

### DIFF
--- a/lib/geocoder/models/mongoid.rb
+++ b/lib/geocoder/models/mongoid.rb
@@ -17,8 +17,14 @@ module Geocoder
       def geocoder_init(options)
         super(options)
         if options[:skip_index] == false
-          index [[ geocoder_options[:coordinates], Mongo::GEO2D ]],
-            :min => -180, :max => 180 # create 2d index
+          # create 2d index
+          if (::Mongoid::VERSION >= "3")
+            index({ geocoder_options[:coordinates].to_sym => '2d' }, 
+                  {:min => -180, :max => 180})
+          else
+            index [[ geocoder_options[:coordinates], '2d' ]],
+              :min => -180, :max => 180
+          end
         end
       end
     end

--- a/test/mongoid_test.rb
+++ b/test/mongoid_test.rb
@@ -17,7 +17,8 @@ class MongoidTest < Test::Unit::TestCase
   def test_custom_coordinate_field_near_scope
     location = [40.750354, -73.993371]
     p = Place.near(location)
-    assert_equal p.selector[:location]['$nearSphere'], location.reverse
+    key = Mongoid::VERSION >= "3" ? "location" : :location
+    assert_equal p.selector[key]['$nearSphere'], location.reverse
   end
 
   def test_model_configuration

--- a/test/mongoid_test_helper.rb
+++ b/test/mongoid_test_helper.rb
@@ -7,8 +7,12 @@ require 'geocoder/models/mongoid'
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 
-Mongoid.configure do |config|
-  config.logger = Logger.new($stderr, :debug)
+if (::Mongoid::VERSION >= "3")
+  Mongoid.logger = Logger.new($stderr, :debug)
+else
+  Mongoid.configure do |config|
+    config.logger = Logger.new($stderr, :debug)
+  end
 end
 
 ##


### PR DESCRIPTION
This is a set of minor changes to make geocoder compatible with the recent changes in Mongoid 3.0.x.  It's a very small set of changes, and runs green with Mongoid 2.4.11 and 3.0.1.

Key changes are:

i) Update the index statement in Geocoder::Model::Mongoid to use the Mongoid 3.0.x syntax when the Mongoid version number is greater than 3.
ii) Update the mongoid_test_helper.rb to set the Mongoid logger appropriately based on the version of Mongoid in use.
ii) Update the call to the Mongoid selector in mongoid_test.rb to use a string key (Mongoid 3.0.x) or a symbol key (Mongoid 2.0.x) as appropriate.

I think this should be a very safe pull, and it preserves backwards compatibility with users who haven't updated to Mongoid 3.0.x.  I have run the Geocoder tests with Mongoid 2.4.11 and Mongoid 3.0.1 and they both run green.
