### PR TITLE
Fixed unit config not working with sqlite distance

### DIFF
--- a/lib/geocoder/stores/active_record.rb
+++ b/lib/geocoder/stores/active_record.rb
@@ -213,8 +213,8 @@ module Geocoder::Store
           bearing = false
         end
 
-        distance = approx_distance_from_sql(latitude, longitude, options)
         options[:units] ||= (geocoder_options[:units] || Geocoder::Configuration.units)
+        distance = approx_distance_from_sql(latitude, longitude, options)
 
         b = Geocoder::Calculations.bounding_box([latitude, longitude], radius, options)
         conditions = [


### PR DESCRIPTION
Since the options hash is populated AFTER distance is calculated, setting units to :km in the config file would be ignored. 

Changed to work same way as https://github.com/balvig/geocoder/blob/master/lib/geocoder/stores/active_record.rb#L147-148

(Was looking for a way to test this but could not find any sqlite3-specific tests...)
