### PR TITLE
Allow bing to search restricted by region

### DIFF
--- a/lib/geocoder/lookups/bing.rb
+++ b/lib/geocoder/lookups/bing.rb
@@ -29,7 +29,7 @@ module Geocoder::Lookup
     end
 
     def sanitized_text(query)
-      URI.escape(query.sanitized_text) if !query.reverse_geocode?
+      URI.escape(query.sanitized_text.strip) if !query.reverse_geocode?
     end
 
     def results(query)

--- a/test/services_test.rb
+++ b/test/services_test.rb
@@ -274,6 +274,16 @@ class ServicesTest < Test::Unit::TestCase
     assert_no_match /query/, url
   end
 
+  def test_bing_query_url_contains_address_with_trailing_and_leading_spaces
+    lookup = Geocoder::Lookup::Bing.new
+    url = lookup.query_url(Geocoder::Query.new(
+      " manchester, lancashire ",
+      :region => "uk"
+    ))
+    assert_match /Locations\/uk\/manchester,%20lancashire/, url
+    assert_no_match /query/, url
+  end
+
   # --- Nominatim ---
 
   def test_nominatim_result_components


### PR DESCRIPTION
We want to limit our geocoding to just within the UK - if the user enters Manchester, by default when on Bing, it'll find the Manchester in the US.

Supplying the region option for Google geocoding works, but the same option isn't supported on Bing. That's what we've added here.

Also, we've changed the url to be used to the structured version as per http://msdn.microsoft.com/en-us/library/ff701711.aspx

For example, the search pinned to the UK region for Manchester now uses the URL:

http://dev.virtualearth.net/REST/v1/Locations/uk/manchester?key=BingMapsKey

Thanks for a great gem!

John Gallagher
Arnold Clark
