### PR TITLE
Limit maxmind local subselect query to reduce cost

### DIFF
--- a/lib/geocoder/lookups/maxmind_local.rb
+++ b/lib/geocoder/lookups/maxmind_local.rb
@@ -36,7 +36,7 @@ module Geocoder::Lookup
         addr = IPAddr.new(query.text).to_i
         q = "SELECT l.country, l.region, l.city, l.latitude, l.longitude
           FROM maxmind_geolite_city_location l WHERE l.loc_id = (SELECT b.loc_id FROM maxmind_geolite_city_blocks b
-          WHERE b.start_ip_num <= #{addr} AND #{addr} <= b.end_ip_num)"
+          WHERE b.start_ip_num <= #{addr} AND #{addr} <= b.end_ip_num LIMIT 1)"
         format_result(q, [:country_name, :region_name, :city_name, :latitude, :longitude])
       elsif configuration[:package] == :country
         addr = IPAddr.new(query.text).to_i


### PR DESCRIPTION
Since we only want to select one IP block anyway, limiting this query
reduces the query cost from (cost=22531.65..22539.67 rows=1 width=31)
to (cost=0.53..8.54 rows=1 width=31)
