### PR TITLE
Support for Mongoid ~> 2.0.0

### DIFF
--- a/lib/geocoder/models/mongoid.rb
+++ b/lib/geocoder/models/mongoid.rb
@@ -18,7 +18,7 @@ module Geocoder
         super(options)
         if options[:skip_index] == false
           # create 2d index
-          if (::Mongoid::VERSION >= "3")
+          if (defined? ::Mongoid::VERSION && ::Mongoid::VERSION >= "3")
             index({ geocoder_options[:coordinates].to_sym => '2d' }, 
                   {:min => -180, :max => 180})
           else


### PR DESCRIPTION
Mongoid v2 doesnt have ::Mongoid::VERSION defined, so that Geocoder cannot initialize.

Before trying to read ::Mongoid::VERSION it checks if it is defined.

It does fall back to Mongoid version < 3 in this if condition
