### PR TITLE
Do not overload Object#hash

### DIFF
--- a/lib/geocoder/results/yahoo.rb
+++ b/lib/geocoder/results/yahoo.rb
@@ -36,7 +36,7 @@ module Geocoder::Result
         line1 line2 line3 line4 cross house street xstreet unittype unit
         neighborhood county countycode
         level0 level1 level2 level3 level4 level0code level1code level2code
-        timezone areacode uzip hash woeid woetype]
+        timezone areacode uzip woeid woetype]
     end
 
     response_attributes.each do |a|


### PR DESCRIPTION
For example if there is some named scope which is lambda with parameters, it will fail if Geocoder::Result::Yahoo is one of params.
