### PR TITLE
Prevent calling CGI.escape on a SafeBuffer

### DIFF
--- a/lib/geocoder/lookups/base.rb
+++ b/lib/geocoder/lookups/base.rb
@@ -242,7 +242,7 @@ module Geocoder
       def hash_to_query(hash)
         require 'cgi' unless defined?(CGI) && defined?(CGI.escape)
         hash.collect{ |p|
-          p[1].nil? ? nil : p.map{ |i| CGI.escape i.to_s } * '='
+          p[1].nil? ? nil : p.map{ |i| CGI.escape i.to_s.to_str } * '='
         }.compact.sort * '&'
       end
     end


### PR DESCRIPTION
I don't know if this is the right place for this but similar to this issue: https://github.com/rails/rails/issues/1555 when the `CGI.escape i.to_s` call is made and `i` is an `ActiveSupport::SafeBuffer`, then it blows up with a `NoMethodError: undefined method`bytesize' for nil:NilClass` error.

This may be overly defensive coding, but using `to_s.to_str` ensures that whatever `CGI.escape` sees is surely a string.
