### PR TITLE
Use OpenSSL::Digest instead of deprecated OpenSSL::Digest::Digest

### DIFF
--- a/lib/geocoder/lookups/google_premier.rb
+++ b/lib/geocoder/lookups/google_premier.rb
@@ -31,7 +31,7 @@ module Geocoder::Lookup
 
     def sign(string)
       raw_private_key = url_safe_base64_decode(configuration.api_key[0])
-      digest = OpenSSL::Digest::Digest.new('sha1')
+      digest = OpenSSL::Digest.new('sha1')
       raw_signature = OpenSSL::HMAC.digest(digest, raw_private_key, string)
       url_safe_base64_encode(raw_signature)
     end

--- a/lib/oauth_util.rb
+++ b/lib/oauth_util.rb
@@ -49,7 +49,7 @@ class OauthUtil
     key = percent_encode( @consumer_secret ) + '&' + percent_encode( @token_secret )
 
     # ref: http://blog.nathanielbibler.com/post/63031273/openssl-hmac-vs-ruby-hmac-benchmarks
-    digest = OpenSSL::Digest::Digest.new( 'sha1' )
+    digest = OpenSSL::Digest.new( 'sha1' )
     hmac = OpenSSL::HMAC.digest( digest, key, @base_str )
 
     # ref http://groups.google.com/group/oauth-ruby/browse_thread/thread/9110ed8c8f3cae81


### PR DESCRIPTION
OpenSSL::Digest::Digest has been discouraged to use since Ruby 1.8 https://github.com/ruby/ruby/blob/ruby_1_8_7/ext/openssl/lib/openssl/digest.rb#L51
and was deprecated recently. ruby/ruby#446

This pull request removes the deprecation warning shown in ruby 2.1
