### PR TITLE
Adds support for custom freegeoip host config

### DIFF
--- a/lib/geocoder/lookups/freegeoip.rb
+++ b/lib/geocoder/lookups/freegeoip.rb
@@ -9,7 +9,7 @@ module Geocoder::Lookup
     end
 
     def query_url(query)
-      "#{protocol}://freegeoip.net/json/#{query.sanitized_text}"
+      "#{protocol}://#{host}/json/#{query.sanitized_text}"
     end
 
     private # ---------------------------------------------------------------
@@ -38,6 +38,10 @@ module Geocoder::Lookup
         "country_name" => "Reserved",
         "country_code" => "RD"
       }
+    end
+
+    def host
+      configuration[:host] || "freegeoip.net"
     end
   end
 end

--- a/test/services_test.rb
+++ b/test/services_test.rb
@@ -162,6 +162,13 @@ class ServicesTest < Test::Unit::TestCase
     assert_equal "Plano, TX 75093, United States", result.address
   end
 
+  def test_freegeoip_host_config
+    Geocoder.configure(:lookup => :freegeoip, :freegeoip => {:host => "local.com"})
+    lookup = Geocoder::Lookup::Freegeoip.new
+    query = Geocoder::Query.new("24.24.24.23")
+    assert_match %r(http://local\.com), lookup.query_url(query)
+  end
+
   # --- MaxMind ---
 
   def test_maxmind_result_on_ip_address_search


### PR DESCRIPTION
This code provides the functionality requested in #562 (a configurable host for freegeoip.net lookups).

You can use it like so: Geocoder.configure(:freegeoip => {:host => 'yourhost.com'})
