### PR TITLE
Add precision method to Geocoder::Result::Yandex.

### DIFF
--- a/lib/geocoder/results/yandex.rb
+++ b/lib/geocoder/results/yandex.rb
@@ -57,6 +57,10 @@ module Geocoder::Result
       address_details['Locality']['Premise']['PremiseName']
     end
 
+    def precision
+      @data['GeoObject']['metaDataProperty']['GeocoderMetaData']['precision']
+    end
+
     private # ----------------------------------------------------------------
 
     def address_details


### PR DESCRIPTION
Yandex maps API supports precision method, as Google does.
http://api.yandex.ru/maps/doc/geocoder/desc/reference/precision.xml

| yg: precision | Query house # | Result house # | Comment |
| --- | --- | --- | --- |
| exact | 27 housing 1 | 27с1 | Exact match. |
| number | 31 housing 4 | 31 | Only house number matches. |
| near | 16/3 | 18 | Only nearby house is found (18–16 < 10). |
| street | 18 | 4 | Street found (18–4 > 10). |
| other | 22 | – | Streen not found, but township, locality, district, etc. |
