### PR TITLE
allow query text that is actually an array.

### DIFF
--- a/lib/geocoder/query.rb
+++ b/lib/geocoder/query.rb
@@ -17,7 +17,11 @@ module Geocoder
 
     def sanitized_text
       if coordinates?
-        text.split(/\s*,\s*/).join(',')
+        if text.is_a?(Array)
+          text.join(',')
+        else
+          text.split(/\s*,\s*/).join(',')
+        end
       else
         text
       end


### PR DESCRIPTION
It's checked for down in `coordinates?`, but when using it with the Google locator this was giving me an error.

Thanks for a great gem!
