### PR TITLE
Configurable Nominatim URL

### DIFF
--- a/lib/geocoder/configuration.rb
+++ b/lib/geocoder/configuration.rb
@@ -40,6 +40,7 @@ module Geocoder
     OPTIONS = [
       :timeout,
       :lookup,
+      :nominatim_url,
       :language,
       :http_headers,
       :use_https,
@@ -62,6 +63,7 @@ module Geocoder
     def set_defaults
       @timeout      = 3           # geocoding service timeout (secs)
       @lookup       = :google     # name of geocoding service (symbol)
+      @nominatim_url= "http://nominatim.openstreetmap.org"     # URL of the Nominatim service
       @language     = :en         # ISO-639 language code
       @http_headers = {}          # HTTP headers for lookup
       @use_https    = false       # use HTTPS for lookup requests? (if supported)

--- a/lib/geocoder/lookups/nominatim.rb
+++ b/lib/geocoder/lookups/nominatim.rb
@@ -31,7 +31,7 @@ module Geocoder::Lookup
         method = 'search'
         params[:q] = query
       end
-      "http://nominatim.openstreetmap.org/#{method}?" + hash_to_query(params)
+      Geocoder::Configuration.nominatim_url+"/#{method}?" + hash_to_query(params)
     end
   end
 end


### PR DESCRIPTION
Since I exceeded the limitations of the nominatim service I decided to create one on my own. 
In order to use geocoder I needed to make the url configurable and set the default value to the original address.
