### PR TITLE
Fix: Maxmind migration generator failed on rolling back

### DIFF
--- a/lib/generators/geocoder/maxmind/templates/migration/geolite_city.rb
+++ b/lib/generators/geocoder/maxmind/templates/migration/geolite_city.rb
@@ -22,6 +22,7 @@ class GeocoderMaxmindGeoliteCity < ActiveRecord::Migration
   end
 
   def self.down
-    drop_table :maxmind_geolite_city
+    drop_table :maxmind_geolite_city_location
+    drop_table :maxmind_geolite_city_blocks
   end
 end


### PR DESCRIPTION
Migration was being generated without the proper table names on the rollback method.
