### PR TITLE
Support for X_REAL_IP and X_FORWARDED_FOR

### DIFF
--- a/lib/geocoder/request.rb
+++ b/lib/geocoder/request.rb
@@ -7,6 +7,8 @@ module Geocoder
       unless defined?(@location)
         if env.has_key?('HTTP_X_REAL_IP')
           @location = Geocoder.search(env['HTTP_X_REAL_IP']).first
+        elsif env.has_key?('HTTP_X_FORWARDED_FOR')
+          @location = Geocoder.search(env['HTTP_X_FORWARDED_FOR']).first
         else
           @location = Geocoder.search(ip).first
         end


### PR DESCRIPTION
I'm using your gem behind a load balancer and forward the real client ip in the X-Real-Ip header.

To support this setup I extended the Geocoder::Request to use an ip address from the HTTP X headers instead of the Rack `ip` method, which is the ip of my load balancer.

http://en.wikipedia.org/wiki/X-Forwarded-For
