### PR TITLE
Switch to byebug for MRI 2.x debugging.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,9 +8,8 @@ group :development, :test do
   gem 'rubyzip'
   gem 'rails'
 
-  platforms :mri do
-    gem 'debugger'
-  end
+  gem 'debugger', :platforms => [:mri_19]
+  gem 'byebug', :platforms => [:mri_20, :mri_21]
 
   platforms :jruby do
     gem 'jruby-openssl'


### PR DESCRIPTION
 Debugger is not working for 2.1.2 and up, and was never fully 2.x compatible.  See details here - https://github.com/cldwalker/debugger#known-issues
