### PR TITLE
Don't throw errors when using SSL

### DIFF
--- a/lib/geocoder/lookups/base.rb
+++ b/lib/geocoder/lookups/base.rb
@@ -233,7 +233,7 @@ module Geocoder
           opts[:use_ssl] = true if configuration.use_https
 
           http_client.start(*args, opts) do |client|
-            resp = client.get(uri.request_uri, configuration.http_headers)
+            client.get(uri.request_uri, configuration.http_headers)
           end
         end
       end


### PR DESCRIPTION
Setting config `:use_ssl => true` currently raises `IOError` from `Net::HTTP`; Because `start` is called before setting the `use_ssl` flag. This patch sets up all of the required args before calling `start`, and uses `.get` on the existing client rather than instantiating a new instance of Net::HTTP::Get.

As a sidebar, MaxmindLocal tests are erroring, presumably because they exist yet `maxmind_local` isn't being required. Not sure what the gameplan is for that, so I left it alone. The rest of the tests are passing.
