### PR TITLE
Allow arbitrary attributes on Geocoder::Result::Test

### DIFF
--- a/lib/geocoder/results/test.rb
+++ b/lib/geocoder/results/test.rb
@@ -4,12 +4,26 @@ module Geocoder
   module Result
     class Test < Base
 
-      %w[latitude longitude neighborhood city state state_code sub_state
-      sub_state_code province province_code postal_code country
-      country_code address street_address street_number route geometry].each do |attr|
+      def self.add_result_attribute(attr)
+        return if respond_to?(attr.to_sym)
+
         define_method(attr) do
           @data[attr.to_s] || @data[attr.to_sym]
         end
+      end
+
+      %w[latitude longitude neighborhood city state state_code sub_state
+      sub_state_code province province_code postal_code country
+      country_code address street_address street_number route geometry].each do |attr|
+        add_result_attribute(attr)
+      end
+
+      def initialize(data)
+        data.keys.each do |attr|
+          Test.add_result_attribute(attr)
+        end
+
+        super
       end
     end
   end

--- a/test/test_mode_test.rb
+++ b/test/test_mode_test.rb
@@ -42,6 +42,15 @@ class TestModeTest < Test::Unit::TestCase
     end
   end
 
+  def test_search_with_custom_attributes
+    custom_attributes = mock_attributes.merge(:custom => 'NY, NY')
+    Geocoder::Lookup::Test.add_stub("New York, NY", [custom_attributes])
+
+    result = Geocoder.search("New York, NY").first
+
+    assert_equal 'NY, NY', result.custom
+  end
+
   private
   def mock_attributes
     coordinates = [40.7143528, -74.0059731]


### PR DESCRIPTION
Similar to #565, but allows to define any attribute methods on test result without changing the code. For example:

``` ruby
Geocoder.configure(:lookup => :test)
Geocoder::Lookup::Test.set_default_stub([{    
      'city'      => 'New York',
      'police'   => 'NYPD'
}])

Geocoder.search('New York').first.police # => 'NYPD'
```
