### PR TITLE
Functionality to pass optional :min_radius value to 'near' searches.

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,11 @@ When querying for objects (if you're using ActiveRecord) you can also look withi
 
 This can also dramatically improve query performance, especially when used in conjunction with indexes on the latitude/longitude columns. Note, however, that returned results do not include `distance` and `bearing` attributes. Note that `#near` performs both bounding box and radius queries for speed.
 
+You can also specify a minimum radius (if you're using ActiveRecord and not Sqlite) to constrain the 
+lower bound (ie. think of a donut, or ring) by using the `:min_radius` option:
+
+    box = Geocoder::Calculations.bounding_box(center_point, distance, :min_radius => 10.5)
+
 
 Advanced Geocoding
 ------------------

--- a/lib/geocoder/stores/active_record.rb
+++ b/lib/geocoder/stores/active_record.rb
@@ -107,6 +107,9 @@ module Geocoder::Store
       # * +:exclude+         - an object to exclude (used by the +nearbys+ method)
       # * +:distance_column+ - used to set the column name of the calculated distance.
       # * +:bearing_column+  - used to set the column name of the calculated bearing.
+      # * +:min_radius+      - the value to use as the minimum radius. 
+      #                        ignored if database is sqlite.
+      #                        default is 0.0
       #
       def near_scope_options(latitude, longitude, radius = 20, options = {})
         if options[:units]
@@ -131,7 +134,8 @@ module Geocoder::Store
         if using_sqlite?
           conditions = bounding_box_conditions
         else
-          conditions = [bounding_box_conditions + " AND #{distance} <= ?", radius]
+          min_radius = options.fetch(:min_radius, 0).to_f
+          conditions = [bounding_box_conditions + " AND (#{distance}) BETWEEN ? AND ?", min_radius, radius]
         end
         {
           :select => select_clause(options[:select],

--- a/test/near_test.rb
+++ b/test/near_test.rb
@@ -9,6 +9,33 @@ class NearTest < Test::Unit::TestCase
       result[:conditions][0]
   end
 
+  def test_near_scope_options_without_sqlite_includes_radius_condition
+    result = Event.send(:near_scope_options, 1.0, 2.0, 5)
+
+    assert_match /BETWEEN \? AND \?$/, result[:conditions][0]
+  end
+
+  def test_near_scope_options_without_sqlite_includes_radius_default_min_radius
+    result = Event.send(:near_scope_options, 1.0, 2.0, 5)
+
+    assert_equal 0, result[:conditions][1]
+    assert_equal 5, result[:conditions][2]
+  end
+
+  def test_near_scope_options_without_sqlite_includes_radius_custom_min_radius
+    result = Event.send(:near_scope_options, 1.0, 2.0, 5, :min_radius => 3)
+
+    assert_equal 3, result[:conditions][1]
+    assert_equal 5, result[:conditions][2]
+  end
+
+  def test_near_scope_options_without_sqlite_includes_radius_bogus_min_radius
+    result = Event.send(:near_scope_options, 1.0, 2.0, 5, :min_radius => 'bogus')
+
+    assert_equal 0, result[:conditions][1]
+    assert_equal 5, result[:conditions][2]
+  end
+
   def test_near_scope_options_with_defaults
     result = Event.send(:near_scope_options, 1.0, 2.0, 5)
 


### PR DESCRIPTION
Only works with ActiveRecord and not Sqlite.  Default's to zero.  I checked the documentation for MySQL, PostgreSQL, and Oracle.  All three state that "A BETWEEN B AND C" is equivalent to "A >= B AND A <= C" so there shouldn't be any performance impact constraining all queries to use a minimum radius of zero.
