### PR TITLE
Fix query params escaping for OauthUtil

### DIFF
--- a/lib/oauth_util.rb
+++ b/lib/oauth_util.rb
@@ -56,7 +56,7 @@ class OauthUtil
   def query_string
     pairs = []
     @params.sort.each { | key, val | 
-      pairs.push( "#{ percent_encode( key ) }=#{ percent_encode( val.to_s ) }" )
+      pairs.push( "#{ CGI.escape(key.to_s).gsub(/%(5B|5D)/n) { [$1].pack('H*') } }=#{ CGI.escape(val.to_s) }" )
     }
     pairs.join '&'
   end

--- a/test/oauth_util_test.rb
+++ b/test/oauth_util_test.rb
@@ -1,0 +1,30 @@
+# encoding: utf-8
+require 'test_helper'
+require 'cgi'
+require 'uri'
+
+class OauthUtilTest < Test::Unit::TestCase
+  def test_query_string_escapes_single_quote
+    base_url = "http://example.com?location=d%27iberville"
+
+    o = OauthUtil.new
+    o.consumer_key = 'consumer_key'
+    o.consumer_secret = 'consumer_secret'
+
+    query_string = o.sign(URI.parse(base_url)).query_string
+
+    assert_match "location=d%27iberville", query_string
+  end
+
+  def test_query_string_sorts_url_keys
+    base_url = "http://example.com?a_param=a&z_param=b&b_param=c&n_param=d"
+
+    o = OauthUtil.new
+    o.consumer_key = 'consumer_key'
+    o.consumer_secret = 'consumer_secret'
+
+    query_string = o.sign(URI.parse(base_url)).query_string
+
+    assert_match /.*a_param=.*b_param=.*n_param=.*z_param=.*/, query_string
+  end
+end


### PR DESCRIPTION
Current implementation of oauth util does not escape URL params correctly.
Request fails for Yahoo BOSS service when contains `'` character. It happens because in `sign` method query params are unescaped by CGI.parse and then they are not fully escaped by `percent_encode`.  

I'm sure that query values and keys should be fully escaped with `CGI.escape`. Proposed logic taken from ActiveSupport's Object extension (`Hash::to_query` and `Object::to_param` methods).

Tested with Yahoo BOSS and works as expected.
