### PR TITLE
language should be a per request-setting

### DIFF
--- a/lib/geocoder/lookups/google.rb
+++ b/lib/geocoder/lookups/google.rb
@@ -44,7 +44,7 @@ module Geocoder::Lookup
       params = {
         (query.reverse_geocode? ? :latlng : :address) => query.sanitized_text,
         :sensor => "false",
-        :language => configuration.language
+        :language => (query.with_language? ? query.language : configuration.language),
       }
       unless (bounds = query.options[:bounds]).nil?
         params[:bounds] = bounds.map{ |point| "%f,%f" % point }.join('|')

--- a/lib/geocoder/query.rb
+++ b/lib/geocoder/query.rb
@@ -7,6 +7,14 @@ module Geocoder
       self.options = options
     end
 
+    def with_language?
+      !language.nil?
+    end
+
+    def language
+      options[:language]
+    end
+
     def execute
       lookup.search(text, options)
     end

--- a/test/unit/lookups/google_test.rb
+++ b/test/unit/lookups/google_test.rb
@@ -4,6 +4,11 @@ require 'test_helper'
 
 class GoogleTest < GeocoderTestCase
 
+  def test_allowing_to_pass_the_language_per_request
+    query = Geocoder::Query.new("Madison Square Garden, New York, NY", language: :fr)
+    assert_equal "http://maps.googleapis.com/maps/api/geocode/json?address=Madison+Square+Garden%2C+New+York%2C+NY&language=fr&sensor=false", query.url
+  end
+
   def test_google_result_components
     result = Geocoder.search("Madison Square Garden, New York, NY").first
     assert_equal "Manhattan",


### PR DESCRIPTION
this will allow users of the google geo-coding api to choose a language on a per request basis:

``` ruby
Geocoder.search("Nantes, France", language: :fr)
```

related #625
