### PR TITLE
IPv6 loopback ip ::1 should be detected as a valid loopback ip..

### DIFF
--- a/lib/geocoder/ip_address.rb
+++ b/lib/geocoder/ip_address.rb
@@ -2,7 +2,7 @@ module Geocoder
   class IpAddress < String
 
     def loopback?
-      valid? and (self == "0.0.0.0" or self.match(/\A127\./))
+      valid? and (self == "0.0.0.0" or self.match(/\A127\./) or self == "::1")
     end
 
     def valid?
@@ -11,6 +11,8 @@ module Geocoder
         ((::ffff:)?((\d{1,3})\.){3}\d{1,3})     # Check for IPv4
         |                                       # .... Or
         (\S+?(:\S+?){6}\S+)                     # Check for IPv6
+        |                                       # .... Or
+        (::1)                                   # IPv6 loopback
         )\z                                     
       }x
       !!self.match(ipregex)

--- a/test/unit/ip_address_test.rb
+++ b/test/unit/ip_address_test.rb
@@ -9,6 +9,7 @@ class IpAddressTest < GeocoderTestCase
     assert Geocoder::IpAddress.new("666.65.123.94").valid? # technically invalid
     assert Geocoder::IpAddress.new("::ffff:12.34.56.78").valid?
     assert Geocoder::IpAddress.new("3ffe:0b00:0000:0000:0001:0000:0000:000a").valid?
+    assert Geocoder::IpAddress.new("::1").valid?
     assert !Geocoder::IpAddress.new("232.65.123.94.43").valid?
     assert !Geocoder::IpAddress.new("232.65.123").valid?
     assert !Geocoder::IpAddress.new("::ffff:123.456.789").valid?
@@ -18,6 +19,7 @@ class IpAddressTest < GeocoderTestCase
   def test_loopback
     assert Geocoder::IpAddress.new("0.0.0.0").loopback?
     assert Geocoder::IpAddress.new("127.0.0.1").loopback?
+    assert Geocoder::IpAddress.new("::1").loopback?
     assert !Geocoder::IpAddress.new("232.65.123.234").loopback?
     assert !Geocoder::IpAddress.new("127 Main St.").loopback?
     assert !Geocoder::IpAddress.new("John Doe\n127 Main St.\nAnywhere, USA").loopback?


### PR DESCRIPTION
We stumbled upon this bug, when running our application test in OSX env, on which `request.remote_ip` returns `::1`.
