### PR TITLE
Add order_by_without_select option for activerecord near scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Rails 4.1 Note
 
 Due to [a change in ActiveRecord's `count` method](https://github.com/rails/rails/pull/10710) you will need to use `count(:all)` to explicitly count all columns ("*") when using a `near` scope. Using `near` and calling `count` with no argument will cause exceptions in many cases.
 
+In the case you use the near scope to filter and order the results but not need the distance and bearing values for each record afterwards, you can add `order_by_without_select: :distance` as option to the near clause and still use `count` without argument.
+
 
 Installation
 ------------

--- a/test/unit/near_test.rb
+++ b/test/unit/near_test.rb
@@ -79,6 +79,13 @@ class NearTest < GeocoderTestCase
     assert_no_consecutive_comma(result[:select])
   end
 
+  def test_near_scope_options_with_order_by_without_select_distance
+    result = PlaceWithCustomResultsHandling.send(:near_scope_options, 1.0, 2.0, 5, order_by_without_select: :distance)
+    assert_nil(result[:select])
+    assert_match(/test_table_name.latitude BETWEEN 0.9276\d* AND 1.0723\d* AND test_table_name.longitude BETWEEN 1.9276\d* AND 2.0723\d* AND /, result[:conditions][0])
+    assert_match(%r{ASIN\(SQRT\(POWER\(SIN\(.*\)\) ASC}, result[:order])
+  end
+
   private
 
   def assert_no_consecutive_comma(string)


### PR DESCRIPTION
Rails 4.1 does not drop added selection columns on count queries
(only on .count(:all)). This parameter adjusts the scope in the way
that the records are filtered and ordered by distance but the distance
is not select separatly. So .count still works with rails 4.1.

Addition to #630
