### PR TITLE
Fix bug on reverse geocoding for esri provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,19 @@ Please see the [source code for each lookup](https://github.com/alexreisner/geoc
     # with Nominatim:
     Geocoder.search("Paris", :params => {:countrycodes => "gb,de,fr,es,us"})
 
+Esri provider can work with many map coordinate projections. If you need to use some projection different from WGS Web Mercator (this is the default and the most used projection in web mapping, used by bing maps, google maps, arcgis online, among others) you can specify it through the wkid (stands for well known ID) parameter. Just provide the wkid code in the configuration hash to make it work. For example, if you need the geocoding output on the WGS84 (World Geodetic System 1984) projection or need to do reverse geocoding for some coordinate data stored on any projection different from web mercator, just use:
+
+    Geocoder.configure(
+
+      :wkid => 4326,
+
+      ...
+
+    )
+
+  For more info on map projections please see [this link](https://en.wikipedia.org/wiki/Map_projection)
+
+
 
 ### Listing and Comparison
 
@@ -427,7 +440,7 @@ Yahoo BOSS is **not a free service**. As of November 17, 2012 Yahoo no longer of
 * **Languages**: English
 * **Documentation**: http://resources.arcgis.com/en/help/arcgis-online-geocoding-rest-api/
 * **Terms of Service**: http://www.esri.com/software/arcgis/arcgisonline/services/geoservices
-* **Limitations**: ?
+* **Limitations**: Some licensing restrictions may apply. See Terms of Service.
 
 
 Caching

--- a/lib/geocoder/configuration.rb
+++ b/lib/geocoder/configuration.rb
@@ -61,7 +61,8 @@ module Geocoder
       :cache_prefix,
       :always_raise,
       :units,
-      :distances
+      :distances,
+      :wkid
     ]
 
     attr_accessor :data
@@ -111,6 +112,11 @@ module Geocoder
       # calculation options
       @data[:units]     = :mi      # :mi or :km
       @data[:distances] = :linear  # :linear or :spherical
+
+      # sets the default projection to web mercator (used by google and most of map providers)
+      # this option is used by the esri provider and defines which geographic projection must be used
+      # for geocoding operations
+      @data[:wkid] = 102100
     end
 
     instance_eval(OPTIONS.map do |option|

--- a/lib/geocoder/lookups/esri.rb
+++ b/lib/geocoder/lookups/esri.rb
@@ -36,13 +36,15 @@ module Geocoder::Lookup
         {
           :location => query.coordinates.reverse.join(','),
           :outFields => :*,
-          :p => :pjson
+          :f => :pjson,
+          :outSR => configuration.wkid
         }.merge(super)
       else
         {
           :f => :pjson,
           :outFields => :*,
-          :text => query.sanitized_text
+          :text => query.sanitized_text,
+          :outSR => configuration.wkid
         }.merge(super)
       end
     end  

--- a/test/services_test.rb
+++ b/test/services_test.rb
@@ -281,7 +281,7 @@ class ServicesTest < Test::Unit::TestCase
     query = Geocoder::Query.new("Bluffton, SC")
     lookup = Geocoder::Lookup.get(:esri)
     res = lookup.query_url(query)
-    assert_equal "http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/find?f=pjson&outFields=%2A&text=Bluffton%2C+SC",
+    assert_equal "http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/find?f=pjson&outFields=%2A&outSR=102100&text=Bluffton%2C+SC",
       res
   end
 
@@ -289,7 +289,7 @@ class ServicesTest < Test::Unit::TestCase
     query = Geocoder::Query.new([45.423733, -75.676333])
     lookup = Geocoder::Lookup.get(:esri)
     res = lookup.query_url(query)
-    assert_equal "http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode?location=-75.676333%2C45.423733&outFields=%2A&p=pjson",
+    assert_equal "http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode?f=pjson&location=-75.676333%2C45.423733&outFields=%2A&outSR=102100",
       res
   end
 


### PR DESCRIPTION
Fix a bug on reverse geocoding by using the correct parameter option for psjon. Also, supports new option for wkids different from wgs web mercator.
