### PR TITLE
Improve regular expressions for queries.

### DIFF
--- a/lib/geocoder/query.rb
+++ b/lib/geocoder/query.rb
@@ -48,7 +48,7 @@ module Geocoder
     def blank?
       !params_given? and (
         (text.is_a?(Array) and text.compact.size < 2) or
-        text.to_s.match(/^\s*$/)
+        text.to_s.match(/\A\s*\z/)
       )
     end
 
@@ -59,14 +59,14 @@ module Geocoder
     # dot-delimited numbers.
     #
     def ip_address?
-      !!text.to_s.match(/^(::ffff:)?(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/)
+      !!text.to_s.match(/\A(::ffff:)?(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})\z/)
     end
 
     ##
     # Is the Query text a loopback IP address?
     #
     def loopback_ip_address?
-      !!(text == "0.0.0.0" or text.to_s.match(/^127/))
+      !!(self.ip_address? and (text == "0.0.0.0" or text.to_s.match(/\A127/)))
     end
 
     ##
@@ -75,7 +75,7 @@ module Geocoder
     def coordinates?
       text.is_a?(Array) or (
         text.is_a?(String) and
-        !!text.to_s.match(/^-?[0-9\.]+, *-?[0-9\.]+$/)
+        !!text.to_s.match(/\A-?[0-9\.]+, *-?[0-9\.]+\z/)
       )
     end
 

--- a/test/query_test.rb
+++ b/test/query_test.rb
@@ -10,6 +10,7 @@ class QueryTest < Test::Unit::TestCase
     assert !Geocoder::Query.new("232.65.123.94.43").ip_address?
     assert !Geocoder::Query.new("232.65.123").ip_address?
     assert !Geocoder::Query.new("::ffff:123.456.789").ip_address?
+    assert !Geocoder::Query.new("Test\n232.65.123.94").ip_address?
   end
 
   def test_blank_query_detection
@@ -18,6 +19,7 @@ class QueryTest < Test::Unit::TestCase
     assert Geocoder::Query.new("\t  ").blank?
     assert !Geocoder::Query.new("a").blank?
     assert !Geocoder::Query.new("Москва").blank? # no ASCII characters
+    assert !Geocoder::Query.new("\na").blank?
 
     assert Geocoder::Query.new(nil, :params => {}).blank?
     assert !Geocoder::Query.new(nil, :params => {:woeid => 1234567}).blank?
@@ -32,11 +34,14 @@ class QueryTest < Test::Unit::TestCase
     assert Geocoder::Query.new("51.178844,5").coordinates?
     assert Geocoder::Query.new("51.178844, -1.826189").coordinates?
     assert !Geocoder::Query.new("232.65.123").coordinates?
+    assert !Geocoder::Query.new("Test\n51.178844, -1.826189").coordinates?
   end
 
   def test_loopback_ip_address
     assert Geocoder::Query.new("0.0.0.0").loopback_ip_address?
     assert Geocoder::Query.new("127.0.0.1").loopback_ip_address?
     assert !Geocoder::Query.new("232.65.123.234").loopback_ip_address?
+    assert !Geocoder::Query.new("127 Main St.").loopback_ip_address?
+    assert !Geocoder::Query.new("John Doe\n127 Main St.\nAnywhere, USA").loopback_ip_address?
   end
 end


### PR DESCRIPTION
Many of the query regular expressions use ^ and $, which permit newlines in Ruby. We can use \A and \z instead. In addition, any address that began with "127" would return true on loopback_ip_address? These issues have been corrected in query.rb with tests.

Note: there are also several other instances of ^ and $ in regexes in the code. As these are mostly related to various provider implementations, I haven't reviewed if using \A and \z would be more appropriate for them.

Thanks!
