### PR TITLE
Added ability to make a default stub for the geometry response parameter

### DIFF
--- a/lib/geocoder/results/test.rb
+++ b/lib/geocoder/results/test.rb
@@ -6,7 +6,7 @@ module Geocoder
 
       %w[latitude longitude city state state_code province
       province_code postal_code country country_code address
-      street_address street_number route].each do |attr|
+      street_address street_number route geometry].each do |attr|
         define_method(attr) do
           @data[attr.to_s] || @data[attr.to_sym]
         end


### PR DESCRIPTION
It will be useful to stub `geometry` response using 

``` ruby
Geocoder.configure(:lookup => :test)
```

Example:
http://maps.googleapis.com/maps/api/geocode/json?address=1600+Amphitheatre+Parkway,+Mountain+View,+CA&sensor=true
