### PR TITLE
Fixes OID warnings when using PostgreSQL

### DIFF
--- a/lib/geocoder/stores/active_record.rb
+++ b/lib/geocoder/stores/active_record.rb
@@ -45,8 +45,7 @@ module Geocoder::Store
             # If no lat/lon given we don't want any results, but we still
             # need distance and bearing columns so you can add, for example:
             # .order("distance")
-            null_val = using_postgres? ? 'NULL::text' : 'NULL'
-            select(select_clause(nil, null_val, null_val)).where(false_condition)
+            select(select_clause(nil, null_value, null_value)).where(false_condition)
           end
         }
 
@@ -65,8 +64,7 @@ module Geocoder::Store
               full_column_name(geocoder_options[:longitude])
             ))
           else
-            null_val = using_postgres? ? 'NULL::text' : 'NULL'
-            select(select_clause(nil, null_val, null_val)).where(false_condition)
+            select(select_clause(nil, null_value, null_value)).where(false_condition)
           end
         }
       end
@@ -228,6 +226,13 @@ module Geocoder::Store
 
       def using_postgres?
         connection.adapter_name.match(/postgres/i)
+      end
+
+      ##
+      # Use OID type when running in PosgreSQL
+      #
+      def null_value
+        using_postgres? ? 'NULL::text' : 'NULL'
       end
 
       ##


### PR DESCRIPTION
Postgres correctly identifies OIDs when `BEARING` and `DISTANCE` columns contain numerical values. It fails to identify OID for NULL when it expects a numerical value. That results in these two warnings:

```
unknown OID: distance(705) (SELECT  cities.*, NULL AS distance, NULL AS bearing FROM "cities"  WHERE (false)  ORDER BY "cities"."id" ASC LIMIT 1)
unknown OID: bearing(705) (SELECT  cities.*, NULL AS distance, NULL AS bearing FROM "cities"  WHERE (false)  ORDER BY "cities"."id" ASC LIMIT 1)
```

This patch explicitly sets an OID type `::text` for NULLs when running in PostgreSQL environment. `::text` is a default OID type in PostgreSQL.

References #637 and #628
