### PR TITLE
Handle Content-Encoding 'gzip' responses from Geocoding API's.

### DIFF
--- a/lib/geocoder/configuration.rb
+++ b/lib/geocoder/configuration.rb
@@ -1,3 +1,5 @@
+# -*- encoding : utf-8 -*-
+
 require 'singleton'
 require 'geocoder/configuration_hash'
 
@@ -95,7 +97,7 @@ module Geocoder
       @data[:lookup]       = :google     # name of street address geocoding service (symbol)
       @data[:ip_lookup]    = :freegeoip  # name of IP address geocoding service (symbol)
       @data[:language]     = :en         # ISO-639 language code
-      @data[:http_headers] = {}          # HTTP headers for lookup
+      @data[:http_headers] = {"Accept-Encoding" => "gzip"} # HTTP headers for lookup
       @data[:use_https]    = false       # use HTTPS for lookup requests? (if supported)
       @data[:http_proxy]   = nil         # HTTP proxy server (user:pass@host:port)
       @data[:https_proxy]  = nil         # HTTPS proxy server (user:pass@host:port)


### PR DESCRIPTION
Now requests gzip'ed responses by default for improved API performance.

```
Geocoder.config[:http_headers] = {"Accept-Encoding" => "gzip"}
```

This request behavior can be overridden with:

```
Geocoder.config[:http_headers] = nil
```

This fix is the result of an issue observed with Bing where it will
sometimes return the first response as:

```
"content-type"=>["application/json"]
```

with no content-encoding response header. However it will sometimes
return gzip body content on subsequent requests:

```
"content-type"=>["application/json"], "content-encoding"=>["gzip"]
```

with the body fully gzip encoded. Geocoder did not previously handle
gzip'ed responses.
