### PR TITLE
use more forgiving 'unstructured' query format in Bing Locations API

### DIFF
--- a/lib/geocoder/lookups/bing.rb
+++ b/lib/geocoder/lookups/bing.rb
@@ -27,7 +27,9 @@ module Geocoder::Lookup
       if !query.reverse_geocode? and r = query.options[:region]
         url << "/#{r}"
       end
-      url + "/" + URI.escape(query.sanitized_text.strip) + "?"
+      # use the more forgiving 'unstructured' query format to allow special
+      # chars, newlines, brackets, typos.
+      url + "?q=" + URI.escape(query.sanitized_text.strip) + "&"
     end
 
     def results(query)

--- a/test/unit/lookups/bing_test.rb
+++ b/test/unit/lookups/bing_test.rb
@@ -12,7 +12,7 @@ class BingTest < GeocoderTestCase
   def test_query_for_reverse_geocode
     lookup = Geocoder::Lookup::Bing.new
     url = lookup.query_url(Geocoder::Query.new([45.423733, -75.676333]))
-    assert_match(/Locations\/45.423733/, url)
+    assert_match(/Locations\?q=45.423733/, url)
   end
 
   def test_result_components
@@ -33,7 +33,7 @@ class BingTest < GeocoderTestCase
       "manchester",
       :region => "uk"
     ))
-    assert_match(/Locations\/uk\/manchester/, url)
+    assert_match(/Locations\/uk\?q=manchester/, url)
     assert_no_match(/query/, url)
   end
 
@@ -42,7 +42,7 @@ class BingTest < GeocoderTestCase
     url = lookup.query_url(Geocoder::Query.new(
       "manchester"
     ))
-    assert_match(/Locations\/manchester/, url)
+    assert_match(/Locations\?q=manchester/, url)
     assert_no_match(/query/, url)
   end
 
@@ -52,7 +52,7 @@ class BingTest < GeocoderTestCase
       "manchester, lancashire",
       :region => "uk"
     ))
-    assert_match(/Locations\/uk\/manchester,%20lancashire/, url)
+    assert_match(/Locations\/uk\?q=manchester,%20lancashire/, url)
     assert_no_match(/query/, url)
   end
 
@@ -62,7 +62,7 @@ class BingTest < GeocoderTestCase
       " manchester, lancashire ",
       :region => "uk"
     ))
-    assert_match(/Locations\/uk\/manchester,%20lancashire/, url)
+    assert_match(/Locations\/uk\?q=manchester,%20lancashire/, url)
     assert_no_match(/query/, url)
   end
 end


### PR DESCRIPTION
Bing's Locations API structured format (URL path) is fairly sensitive to common typos and cut-paste problems like having a newline char in the address or the user accidentally appending a non-alpha char in a zip code search (i.e. try adding a ] to a zip code search).

The optional unstructured query format uses the query string instead of the URL path and is less sensitive to input exceptions.

Read more here: http://msdn.microsoft.com/en-us/library/ff701711.aspx
