### PR TITLE
Updated lib/geocoder/lookup.rb to include geocodio

### DIFF
--- a/lib/geocoder/lookup.rb
+++ b/lib/geocoder/lookup.rb
@@ -29,6 +29,7 @@ module Geocoder
         :bing,
         :geocoder_ca,
         :geocoder_us,
+        :geocodio,
         :yandex,
         :nominatim,
         :mapquest,


### PR DESCRIPTION
Was throwing erroneous error now that Geocod.io support has been added to this gem.
