### PR TITLE
Quick convert of :units to symbol

### DIFF
--- a/lib/geocoder/stores/active_record.rb
+++ b/lib/geocoder/stores/active_record.rb
@@ -103,6 +103,9 @@ module Geocoder::Store
       # * +:exclude+         - an object to exclude (used by the +nearbys+ method)
       #
       def near_scope_options(latitude, longitude, radius = 20, options = {})
+        if options[:units]
+          options[:units] = options[:units].to_sym
+        end
         options[:units] ||= (geocoder_options[:units] || Geocoder.config.units)
         select_distance = options.fetch(:select_distance, true)
         options[:order] = "" if !select_distance && !options.include?(:order)


### PR DESCRIPTION
I just wrote quick conversion to always pass symbol to near scope options (as per Issue #297).  Passes all tests.
