### PR TITLE
Geocoder.cache returning cache store instead of Geocoder::Cache instance.

### DIFF
--- a/lib/geocoder.rb
+++ b/lib/geocoder.rb
@@ -44,7 +44,7 @@ module Geocoder
   #
   def cache
     warn "WARNING: Calling Geocoder.cache is DEPRECATED. The #cache method now belongs to the Geocoder::Lookup object."
-    Geocoder::Lookup.get(Geocoder.config.lookup).send(:configuration).cache
+    Geocoder::Lookup.get(Geocoder.config.lookup).cache
   end
 end
 

--- a/lib/geocoder/lookups/base.rb
+++ b/lib/geocoder/lookups/base.rb
@@ -72,6 +72,16 @@ module Geocoder
       def query_url(query)
         fail
       end
+      
+      ##
+      # The working Cache object.
+      #
+      def cache
+        if @cache.nil? and store = configuration.cache
+          @cache = Cache.new(store, configuration.cache_prefix)
+        end
+        @cache
+      end
 
       private # -------------------------------------------------------------
 
@@ -223,16 +233,6 @@ module Geocoder
             "The #{query.lookup.name} API requires a key to be configured: " +
             parts_string.inspect
         end
-      end
-
-      ##
-      # The working Cache object.
-      #
-      def cache
-        if @cache.nil? and store = configuration.cache
-          @cache = Cache.new(store, configuration.cache_prefix)
-        end
-        @cache
       end
 
       ##


### PR DESCRIPTION
Running _Geocoder.cache.expire(:all)_ with a Redis cache store results in the following error (Rails 3.2.12):

```
ArgumentError: wrong number of arguments (1 for 2)
    from /Users/.../gems/redis-3.0.2/lib/redis.rb:301:in `expire'
```

Geocoder is calling the _expire_ method directly on the Redis client, instead of the expire method in Geocoder::Cache.
