### PR TITLE
Allow Mapquest API version to be specified

### DIFF
--- a/lib/geocoder/lookups/mapquest.rb
+++ b/lib/geocoder/lookups/mapquest.rb
@@ -15,7 +15,8 @@ module Geocoder::Lookup
 
     def query_url(query)
       domain = configuration[:licensed] ? "www" : "open"
-      url = "#{protocol}://#{domain}.mapquestapi.com/geocoding/v1/#{search_type(query)}?"
+      version = configuration[:version] || 1
+      url = "#{protocol}://#{domain}.mapquestapi.com/geocoding/v#{version}/#{search_type(query)}?"
       url + url_query_string(query)
     end
 

--- a/test/services_test.rb
+++ b/test/services_test.rb
@@ -281,11 +281,11 @@ class ServicesTest < Test::Unit::TestCase
   end
 
   def test_api_route_licensed
-    Geocoder.configure(:lookup => :mapquest, :api_key => "abc123", :mapquest => {:licensed => true})
+    Geocoder.configure(:lookup => :mapquest, :api_key => "abc123", :mapquest => {:licensed => true, :version => 2})
     lookup = Geocoder::Lookup::Mapquest.new
     query = Geocoder::Query.new("Bluffton, SC")
     res = lookup.query_url(query)
-    assert_equal "http://www.mapquestapi.com/geocoding/v1/address?key=abc123&location=Bluffton%2C+SC",
+    assert_equal "http://www.mapquestapi.com/geocoding/v2/address?key=abc123&location=Bluffton%2C+SC",
       res
   end
 


### PR DESCRIPTION
This adds a new configuration variable allowing the Mapquest API version to be specified. I found it necessary to use v2 to geocode non-US addresses. The JSON format appears to be the same for v1 and v2 so I have not added any new fixtures or tests, except to verify the URL is built correctly.
