### PR TITLE
Adding support for Google Places API

### DIFF
--- a/lib/geocoder/lookup.rb
+++ b/lib/geocoder/lookup.rb
@@ -29,6 +29,8 @@ module Geocoder
         :yandex,
         :nominatim,
         :mapquest,
+        :google_places,
+        :google_details,
         :test
       ]
     end

--- a/lib/geocoder/lookups/google_details.rb
+++ b/lib/geocoder/lookups/google_details.rb
@@ -1,0 +1,50 @@
+
+
+require 'geocoder/lookups/base'
+require "geocoder/results/google_details"
+
+module Geocoder::Lookup
+  class GoogleDetails < Base
+
+
+  private
+
+    def results(query)
+      return [] unless doc = fetch_data(query)
+
+      case doc['status']; when "OK" # OK status implies >0 results
+        return [doc['result']]
+      when "OVER_QUERY_LIMIT"
+        raise_error(Geocoder::OverQueryLimitError) ||
+          warn("Google Geocoding API error: over query limit.")
+      when "REQUEST_DENIED"
+        raise_error(Geocoder::RequestDenied) ||
+          warn("Google Geocoding API error: request denied.")
+      when "INVALID_REQUEST"
+        raise_error(Geocoder::InvalidRequest) ||
+          warn("Google Geocoding API error: invalid request.")
+      end
+      return []
+    end
+
+    def query_url_google_params(query)
+      params = {
+        :sensor => "false",
+        :language => Geocoder::Configuration.language,
+        :reference => query.sanitized_text
+      }
+      params
+    end
+
+    def query_url_params(query)
+      super.merge(query_url_google_params(query)).merge(
+        :key => Geocoder::Configuration.api_key
+      )
+    end
+
+    def query_url(query)
+      "#{protocol}://maps.googleapis.com/maps/api/place/details/json?" + url_query_string(query)
+    end
+  end
+end
+

--- a/lib/geocoder/lookups/google_places.rb
+++ b/lib/geocoder/lookups/google_places.rb
@@ -1,0 +1,52 @@
+require 'geocoder/lookups/base'
+require "geocoder/results/google_places"
+
+module Geocoder::Lookup
+  class GooglePlaces < Base
+
+  private
+
+    def results(query)
+      return [] unless doc = fetch_data(query)
+
+      case doc['status']; when "OK" # OK status implies >0 results
+        return doc['results']
+      when "OVER_QUERY_LIMIT"
+        raise_error(Geocoder::OverQueryLimitError) ||
+          warn("Google Geocoding API error: over query limit.")
+      when "REQUEST_DENIED"
+        raise_error(Geocoder::RequestDenied) ||
+          warn("Google Geocoding API error: request denied.")
+      when "INVALID_REQUEST"
+        raise_error(Geocoder::InvalidRequest) ||
+          warn("Google Geocoding API error: invalid request.")
+      end
+      return []
+    end
+
+    def query_url_google_params(query)
+      params = {
+        :sensor => "false",
+        :language => Geocoder::Configuration.language,
+        :query => query.sanitized_text
+      }
+
+
+      unless (bounds = query.options[:bounds]).nil?
+        params[:bounds] = bounds.map{ |point| "%f,%f" % point }.join('|')
+      end
+      params
+    end
+
+    def query_url_params(query)
+      super.merge(query_url_google_params(query)).merge(
+        :key => Geocoder::Configuration.api_key
+      )
+    end
+
+    def query_url(query)
+      "#{protocol}://maps.googleapis.com/maps/api/place/textsearch/json?" + url_query_string(query)
+    end
+  end
+end
+

