### PR TITLE
Add bounds option to configuration. Fixes #482.

### DIFF
--- a/lib/geocoder/configuration.rb
+++ b/lib/geocoder/configuration.rb
@@ -61,7 +61,8 @@ module Geocoder
       :cache_prefix,
       :always_raise,
       :units,
-      :distances
+      :distances,
+      :bounds
     ]
 
     attr_accessor :data
@@ -102,6 +103,7 @@ module Geocoder
       @data[:api_key]      = nil         # API key for geocoding service
       @data[:cache]        = nil         # cache object (must respond to #[], #[]=, and #keys)
       @data[:cache_prefix] = "geocoder:" # prefix (string) to use for all cache keys
+      @data[:bounds]       = nil          # Google-only option to restrict the search area
 
       # exceptions that should not be rescued by default
       # (if you want to implement custom error handling);

--- a/lib/geocoder/lookups/google.rb
+++ b/lib/geocoder/lookups/google.rb
@@ -41,7 +41,7 @@ module Geocoder::Lookup
         :sensor => "false",
         :language => configuration.language
       }
-      unless (bounds = query.options[:bounds]).nil?
+      unless (bounds = query.options[:bounds] || configuration.bounds).nil?
         params[:bounds] = bounds.map{ |point| "%f,%f" % point }.join('|')
       end
       unless (region = query.options[:region]).nil?

--- a/test/services_test.rb
+++ b/test/services_test.rb
@@ -53,6 +53,23 @@ class ServicesTest < Test::Unit::TestCase
     assert_match /bounds=40.0+%2C-120.0+%7C39.0+%2C-121.0+/, url
   end
 
+  def test_google_query_url_when_config_contains_bounds
+    Geocoder.configure(:bounds => [[40.0, -120.0], [39.0, -121.0]])
+    lookup = Geocoder::Lookup::Google.new
+    url = lookup.query_url(Geocoder::Query.new("Paris"))
+    assert_match /bounds=40.0+%2C-120.0+%7C39.0+%2C-121.0+/, url
+  end
+
+  def test_google_query_url_uses_search_bounds_when_config_contains_bounds
+    Geocoder.configure(:bounds => [[32.1,-95.9], [33.9,-94.3]])
+    lookup = Geocoder::Lookup::Google.new
+    url = lookup.query_url(Geocoder::Query.new(
+      "Some Intersection",
+      :bounds => [[40.0, -120.0], [39.0, -121.0]]
+    ))
+    assert_match /bounds=40.0+%2C-120.0+%7C39.0+%2C-121.0+/, url
+  end
+
   def test_google_query_url_contains_region
     lookup = Geocoder::Lookup::Google.new
     url = lookup.query_url(Geocoder::Query.new(
@@ -324,7 +341,7 @@ class ServicesTest < Test::Unit::TestCase
     assert_equal 40.75004981300049, result.coordinates[0]
     assert_equal -73.99423889799965, result.coordinates[1]
   end
-  
+
   def test_esri_results_component_when_reverse_geocoding
     Geocoder.configure(:lookup => :esri)
     result = Geocoder.search([45.423733, -75.676333]).first


### PR DESCRIPTION
This commit allows people to specify a default bounds in the configuration when using Google's service. Any lookup will include the bounds, which adds support for bounds in the `near` method (see [issue #482](https://github.com/alexreisner/geocoder/issues/482)). If bounds are specified in the config as well as in a search query (like `Geocoder.search("Paris", :bounds => [[32.1,-95.9], [33.9,-94.3]])`), then the bounds specified in the search will take precedence over those in the configuration.
