### PR TITLE
use hashed cache key to prevent too long cache key

### DIFF
--- a/lib/geocoder/lookups/base.rb
+++ b/lib/geocoder/lookups/base.rb
@@ -210,7 +210,7 @@ module Geocoder
       # The result might or might not be cached.
       #
       def fetch_raw_data(query)
-        key = cache_key(query)
+        key = Digest::MD5.hexdigest(cache_key(query))
         if cache and body = cache[key]
           @cache_hit = true
         else


### PR DESCRIPTION
We hit some time using the cache an error due to a too long cache key.

I changed to use the md5 of the url as a cache key.
Maybe this should be optional through configuration.

What do you think?
