### PR TITLE
Update so opencagedata will return coordinates.

### DIFF
--- a/lib/geocoder/results/opencagedata.rb
+++ b/lib/geocoder/results/opencagedata.rb
@@ -64,7 +64,7 @@ module Geocoder::Result
     end
 
     def coordinates
-      [@data['lat'].to_f, @data['lon'].to_f]
+      [@data['geometry']['lat'].to_f, @data['geometry']['lng'].to_f]
     end
     def self.response_attributes
       %w[boundingbox license 


### PR DESCRIPTION
In the current opencagedata api, latitude and longitude are stored under geometry: {lat: ..., lng: ...}
