### PR TITLE
added units example to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ To find objects by location, use the following scopes:
 
     Venue.near('Omaha, NE, US', 20)    # venues within 20 miles of Omaha
     Venue.near([40.71, 100.23], 20)    # venues within 20 miles of a point
+    Venue.near([40.71, 100.23], 20, :units => :km)
+                                       # venues within 20 kilometres of a point
     Venue.geocoded                     # venues with coordinates
     Venue.not_geocoded                 # venues without coordinates
 


### PR DESCRIPTION
A few of the coders on our project spent a while banging our head against this, trying to figure out how to pass units in to the "near" method.  I've added a doc example showing it, since it seems like something that might be quite often needed.  If other params can be passed -- apart from the API-specific ones I mean -- it might be good to show a more generalised example of how they are passed.
