### PR TITLE
Fix city fetching from yandex

### DIFF
--- a/test/result_test.rb
+++ b/test/result_test.rb
@@ -26,7 +26,7 @@ class ResultTest < Test::Unit::TestCase
       Geocoder.configure(:lookup => :yandex)
       set_api_key!(:yandex)
       result = Geocoder.search("new york").first
-      assert_equal "New York", result.city
+      assert_equal "", result.city
     end
   end
 


### PR DESCRIPTION
I couldn't receive the city if in the address there is a residential district, because sub_state returns a name
