### PR TITLE
Document google free API requiring https

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ The following is a comparison of the supported geocoding APIs. The "Limitations"
 
 #### Google (`:google`, `:google_premier`)
 
-* **API key**: required for Premier, optional for the free service
+* **API key**: required for Premier, optional for the free service (if using the free service with API key, https is required. Add `:use_https  => true` to `Geocoder.configure`)
 * **Key signup**: https://developers.google.com/maps/documentation/business/
 * **Quota**: 2,500 requests/day, 100,000 with Google Maps API Premier
 * **Region**: world


### PR DESCRIPTION
I stumbled here, ended up finding the answer in the [issues](https://github.com/alexreisner/geocoder/issues/698). Would be great to document this in the main readme.
