### PR TITLE
Batch size in rake task for large database

### DIFF
--- a/lib/tasks/geocoder.rake
+++ b/lib/tasks/geocoder.rake
@@ -3,10 +3,12 @@ namespace :geocode do
   task :all => :environment do
     class_name = ENV['CLASS'] || ENV['class']
     sleep_timer = ENV['SLEEP'] || ENV['sleep']
+    batch = ENV['BATCH'] || ENV['batch']
     raise "Please specify a CLASS (model)" unless class_name
     klass = class_from_string(class_name)
+    batch = batch.to_i unless batch.nil?
 
-    klass.not_geocoded.each do |obj|
+    klass.not_geocoded.find_each(batch_size: batch) do |obj|
       obj.geocode; obj.save
       sleep(sleep_timer.to_f) unless sleep_timer.nil?
     end

--- a/test/unit/rake_task_test.rb
+++ b/test/unit/rake_task_test.rb
@@ -1,0 +1,21 @@
+# encoding: utf-8
+$: << File.join(File.dirname(__FILE__), "..")
+require 'test_helper'
+
+class RakeTaskTest < GeocoderTestCase
+  def setup
+    Rake.application.rake_require "tasks/geocoder"
+    Rake::Task.define_task(:environment)
+  end
+
+  def test_rake_task_geocode_raise_specify_class_message
+    assert_raise(RuntimeError, "Please specify a CLASS (model)") do
+      Rake.application.invoke_task("geocode:all")
+    end
+  end
+
+  def test_rake_task_geocode_specify_class
+    ENV['CLASS'] = 'Place'
+    assert_nil Rake.application.invoke_task("geocode:all")
+  end
+end


### PR DESCRIPTION
Add batch size for rake task `geocode:all`.
This may help people who have large database sets.
I decided to add this feature after the question on [stackowerflow#geocoder-ruby-gem-on-demand](http://stackoverflow.com/questions/23012404/geocoder-ruby-gem-on-demand/23012625)
This is my first commit to open source, please correct if I'm wrong. :pray:
