### PR TITLE
fix a bug about the yahoo api,change results to result

### DIFF
--- a/lib/geocoder/lookups/yahoo.rb
+++ b/lib/geocoder/lookups/yahoo.rb
@@ -13,7 +13,7 @@ module Geocoder::Lookup
     def results(query)
       return [] unless doc = fetch_data(query)
       if doc = doc['ResultSet'] and doc['Error'] == 0
-        return doc['Found'] > 0 ? doc['Results'] : []
+        return doc['Found'] > 0 ? doc['Result'] : []
       else
         warn "Yahoo Geocoding API error: #{doc['Error']} (#{doc['ErrorMessage']})."
         return []


### PR DESCRIPTION
I think Yahoo change the xml tag of the response
We have in the gecoder : geocoder / lib / geocoder / lookups / yahoo.rb
the hash Results with a S
and Yahoo deliver result without an S
Result> .... </Result
So we get this error 
Geocoder.search("paris France")
Yahoo Geocoding API error: 0 (No error).
