### PR TITLE
Fix configure syntax for test docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,7 +487,9 @@ Testing Apps that Use Geocoder
 
 When writing tests for an app that uses Geocoder it may be useful to avoid network calls and have Geocoder return consistent, configurable results. To do this, configure and use the `:test` lookup. For example:
 
-    Geocoder.configure(:lookup => :test)
+    Geocoder.configure do |config| 
+      config.lookup = :test
+    end
 
     Geocoder::Lookup::Test.add_stub(
       "New York, NY", [


### PR DESCRIPTION
This was breaking for me using 1.1.5. The updates fixes it.
