### PR TITLE
Add IPv6 format detection

### DIFF
--- a/lib/geocoder/ip_address.rb
+++ b/lib/geocoder/ip_address.rb
@@ -6,7 +6,14 @@ module Geocoder
     end
 
     def valid?
-      !!self.match(/\A(::ffff:)?(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})\z/)
+      ipregex = %r{
+        \A(                                     # String Starts
+        ((::ffff:)?((\d{1,3})\.){3}\d{1,3})     # Check for IPv4
+        |                                       # .... Or
+        (\S+?(:\S+?){6}\S+)                     # Check for IPv6
+        )\z                                     
+      }x
+      !!self.match(ipregex)
     end
   end
 end

--- a/test/unit/ip_address_test.rb
+++ b/test/unit/ip_address_test.rb
@@ -8,6 +8,7 @@ class IpAddressTest < GeocoderTestCase
     assert Geocoder::IpAddress.new("232.65.123.94").valid?
     assert Geocoder::IpAddress.new("666.65.123.94").valid? # technically invalid
     assert Geocoder::IpAddress.new("::ffff:12.34.56.78").valid?
+    assert Geocoder::IpAddress.new("3ffe:0b00:0000:0000:0001:0000:0000:000a").valid?
     assert !Geocoder::IpAddress.new("232.65.123.94.43").valid?
     assert !Geocoder::IpAddress.new("232.65.123").valid?
     assert !Geocoder::IpAddress.new("::ffff:123.456.789").valid?

--- a/test/unit/query_test.rb
+++ b/test/unit/query_test.rb
@@ -6,6 +6,7 @@ class QueryTest < GeocoderTestCase
 
   def test_ip_address_detection
     assert Geocoder::Query.new("232.65.123.94").ip_address?
+    assert Geocoder::Query.new("3ffe:0b00:0000:0000:0001:0000:0000:000a").ip_address?
     assert !Geocoder::Query.new("232.65.123.94.43").ip_address?
     assert !Geocoder::Query.new("::ffff:123.456.789").ip_address?
   end


### PR DESCRIPTION
While freegeoip doesn't support IPv6, maxmind does, and it makes sense to at least know when someone is submitting an IPv6 address.
