### PR TITLE
Allow custom search options when geocoding on the model

### DIFF
--- a/lib/geocoder/stores/base.rb
+++ b/lib/geocoder/stores/base.rb
@@ -101,7 +101,11 @@ module Geocoder
           return
         end
 
-        results = Geocoder.search(query,options[:search_options])
+        search_options = options[:search_options]
+        if search_options && search_options.respond_to?(:call)
+          search_options = search_options.call(self,query,options)
+        end
+        results = Geocoder.search(query,search_options||{})
 
         # execute custom block, if specified in configuration
         block_key = reverse ? :reverse_block : :geocode_block


### PR DESCRIPTION
Geocoder.search accepts a custom options parameter which can be used to apply service specific configuration for a given search. In my cause, limiting a search result to a specific country for google. 

This patch allows developers to pass a :search_options value or proc which is in turn forwarded to the Gecoder.search method when the model is geocoded.
