### PR TITLE
Fix to #nearbys when activerecord model has a primary key different than 'id'

### DIFF
--- a/lib/geocoder/stores/active_record.rb
+++ b/lib/geocoder/stores/active_record.rb
@@ -253,7 +253,7 @@ module Geocoder::Store
       #
       def add_exclude_condition(conditions, exclude)
         if exclude
-          conditions[0] << " AND #{full_column_name(:id)} != ?"
+          conditions[0] << " AND #{full_column_name(primary_key)} != ?"
           conditions << exclude.id
         end
         conditions

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -1,0 +1,15 @@
+# encoding: utf-8
+require 'test_helper'
+
+class ActiveRecordTest < Test::Unit::TestCase
+
+  def test_exclude_condition_when_model_has_a_custom_primary_key
+    venue = VenuePlus.new(*venue_params(:msg))
+
+    # just call private method directly so we don't have to stub .near scope
+    conditions = venue.class.send(:add_exclude_condition, ["fake_condition"], venue)
+
+    assert_match( /#{VenuePlus.primary_key}/, conditions.join)
+  end
+
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,6 +35,17 @@ module ActiveRecord
         read_attribute name
       end
     end
+
+    class << self
+      def table_name
+        'test_table_name'
+      end
+
+      def primary_key
+        :id
+      end
+    end
+
   end
 end
 
@@ -190,6 +201,20 @@ class Venue < ActiveRecord::Base
     write_attribute :name, name
     write_attribute :address, address
   end
+end
+
+##
+# Geocoded model.
+# - Has user-defined primary key (not just 'id')
+#
+class VenuePlus < Venue
+
+  class << self
+    def primary_key
+      :custom_primary_key_id
+    end
+  end
+
 end
 
 ##


### PR DESCRIPTION
Fixes: #194 - add_exclude_condition breaks on tables without ID field - https://github.com/alexreisner/geocoder/issues/194
