### PR TITLE
add route to google result parser

### DIFF
--- a/lib/geocoder/results/google.rb
+++ b/lib/geocoder/results/google.rb
@@ -53,6 +53,12 @@ module Geocoder::Result
       end
     end
 
+    def route
+      if route = address_components_of_type(:route).first
+        route['long_name']
+      end
+    end
+
     def types
       @data['types']
     end

--- a/test/services_test.rb
+++ b/test/services_test.rb
@@ -25,6 +25,12 @@ class ServicesTest < Test::Unit::TestCase
       result.address_components_of_type(:sublocality).first['long_name']
   end
 
+  def test_google_result_components_contains_route
+    result = Geocoder.search("Madison Square Garden, New York, NY").first
+    assert_equal "Penn Plaza",
+      result.address_components_of_type(:route).first['long_name']
+  end
+
   def test_google_returns_city_when_no_locality_in_result
     result = Geocoder.search("no locality").first
     assert_equal "Haram", result.city


### PR DESCRIPTION
Since google returns the route on geolocation, I think (mostly because I need this info) that's a good thing to support it.
