### PR TITLE
require 'date' so Date#today is available for gemspec.date

### DIFF
--- a/geocoder.gemspec
+++ b/geocoder.gemspec
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
 $:.push File.expand_path("../lib", __FILE__)
+require 'date'
 require "geocoder/version"
 
 Gem::Specification.new do |s|


### PR DESCRIPTION
fixes `undefined method`today' for Date:Class (NoMethodError)` on gemspec
