### PR TITLE
Allow symbol to mean radius comes from a db column

### DIFF
--- a/lib/geocoder/calculations.rb
+++ b/lib/geocoder/calculations.rb
@@ -206,13 +206,18 @@ module Geocoder
     #
     def bounding_box(point, radius, options = {})
       lat,lon = extract_coordinates(point)
-      radius  = radius.to_f
+      if radius.kind_of?(Symbol)
+        radius = radius.to_s
+      else
+        radius  = radius.to_f
+      end
+      
       units   = options[:units] || Geocoder.config.units
       [
-        lat - (radius / latitude_degree_distance(units)),
-        lon - (radius / longitude_degree_distance(lat, units)),
-        lat + (radius / latitude_degree_distance(units)),
-        lon + (radius / longitude_degree_distance(lat, units))
+        "#{lat} - (#{radius} / #{latitude_degree_distance(units)})",
+        "#{lon} - (#{radius} / #{longitude_degree_distance(lat, units)})",
+        "#{lat} + (#{radius} / #{latitude_degree_distance(units)})",
+        "#{lon} + (#{radius} / #{longitude_degree_distance(lat, units)})"
       ]
     end
 

--- a/lib/geocoder/stores/active_record.rb
+++ b/lib/geocoder/stores/active_record.rb
@@ -87,6 +87,7 @@ module Geocoder::Store
       ##
       # Get options hash suitable for passing to ActiveRecord.find to get
       # records within a radius (in kilometers) of the given point.
+      # If radius is a symbol, it is intepreted as a column name in the table.
       # Options hash may include:
       #
       # * +:units+   - <tt>:mi</tt> or <tt>:km</tt>; to be used.
@@ -127,7 +128,11 @@ module Geocoder::Store
         if using_sqlite?
           conditions = bounding_box_conditions
         else
-          conditions = [bounding_box_conditions + " AND #{distance} <= ?", radius]
+          if radius.kind_of?(Symbol)
+            conditions = [bounding_box_conditions + " AND #{distance} <= #{radius.to_s}"]
+          else
+            conditions = [bounding_box_conditions + " AND #{distance} <= ?", radius]
+          end
         end
         {
           :select => select_clause(options[:select],


### PR DESCRIPTION
Hi Alex, please take a look at this change. There's may be a cleaner way to do it, but this was quick-and-dirty and does what I needed.

The use-case this new feature supports is for the case when each record has its own radius (e.g., a delivery radius for a store), and you as a customer want to see if you qualify. If the radius you pass in to .near(...) is a symbol, e.g., :delivery_radius_miles, then that text gets passed through to the query as a column name rather than getting cast in ruby to a float and used in app-level calculations. There is a side-effect in how I implemented it; even if you pass a numeric value, the calculation is still done in the database layer.
