### PR TITLE
add support for default test stub value

### DIFF
--- a/lib/geocoder/lookups/test.rb
+++ b/lib/geocoder/lookups/test.rb
@@ -13,9 +13,17 @@ module Geocoder
         stubs[query_text] = results
       end
 
+      def self.add_default_stub(&block)
+        @default_stub = block
+      end
+
       def self.read_stub(query_text)
         stubs.fetch(query_text) {
-          raise ArgumentError, "unknown stub request #{query_text}"
+          if @default_stub
+            @default_stub.call
+          else
+            raise ArgumentError, "unknown stub request #{query_text}"
+          end
         }
       end
 
@@ -25,6 +33,7 @@ module Geocoder
 
       def self.reset
         @stubs = {}
+        @default_stub = nil
       end
 
       private

--- a/test/test_mode_test.rb
+++ b/test/test_mode_test.rb
@@ -13,8 +13,41 @@ class TestModeTest < Test::Unit::TestCase
   end
 
   def test_search_with_known_stub
+    Geocoder::Lookup::Test.add_stub("New York, NY", [mock_attributes])
+
+    results = Geocoder.search("New York, NY")
+    result = results.first
+
+    assert_equal 1, results.size
+    mock_attributes.keys.each do |attr|
+      assert_equal mock_attributes[attr], result.send(attr)
+    end
+  end
+
+  def test_search_with_unknown_stub_without_default
+    assert_raise ArgumentError do
+      Geocoder.search("New York, NY")
+    end
+  end
+
+  def test_search_with_unknown_stub_with_default
+    Geocoder::Lookup::Test.add_default_stub do
+      [mock_attributes]
+    end
+
+    results = Geocoder.search("Atlantis, OC")
+    result = results.first
+
+    assert_equal 1, results.size
+    mock_attributes.keys.each do |attr|
+      assert_equal mock_attributes[attr], result.send(attr)
+    end
+  end
+
+  private
+  def mock_attributes
     coordinates = [40.7143528, -74.0059731]
-    attributes = {
+    @mock_attributes ||= {
       'coordinates'  => coordinates,
       'latitude'     => coordinates[0],
       'longitude'    => coordinates[1],
@@ -24,27 +57,5 @@ class TestModeTest < Test::Unit::TestCase
       'country'      => 'United States',
       'country_code' => 'US',
     }
-
-    Geocoder::Lookup::Test.add_stub("New York, NY", [attributes])
-
-    results = Geocoder.search("New York, NY")
-    assert_equal 1, results.size
-
-    result = results.first
-    assert_equal coordinates,                result.coordinates
-    assert_equal attributes['latitude'],     result.latitude
-    assert_equal attributes['longitude'],    result.longitude
-    assert_equal attributes['address'],      result.address
-    assert_equal attributes['state'],        result.state
-    assert_equal attributes['state_code'],   result.state_code
-    assert_equal attributes['country'],      result.country
-    assert_equal attributes['country_code'], result.country_code
   end
-
-  def test_search_with_unknown_stub
-    assert_raise ArgumentError do
-      Geocoder.search("New York, NY")
-    end
-  end
-
 end


### PR DESCRIPTION
Add support for a default stub value when using running tests w/Geocoder. Allows you to set a single default stub for your entire application to avoid the "unknown stub request..." exceptions.

syntax:

```
Geocoder.configure(:lookup => :test)
Geocoder::Lookup::Test.add_default_stub do
      # expected values go here
 end
```
