### PR TITLE
Add option to specify custom lookup for a Query

### DIFF
--- a/lib/geocoder/query.rb
+++ b/lib/geocoder/query.rb
@@ -31,7 +31,7 @@ module Geocoder
       if ip_address?
         name = Configuration.ip_lookup || Geocoder::Lookup.ip_services.first
       else
-        name = Configuration.lookup || Geocoder::Lookup.street_services.first
+        name = options[:lookup] || Configuration.lookup || Geocoder::Lookup.street_services.first
       end
       Lookup.get(name)
     end

--- a/test/query_test.rb
+++ b/test/query_test.rb
@@ -44,4 +44,8 @@ class QueryTest < Test::Unit::TestCase
     assert !Geocoder::Query.new("127 Main St.").loopback_ip_address?
     assert !Geocoder::Query.new("John Doe\n127 Main St.\nAnywhere, USA").loopback_ip_address?
   end
+
+  def test_lookup
+    assert_equal Geocoder::Lookup::Bing, Geocoder::Query.new("4227 Main St.", :lookup => :bing).lookup.class
+  end
 end


### PR DESCRIPTION
This now allows for the following snippet to work:

``` ruby
Geocoder.search("4227 Main St., Chicago, IL", :lookup => :bing)
```

If a geocode attempt fails, I need to take matters into my own hands.  The best strategy, in my case, is to simply specify the various API end points until I can get what I'm looking for.
