### PR TITLE
Allow lookup service to fully opt-out of https

### DIFF
--- a/lib/geocoder/lookups/base.rb
+++ b/lib/geocoder/lookups/base.rb
@@ -99,7 +99,7 @@ module Geocoder
       # Object used to make HTTP requests.
       #
       def http_client
-        protocol = "http#{'s' if configuration.use_https}"
+        protocol = "http#{'s' if use_ssl?}"
         proxy_name = "#{protocol}_proxy"
         if proxy = configuration.send(proxy_name)
           proxy_url = !!(proxy =~ /^#{protocol}/) ? proxy : protocol + '://' + proxy
@@ -198,7 +198,7 @@ module Geocoder
       # Set in configuration but not available for every service.
       #
       def protocol
-        "http" + (configuration.use_https ? "s" : "")
+        "http" + (use_ssl? ? "s" : "")
       end
 
       def valid_response?(response)
@@ -262,12 +262,16 @@ module Geocoder
           args = [uri.host, uri.port]
           args = args.push(uri.user, uri.password) unless uri.user.nil? or uri.password.nil?
           opts = {}
-          opts[:use_ssl] = true if configuration.use_https
+          opts[:use_ssl] = use_ssl?
 
           http_client.start(*args, opts) do |client|
             client.get(uri.request_uri, configuration.http_headers)
           end
         end
+      end
+
+      def use_ssl?
+        configuration.use_https
       end
 
       def check_api_key_configuration!(query)

--- a/lib/geocoder/lookups/telize.rb
+++ b/lib/geocoder/lookups/telize.rb
@@ -15,6 +15,10 @@ module Geocoder::Lookup
 
     private # ---------------------------------------------------------------
 
+    def use_ssl?
+      false
+    end
+
     def results(query)
       # don't look up a loopback address, just return the stored result
       return [reserved_result(query.text)] if query.loopback_ip_address?

--- a/test/integration/http_client_test.rb
+++ b/test/integration/http_client_test.rb
@@ -22,4 +22,10 @@ class HttpClientTest < Test::Unit::TestCase
     results = Geocoder.search "27701"
     assert_not_nil results.first
   end
+
+  def test_ssl_opt_out
+    Geocoder.configure(ip_lookup: :telize, use_https: true)
+    results = Geocoder.search "74.200.247.59"
+    assert_not_nil results.first
+  end
 end

--- a/test/unit/lookups/telize_test.rb
+++ b/test/unit/lookups/telize_test.rb
@@ -27,4 +27,10 @@ class TelizeTest < GeocoderTestCase
     results = Geocoder.search("555.555.555.555")
     assert_equal 0, results.length
   end
+
+  def test_uses_http_even_if_use_https_true
+    Geocoder.configure(use_https: true)
+    result = Geocoder.search("74.200.247.59").first
+    assert result.is_a?(Geocoder::Result::Telize)
+  end
 end


### PR DESCRIPTION
If you have an address geocoding service that you want to use HTTPS with
and then attempt to use an ip_geocoder that does not support HTTPS (e.g.
Telize) then the ip_geocoder lookups will fail because
Geocoder::Lookups::Base#make_api_request turns on opts[:use_ssl] based
on that single configuration value.

Rather than allowing for per-provider HTTPS configuration I have just
refactored Geocoder::Lookups::Base call a private `use_ssl?` method
which can be overridden by individual lookup provider implementations.
The default implementation of `use_ssl?` simply returns the value from
the config thus preserving the existing behavior but this allows
subclasses, like Telize, to override `use_ssl?` completely to return
false and thus fully opt-out of HTTPS regardless of what the
configuration was.
