### PR TITLE
result.coordinates not working for maxmind_local

### DIFF
--- a/test/unit/lookups/maxmind_local_test.rb
+++ b/test/unit/lookups/maxmind_local_test.rb
@@ -18,6 +18,7 @@ class MaxmindLocalTest < GeocoderTestCase
     assert_equal result.postal_code, '94043'
     assert_equal result.latitude, 37.41919999999999
     assert_equal result.longitude, -122.0574
+    assert_equal result.coordinates, [37.41919999999999, -122.0574]
   end
 
   def test_loopback


### PR DESCRIPTION
Hello,

The symptom of my issue was that result.coordinates was always returning [0.0, 0.0] for the coordinates.

I proved my issue with a test. However, when I tried to fix it, I ran into issues with the data held within the results object being a mixture of strings and symbols.

It appears that the maxmind_local (and maxmind, but I have not tested it) stores its results hash with symbols instead of strings. That is fine for the most part because the Result::MaxmindLocal class refers to keys as symbols within. However, the Result::Base class provides some methods, like coordinates, but looks up from the results hash via string keys.

I have tried to change the internals of Result::MaxmindLocal to use strings, but at least in the tests, the data hash is actually keyed with symbols, and I am not sure where the symbols are coming, from, considering all other tests and implementations use strings. I also considered perhaps porting over with_indifferent_access and applying it to the data hash, but I feel like that might be too big of a chainsaw.

I'm willing to implement a fix, but am unsure which implementation would be most likely to be accepted.

Thanks
