### PR TITLE
Correction in configuration template for :distances

### DIFF
--- a/lib/generators/geocoder/config/templates/initializer.rb
+++ b/lib/generators/geocoder/config/templates/initializer.rb
@@ -19,7 +19,7 @@ Geocoder.configure do |config|
   # config.always_raise = []
 
   ## Calculation options
-  # config.units  = :mi        # :km for kilometers or :mi for miles
-  # config.method = :linear    # :spherical or :linear
+  # config.units     = :mi        # :km for kilometers or :mi for miles
+  # config.distances = :linear    # :spherical or :linear
 end
 


### PR DESCRIPTION
With pull request #95 the option to choose `:linear` or `:spherical` distances was added and @alexreisner changed the config option from `:method` to `:distances`. However, he forgot to make that change in the config generator as well.
