### PR TITLE
add object kind recognising for yandex result object

### DIFF
--- a/lib/geocoder/results/yandex.rb
+++ b/lib/geocoder/results/yandex.rb
@@ -59,6 +59,10 @@ module Geocoder::Result
       address_details['Locality']['Premise']['PremiseName']
     end
 
+    def kind
+      @data['GeoObject']['metaDataProperty']['GeocoderMetaData']['kind']
+    end
+
     def precision
       @data['GeoObject']['metaDataProperty']['GeocoderMetaData']['precision']
     end

--- a/test/result_test.rb
+++ b/test/result_test.rb
@@ -30,6 +30,16 @@ class ResultTest < Test::Unit::TestCase
     end
   end
 
+  def test_yandex_result_kind
+    assert_nothing_raised do
+      Geocoder.configure(:lookup => :yandex)
+      set_api_key!(:yandex)
+      ["new york", [45.423733, -75.676333], "no city and town"].each do |query|
+        Geocoder.search("new york").first.kind
+      end
+    end
+  end
+
   private # ------------------------------------------------------------------
 
   def assert_result_has_required_attributes(result)


### PR DESCRIPTION
Yandex tells us what is the kind of returned objects. Sometimes it is useful to obtain that information with some pretty syntax instead of travelling through data by hands.