--- a/lib/geocoder/results/google_details.rb
+++ b/lib/geocoder/results/google_details.rb
@@ -1,0 +1,117 @@
+require 'geocoder/results/base'
+
+module Geocoder::Result
+  class GoogleDetails < Base
+
+    def coordinates
+      ['lat', 'lng'].map{ |i| geometry['location'][i] }
+    end
+
+    def address(format = :full)
+      formatted_address
+    end
+
+    def city
+      fields = [:locality, :sublocality,
+        :administrative_area_level_3,
+        :administrative_area_level_2]
+      fields.each do |f|
+        if entity = address_components_of_type(f).first
+          return entity['long_name']
+        end
+      end
+      return nil # no appropriate components found
+    end
+
+    def state
+      if state = address_components_of_type(:administrative_area_level_1).first
+        state['long_name']
+      end
+    end
+
+    def state_code
+      if state = address_components_of_type(:administrative_area_level_1).first
+        state['short_name']
+      end
+    end
+
+    def country
+      if country = address_components_of_type(:country).first
+        country['long_name']
+      end
+    end
+
+    def country_code
+      if country = address_components_of_type(:country).first
+        country['short_name']
+      end
+    end
+
+    def postal_code
+      if postal = address_components_of_type(:postal_code).first
+        postal['long_name']
+      end
+    end
+
+    def types
+      @data['types']
+    end
+
+    def formatted_address
+      @data['formatted_address']
+    end
+
+    def address_components
+      @data['address_components']
+    end
+
+    # Additional
+    def icon
+      @data['icon']
+    end
+
+    def phone
+      @data['international_phone_number']
+    end
+
+    def name
+      @data['name']
+    end
+
+    def url
+      @data['url']
+    end
+
+    def website
+      @data['website']
+    end
+
+    def utc_offset
+      @data['utc_offset']
+    end
+
+
+
+    ##
+    # Get address components of a given type. Valid types are defined in
+    # Google's Geocoding API documentation and include (among others):
+    #
+    #   :street_number
+    #   :locality
+    #   :neighborhood
+    #   :route
+    #   :postal_code
+    #
+    def address_components_of_type(type)
+      address_components.select{ |c| c['types'].include?(type.to_s) }
+    end
+
+    def geometry
+      @data['geometry']
+    end
+
+    def precision
+      geometry['location_type'] if geometry
+    end
+  end
+end

--- a/lib/geocoder/results/google_places.rb
+++ b/lib/geocoder/results/google_places.rb
@@ -1,0 +1,84 @@
+require 'geocoder/results/base'
+
+module Geocoder::Result
+  class GooglePlaces < Base
+
+    def initialize(data)
+      super(data)
+      @google_details = nil
+    end
+
+    def coordinates
+      ['lat', 'lng'].map{ |i| geometry['location'][i] }
+    end
+
+    def address(format = :full)
+      formatted_address
+    end
+
+    def city
+      get_details if @google_details.nil?
+      return @google_details.nil? ? nil : @google_details.city
+    end
+
+    def state
+      get_details if @google_details.nil?
+      return @google_details.nil? ? nil : @google_details.state
+    end
+
+    def state_code
+      get_details if @google_details.nil?
+      return @google_details.nil? ? nil : @google_details.state_code
+    end
+
+    def country
+      get_details if @google_details.nil?
+      return @google_details.nil? ? nil : @google_details.country
+    end
+
+    def country_code
+      get_details if @google_details.nil?
+      return @google_details.nil? ? nil : @google_details.country_code
+    end
+
+    def postal_code
+      get_details if @google_details.nil?
+      return @google_details.nil? ? nil : @google_details.postal_code
+    end
+
+
+    def formatted_address
+      @data['formatted_address']
+    end
+
+    def geometry
+      @data['geometry']
+    end
+
+    def reference
+      @data['reference']
+    end
+
+    def get_details
+      if (@google_details.nil?)
+        details = Geocoder::Lookup::GoogleDetails.new().search(reference)
+        @google_details = details[0]
+      end
+      return @google_details
+    end
+
+    # additional
+    def rating
+      @data['rating']
+    end
+
+    def types
+      @data['types']
+    end
+
+    def icon
+      @data['icon']
+    end
+
+  end
+end


### PR DESCRIPTION
Hi

I add support for Google Places API (https://developers.google.com/places/documentation/search) and it fits very well in geocoder project.

At first, Google Places API is not geocoding at all, but it searches for places. It will return multiple places with some data  (note that place does not have full set of data as in geocoder (it has full_address, but not parsed). To obtain parsed values second call to 'details' api must be made.

I added lazy call for details (only if you access fields like: city, country, ..). Lat,lng and full_address are present without second call.

Hope that you will include this patch. Im currently working on Google Places 'nearby' search and also started implementing NOKIA, FourSquare and Bing lookups.

Any comments to improve code?

Tx for great gem.
