### PR TITLE
add alternate attributes options for near_scope_options

### DIFF
--- a/lib/geocoder/stores/active_record.rb
+++ b/lib/geocoder/stores/active_record.rb
@@ -115,8 +115,8 @@ module Geocoder::Store
         if options[:units]
           options[:units] = options[:units].to_sym
         end
-        latitude_attribute = options[:alternate_latitude] || geocoder_options[:latitude]
-        longitude_attribute = options[:alternate_longitude] || geocoder_options[:longitude]
+        latitude_attribute = options[:latitude] || geocoder_options[:latitude]
+        longitude_attribute = options[:longitude] || geocoder_options[:longitude]
         options[:units] ||= (geocoder_options[:units] || Geocoder.config.units)
         select_distance = options.fetch(:select_distance, true)
         options[:order] = "" if !select_distance && !options.include?(:order)
@@ -159,8 +159,8 @@ module Geocoder::Store
         Geocoder::Sql.send(
           method_prefix + "_distance",
           latitude, longitude,
-          full_column_name(options[:alternate_latitude] || geocoder_options[:latitude]),
-          full_column_name(options[:alternate_longitude]|| geocoder_options[:longitude]),
+          full_column_name(options[:latitude] || geocoder_options[:latitude]),
+          full_column_name(options[:longitude]|| geocoder_options[:longitude]),
           options
         )
       end
@@ -178,8 +178,8 @@ module Geocoder::Store
           Geocoder::Sql.send(
             method_prefix + "_bearing",
             latitude, longitude,
-            full_column_name(options[:alternate_latitude] || geocoder_options[:latitude]),
-            full_column_name(options[:alternate_longitude]|| geocoder_options[:longitude]),
+            full_column_name(options[:latitude] || geocoder_options[:latitude]),
+            full_column_name(options[:longitude]|| geocoder_options[:longitude]),
             options
           )
         end


### PR DESCRIPTION
I have models with multiple sets of coordinates that I wanted to query on easily. For example, I needed to be able to query User.near based on its latitude/longitude, last_login_latitude/last_login_longitude, etc, so I added optional arguments :alternate_latitude and :alternate_longitude to the options hash in near_scope_options to be able to query on different columns on my users table. So:

```
User.near("Omaha, NE", 5, alternate_latitude: :last_login_latitude, alternate_longitude: :last_login_longitude)
```
