### PR TITLE
Fix maxmind results from reserved response

### DIFF
--- a/lib/geocoder/lookups/maxmind.rb
+++ b/lib/geocoder/lookups/maxmind.rb
@@ -75,7 +75,7 @@ module Geocoder::Lookup
     end
 
     def reserved_result
-      ",,,,0,0,0,0,,,"
+      ",,,,0,0,0,0,,,".split(",")
     end
 
     def query_url_params(query)

--- a/test/services_test.rb
+++ b/test/services_test.rb
@@ -226,6 +226,18 @@ class ServicesTest < Test::Unit::TestCase
     end
   end
 
+  def test_maxmind_works_when_loopback_address_on_omni
+    Geocoder.configure(:ip_lookup => :maxmind, :maxmind => { :service => :omni })
+    result = Geocoder.search("127.0.0.1").first
+    assert_equal "", result.country_code
+  end
+
+  def test_maxmind_works_when_loopback_address_on_country
+    Geocoder.configure(:ip_lookup => :maxmind, :maxmind => { :service => :country })
+    result = Geocoder.search("127.0.0.1").first
+    assert_equal "", result.country_code
+  end
+
 
   # --- Bing ---
 
@@ -333,7 +345,7 @@ class ServicesTest < Test::Unit::TestCase
     assert_equal 40.75004981300049, result.coordinates[0]
     assert_equal -73.99423889799965, result.coordinates[1]
   end
-  
+
   def test_esri_results_component_when_reverse_geocoding
     Geocoder.configure(:lookup => :esri)
     result = Geocoder.search([45.423733, -75.676333]).first


### PR DESCRIPTION
In maxmind querying for `127.0.0.1` raises an exception, as `reserved_result` is expected to return an array.
