### PR TITLE
Improve Baidu and BaiduIp lookup by fixing error and cover test.

### DIFF
--- a/lib/geocoder/lookups/baidu.rb
+++ b/lib/geocoder/lookups/baidu.rb
@@ -24,19 +24,19 @@ module Geocoder::Lookup
       when 0
         return [doc['result']] unless doc['result'].blank?
       when 1, 3, 4
-        raise_error(Geocoder::Error, messages) ||
+        raise_error(Geocoder::Error, "server error.") ||
           warn("Baidu Geocoding API error: server error.")
       when 2
-        raise_error(Geocoder::InvalidRequest, messages) ||
+        raise_error(Geocoder::InvalidRequest, "invalid request.") ||
           warn("Baidu Geocoding API error: invalid request.")
       when 5
-        raise_error(Geocoder::InvalidApiKey, messages) ||
+        raise_error(Geocoder::InvalidApiKey, "invalid api key") ||
           warn("Baidu Geocoding API error: invalid api key.")
       when 101, 102, 200..299
-        raise_error(Geocoder::RequestDenied) ||
+        raise_error(Geocoder::RequestDenied, "request denied") ||
           warn("Baidu Geocoding API error: request denied.")
       when 300..399
-        raise_error(Geocoder::OverQueryLimitError) ||
+        raise_error(Geocoder::OverQueryLimitError, "over query limit.") ||
           warn("Baidu Geocoding API error: over query limit.")
       end
       return []

--- a/lib/geocoder/lookups/baidu_ip.rb
+++ b/lib/geocoder/lookups/baidu_ip.rb
@@ -24,19 +24,19 @@ module Geocoder::Lookup
       when 0
         return [doc['content']] unless doc['content'].blank?
       when 1, 3, 4
-        raise_error(Geocoder::Error, messages) ||
+        raise_error(Geocoder::Error, "server error.") ||
           warn("Baidu IP Geocoding API error: server error.")
       when 2
-        raise_error(Geocoder::InvalidRequest, messages) ||
+        raise_error(Geocoder::InvalidRequest, "invalid request.") ||
           warn("Baidu IP Geocoding API error: invalid request.")
       when 5
-        raise_error(Geocoder::InvalidApiKey, messages) ||
+        raise_error(Geocoder::InvalidApiKey, "invalid api key.") ||
           warn("Baidu IP Geocoding API error: invalid api key.")
       when 101, 102, 200..299
-        raise_error(Geocoder::RequestDenied) ||
+        raise_error(Geocoder::RequestDenied, "request denied.") ||
           warn("Baidu IP Geocoding API error: request denied.")
       when 300..399
-        raise_error(Geocoder::OverQueryLimitError) ||
+        raise_error(Geocoder::OverQueryLimitError, "over query limit") ||
           warn("Baidu IP Geocoding API error: over query limit.")
       end
       return []


### PR DESCRIPTION
-  fixes the error when calling messages in both Baidu and BaiduIp lookup because messages is not defined.
- adds some tests to cover more for both Baidu and BaiduIp lookup .
