### PR TITLE
Fixes CHANGELOG.md formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@ Changelog
 Major changes to Geocoder for each release. Please see the Git log for complete list of changes.
 
 1.2.3 (2014 Jul 11)
-
+-------------------
 * Add Telize IP address lookup (thanks github.com/lukeroberts1990).
 * Fix bug in Bing reverse geocoding (thanks github.com/nickelser).
 
 1.2.2 (2014 Jun 12)
-
+-------------------
 * Add ability to specify language per query (thanks github.com/mkristian).
 * Handle Errno::ECONNREFUSED exceptions like TimeoutError exceptions.
 * Switch to 'unstructured' query format for Bing API (thanks github.com/lukewendling).


### PR DESCRIPTION
This fix adds formatting to match the other version headers.  They were previously plain text.
