### PR TITLE
Yandex API key is not required

### DIFF
--- a/lib/geocoder/lookups/yandex.rb
+++ b/lib/geocoder/lookups/yandex.rb
@@ -12,10 +12,6 @@ module Geocoder::Lookup
       "http://maps.yandex.ru/?ll=#{coordinates.reverse.join(',')}"
     end
 
-    def required_api_key_parts
-      ["key"]
-    end
-
     private # ---------------------------------------------------------------
 
     def results(query)


### PR DESCRIPTION
For now Yandex don't require API key.

See http://api.yandex.ru/maps/doc/geocoder/desc/concepts/input_params.xml (sorry, I don't know where is english version this page), key is in optional parameters.
