### PR TITLE
Allow language to be set in geocoded_by as proc

### DIFF
--- a/lib/geocoder/models/active_record.rb
+++ b/lib/geocoder/models/active_record.rb
@@ -17,7 +17,8 @@ module Geocoder
           :geocode_block => block,
           :units         => options[:units],
           :method        => options[:method],
-          :lookup        => options[:lookup]
+          :lookup        => options[:lookup],
+          :language      => options[:language]
         )
       end
 
@@ -33,7 +34,8 @@ module Geocoder
           :reverse_block   => block,
           :units           => options[:units],
           :method          => options[:method],
-          :lookup          => options[:lookup]
+          :lookup          => options[:lookup],
+          :language        => options[:language]
         )
       end
 

--- a/lib/geocoder/models/mongo_base.rb
+++ b/lib/geocoder/models/mongo_base.rb
@@ -20,7 +20,8 @@ module Geocoder
           :units         => options[:units],
           :method        => options[:method],
           :skip_index    => options[:skip_index] || false,
-          :lookup        => options[:lookup]
+          :lookup        => options[:lookup],
+          :language      => options[:language]
         )
       end
 
@@ -36,7 +37,8 @@ module Geocoder
           :units           => options[:units],
           :method          => options[:method],
           :skip_index      => options[:skip_index] || false,
-          :lookup          => options[:lookup]
+          :lookup          => options[:lookup],
+          :language        => options[:language]
         )
       end
 

--- a/lib/geocoder/stores/base.rb
+++ b/lib/geocoder/stores/base.rb
@@ -101,7 +101,7 @@ module Geocoder
           return
         end
 
-        query_options = [:lookup, :ip_lookup].inject({}) do |hash, key|
+        query_options = [:lookup, :ip_lookup, :language].inject({}) do |hash, key|
           if options.has_key?(key)
             val = options[key]
             hash[key] = val.respond_to?(:call) ? val.call(self) : val


### PR DESCRIPTION
Along the lines of what has been done with the :lookup, and with the inclusion of the ability to send the language in which the address will be geocoded, this allows, for example
`geocoded_by :full_address, :language => Proc.new {|model| I18n.locale}`
and
`reverse_geocoded_by :full_address, :language => Proc.new {|model| I18n.locale}`
