### PR TITLE
Substate for Google result

### DIFF
--- a/lib/geocoder/results/google.rb
+++ b/lib/geocoder/results/google.rb
@@ -35,6 +35,18 @@ module Geocoder::Result
       end
     end
 
+    def sub_state
+      if state = address_components_of_type(:administrative_area_level_2).first
+        state['long_name']
+      end
+    end
+
+    def sub_state_code
+      if state = address_components_of_type(:administrative_area_level_2).first
+        state['short_name']
+      end
+    end
+
     def country
       if country = address_components_of_type(:country).first
         country['long_name']


### PR DESCRIPTION
Substate for Google result.

It's not necessary designate city, for example:

```
r = Geocoder.search('55.430359,37.277830').first
r.city => "Krasnaya Pakhra"
r.sub_state => "Podolsky District"
```
