### PR TITLE
Add a dummy lookup to be used for testing in apps that use Geocoder.

### DIFF
--- a/lib/geocoder.rb
+++ b/lib/geocoder.rb
@@ -57,7 +57,7 @@ module Geocoder
   # All street address lookups, default first.
   #
   def street_lookups
-    [:google, :google_premier, :yahoo, :bing, :geocoder_ca, :yandex, :nominatim,:mapquest]
+    [:google, :google_premier, :yahoo, :bing, :geocoder_ca, :yandex, :nominatim,:mapquest, :dummy]
   end
 
   ##

--- a/lib/geocoder/lookups/dummy.rb
+++ b/lib/geocoder/lookups/dummy.rb
@@ -1,0 +1,39 @@
+require 'geocoder/lookups/base'
+require 'geocoder/results/dummy'
+
+module Geocoder::Lookup
+  class Dummy < Base
+    class << self
+      def queries
+        @queries || {}
+      end
+
+      def add_query query, *datas
+        @queries ||= {}
+        @queries[query.to_str] = datas.flatten.map do |data|
+          Geocoder::Result::Dummy.new(data)
+        end
+      end
+
+      def remove_query query
+        @queries.delete(query.to_str) if @queries
+      end
+
+      def clear_queries
+        # don't do anything unless we have queries
+        return unless @queries
+        @queries.clear
+      end
+    end
+
+    def search(query)
+      results = self.class.queries[query.to_str]
+      if results
+        results
+      else
+        warn "No results were found for '#{query}'"
+        return []
+      end
+    end
+  end
+end

--- a/lib/geocoder/results/dummy.rb
+++ b/lib/geocoder/results/dummy.rb
@@ -1,0 +1,50 @@
+require 'geocoder/results/base'
+
+module Geocoder::Result
+  class Dummy < Base
+
+    def initialize(data = {})
+      @data = data.dup
+    end
+
+    def address(format = :full)
+      @data['address']
+    end
+
+    def city
+      @data['city']
+    end
+
+    def state_code
+      @data['state']
+    end
+
+    alias_method :state, :state_code
+
+    def country
+      @data['country']
+    end
+
+    alias_method :country_code, :country
+
+    def postal_code
+      @data['postal_code']
+    end
+
+    def latitude
+      @data['latitude']
+    end
+
+    def longitude
+      @data['longitude']
+    end
+
+    def coordinates
+      @data['coordinates'] || [latitude.to_f, longitude.to_f]
+    end
+
+    def address_data
+      @data.dup
+    end
+  end
+end

--- a/test/dummy_test.rb
+++ b/test/dummy_test.rb
@@ -1,0 +1,101 @@
+require 'test_helper'
+require 'geocoder/lookups/dummy'
+
+class ServicesTest < Test::Unit::TestCase
+  RESULT_DATA = {
+    'address'     => 'Madison Square Garden, West 31st Street, Long Island City, New York City, New York, 10001, United States of America',
+    'city'        => 'New York City',
+    'state'       => 'New York',
+    'country'     => 'United States of America',
+    'postal_code' => '10001'
+  }
+
+  def test_dummy_address
+    expected = 'Madison Square Garden, New York, NY'
+    result = Geocoder::Result::Dummy.new 'address' => expected
+    assert_equal expected, result.address
+  end
+
+  def test_dummy_city
+    expected = 'New York City'
+    result = Geocoder::Result::Dummy.new 'city' => expected
+    assert_equal expected, result.city
+  end
+
+  def test_dummy_state
+    expected = 'New York'
+    result = Geocoder::Result::Dummy.new 'state' => expected
+    assert_equal expected, result.state
+  end
+
+  def test_dummy_country
+    expected = 'United States of America'
+    result = Geocoder::Result::Dummy.new 'country' => expected
+    assert_equal expected, result.country
+  end
+
+  def test_dummy_postal_code
+    expected = '10001'
+    result = Geocoder::Result::Dummy.new 'postal_code' => expected
+    assert_equal expected, result.postal_code
+  end
+
+  def test_dummy_latitude
+    expected = 45.423733
+    result = Geocoder::Result::Dummy.new 'latitude' => expected
+    assert_equal expected, result.latitude
+  end
+
+  def test_dummy_longitude
+    expected = -75.676333
+    result = Geocoder::Result::Dummy.new 'longitude' => expected
+    assert_equal expected, result.longitude
+  end
+
+  def test_dummy_coordinates
+    expected = [45.423733, -75.676333]
+    result = Geocoder::Result::Dummy.new 'coordinates' => expected
+    assert_equal expected, result.coordinates
+  end
+
+  def test_dummy_address_data
+    expected = {'foo' => 'bar'}
+    result = Geocoder::Result::Dummy.new expected
+    assert_equal expected, result.address_data
+  end
+
+  def test_dummy_add_queries
+    query = "Madison Square Garden, New York, NY"
+    assert_equal 0, Geocoder::Lookup::Dummy.queries.size
+    result = Geocoder::Lookup::Dummy.add_query(query, RESULT_DATA)
+    assert_equal 1, Geocoder::Lookup::Dummy.queries.size
+    assert_equal result, Geocoder::Lookup::Dummy.queries[query]
+  end
+
+  def test_dummy_remove_query
+    Geocoder::Lookup::Dummy.add_query "Madison Square Garden, New York, NY", RESULT_DATA
+    assert_equal 1, Geocoder::Lookup::Dummy.queries.size
+    Geocoder::Lookup::Dummy.remove_query "Madison Square Garden, New York, NY"
+    assert_equal 0, Geocoder::Lookup::Dummy.queries.size
+  end
+
+  def test_dummy_clear_queries
+    Geocoder::Lookup::Dummy.add_query "Madison Square Garden, New York, NY", RESULT_DATA
+    assert_equal 1, Geocoder::Lookup::Dummy.queries.size
+    Geocoder::Lookup::Dummy.clear_queries
+    assert_equal 0, Geocoder::Lookup::Dummy.queries.size
+  end
+
+  def test_dummy_result_components
+    Geocoder::Configuration.lookup = :dummy
+    expected_result = Geocoder::Lookup::Dummy.add_query("Madison Square Garden, New York, NY", RESULT_DATA).first
+    actual_result = Geocoder.search("Madison Square Garden, New York, NY").first
+    assert_equal expected_result.address, actual_result.address
+  end
+
+  def test_dummy_no_results
+    Geocoder::Configuration.lookup = :dummy
+    results = Geocoder.search("no results")
+    assert_equal 0, results.length
+  end
+end


### PR DESCRIPTION
Very easily pre-fill queries with the results you expect and when a query matches it will return those results.

To add a query simply do:

``` ruby
Geocoder::Lookup::Dummy.add_query "Neverland", {'address' => 'Beyond the farthest star and head east' ...}
```

And then just query that as so:

``` ruby
Geocoder::Configuration.lookup = :dummy
Geocoder.search 'Neverland'
```
