### PR TITLE
Change mongodb near query so that a nil radius omits the maxDistance instead of setting to 0.0

### DIFF
--- a/lib/geocoder/stores/mongo_base.rb
+++ b/lib/geocoder/stores/mongo_base.rb
@@ -31,8 +31,11 @@ module Geocoder::Store
           field = geocoder_options[:coordinates]
           conds[field] = empty.clone
           conds[field]["$nearSphere"]  = coords.reverse
-          conds[field]["$maxDistance"] = \
-            Geocoder::Calculations.distance_to_radians(radius, options[:units])
+
+          if radius
+            conds[field]["$maxDistance"] = \
+              Geocoder::Calculations.distance_to_radians(radius, options[:units])
+          end
 
           if obj = options[:exclude]
             conds[:_id.ne] = obj.id

--- a/test/mongoid_test.rb
+++ b/test/mongoid_test.rb
@@ -36,4 +36,11 @@ class MongoidTest < Test::Unit::TestCase
     result = PlaceWithoutIndex.index_options.keys.flatten[0] == :coordinates
     assert !result
   end
+
+  def test_nil_radius_omits_max_distance
+    location = [40.750354, -73.993371]
+    p = Place.near(location, nil)
+    key = Mongoid::VERSION >= "3" ? "location" : :location
+    assert_equal nil, p.selector[key]['$maxDistance']
+  end
 end


### PR DESCRIPTION
Currently, when a nil radius is passed to the near scope, maxDistance is set to 0.0 which will not return any results. Since maxDistance is optional (http://docs.mongodb.org/manual/reference/operator/query/near/#op._S_near), I think it would be nice to not force maxDistance to be set. This pull requests checks to see if radius is not nil before setting the maxDistance operator.
