### PR TITLE
Removed state from city.

### DIFF
--- a/lib/geocoder/results/nominatim.rb
+++ b/lib/geocoder/results/nominatim.rb
@@ -25,7 +25,7 @@ module Geocoder::Result
     end
 
     def city
-      %w[city town village hamlet state].each do |key|
+      %w[city town village hamlet].each do |key|
         return @data['address'][key] if @data['address'].key?(key)
       end
       return nil


### PR DESCRIPTION
As discussed [here](https://github.com/alexreisner/geocoder/pull/283) and because it returns simply invalid results in the majority of cases.
