### PR TITLE
Fix Bing reverse geocode lookups

### DIFF
--- a/lib/geocoder/lookups/bing.rb
+++ b/lib/geocoder/lookups/bing.rb
@@ -24,12 +24,17 @@ module Geocoder::Lookup
 
     def base_url(query)
       url = "#{protocol}://dev.virtualearth.net/REST/v1/Locations"
-      if !query.reverse_geocode? and r = query.options[:region]
-        url << "/#{r}"
+
+      if !query.reverse_geocode?
+        if r = query.options[:region]
+          url << "/#{r}"
+        end
+        # use the more forgiving 'unstructured' query format to allow special
+        # chars, newlines, brackets, typos.
+        url + "?q=" + URI.escape(query.sanitized_text.strip) + "&"
+      else
+        url + "/#{URI.escape(query.sanitized_text.strip)}?"
       end
-      # use the more forgiving 'unstructured' query format to allow special
-      # chars, newlines, brackets, typos.
-      url + "?q=" + URI.escape(query.sanitized_text.strip) + "&"
     end
 
     def results(query)

--- a/test/unit/lookups/bing_test.rb
+++ b/test/unit/lookups/bing_test.rb
@@ -12,7 +12,7 @@ class BingTest < GeocoderTestCase
   def test_query_for_reverse_geocode
     lookup = Geocoder::Lookup::Bing.new
     url = lookup.query_url(Geocoder::Query.new([45.423733, -75.676333]))
-    assert_match(/Locations\?q=45.423733/, url)
+    assert_match(/Locations\/45.423733/, url)
   end
 
   def test_result_components


### PR DESCRIPTION
Bing reverse geocode lookups ('point searches') are currently broken due to needing a different endpoint, as described here: http://msdn.microsoft.com/en-us/library/ff701710.aspx
