### PR TITLE
Fixed exception on nil result

### DIFF
--- a/lib/geocoder/lookups/base.rb
+++ b/lib/geocoder/lookups/base.rb
@@ -26,11 +26,14 @@ module Geocoder
       #
       def search(query, options = {})
         query = Geocoder::Query.new(query, options) unless query.is_a?(Geocoder::Query)
-        results(query).map{ |r|
-          result = result_class.new(r)
-          result.cache_hit = @cache_hit if cache
-          result
-        }
+        r = results(query)
+        if r 
+          r.map{ |r|
+            result = result_class.new(r)
+            result.cache_hit = @cache_hit if cache
+            result
+          }
+        end
       end
 
       ##


### PR DESCRIPTION
Occasionally getting this while using Yahoo as the provider:

```
NoMethodError: undefined method `map' for nil:NilClass
        from /home/paul/.rvm/gems/ruby-1.9.3-p286/gems/geocoder-1.1.4/lib/geocoder/lookups/base.rb:29:in `search'
        from /home/paul/.rvm/gems/ruby-1.9.3-p286/gems/geocoder-1.1.4/lib/geocoder/query.rb:11:in `execute'
        from /home/paul/.rvm/gems/ruby-1.9.3-p286/gems/geocoder-1.1.4/lib/geocoder.rb:20:in `search'
        from /home/paul/.rvm/gems/ruby-1.9.3-p286/gems/geocoder-1.1.4/lib/geocoder/stores/base.rb:103:in `do_lookup'
        from /home/paul/.rvm/gems/ruby-1.9.3-p286/gems/geocoder-1.1.4/lib/geocoder/stores/active_record.rb:208:in `geocode'
```
