### PR TITLE
Return ActiveRecord::Relation instead of nil

### DIFF
--- a/lib/geocoder/stores/active_record.rb
+++ b/lib/geocoder/stores/active_record.rb
@@ -28,6 +28,8 @@ module Geocoder::Store
             "OR #{geocoder_options[:longitude]} IS NULL")
         }
 
+        scope :none, where('1==0')
+
         ##
         # Find all objects within a radius of the given location.
         # Location may be either a string to geocode or an array of

--- a/lib/geocoder/stores/base.rb
+++ b/lib/geocoder/stores/base.rb
@@ -24,7 +24,7 @@ module Geocoder
       #
       def distance_to(point, units = nil)
         units ||= self.class.geocoder_options[:units]
-        return nil unless geocoded?
+        return self.class.none unless geocoded?
         Geocoder::Calculations.distance_between(
           to_coordinates, point, :units => units)
       end
@@ -38,7 +38,7 @@ module Geocoder
       #
       def bearing_to(point, options = {})
         options[:method] ||= self.class.geocoder_options[:method]
-        return nil unless geocoded?
+        return self.class.none unless geocoded?
         Geocoder::Calculations.bearing_between(
           to_coordinates, point, options)
       end
@@ -50,7 +50,7 @@ module Geocoder
       #
       def bearing_from(point, options = {})
         options[:method] ||= self.class.geocoder_options[:method]
-        return nil unless geocoded?
+        return self.class.none unless geocoded?
         Geocoder::Calculations.bearing_between(
           point, to_coordinates, options)
       end
@@ -61,7 +61,7 @@ module Geocoder
       # Returns nil if the object is not geocoded.
       #
       def nearbys(radius = 20, options = {})
-        return nil unless geocoded?
+        return self.class.none unless geocoded?
         options.merge!(:exclude => self) unless send(self.class.primary_key).nil?
         self.class.near(self, radius, options)
       end


### PR DESCRIPTION
When an ActiveRecord::Base fails to be geocoded and methods like nearbys are called, the returned value is nil.  Often this nil would break logic when chained with additional scopes and I would need to write extra code to check for nil.  By returning an empty ActiveRecord::Relation this removes the need for that extra check.
