### PR TITLE
Fix Yandex city error when JSON does not include 'AdministrativeArea'

### DIFF
--- a/lib/geocoder/results/yandex.rb
+++ b/lib/geocoder/results/yandex.rb
@@ -14,7 +14,8 @@ module Geocoder::Result
     def city
       if state.empty? and address_details.has_key? 'Locality'
         address_details['Locality']['LocalityName']
-      elsif sub_state.empty? and address_details['AdministrativeArea'].has_key? 'Locality'
+      elsif sub_state.empty? and address_details.has_key? 'AdministrativeArea' and
+          address_details['AdministrativeArea'].has_key? 'Locality'
         address_details['AdministrativeArea']['Locality']['LocalityName']
       elsif not sub_state_city.empty?
         sub_state_city

--- a/test/fixtures/yandex_no_administrative_area
+++ b/test/fixtures/yandex_no_administrative_area
@@ -1,0 +1,53 @@
+{
+   "response":{
+      "GeoObjectCollection":{
+         "metaDataProperty":{
+            "GeocoderResponseMetaData":{
+               "request":"13.813139,100.560291",
+               "found":"1",
+               "results":"1",
+               "Point":{
+                  "pos":"13.813139 100.560291"
+               }
+            }
+         },
+         "featureMember":[
+            {
+               "GeoObject":{
+                  "metaDataProperty":{
+                     "GeocoderMetaData":{
+                        "kind":"house",
+                        "text":"Thailand, Phahon Yothin Road, 1130/5",
+                        "precision":"exact",
+                        "AddressDetails":{
+                           "Country":{
+                              "AddressLine":"Phahon Yothin Road, 1130/5",
+                              "CountryNameCode":"TH",
+                              "CountryName":"Thailand",
+                              "Thoroughfare":{
+                                 "ThoroughfareName":"Phahon Yothin Road",
+                                 "Premise":{
+                                    "PremiseNumber":"1130/5"
+                                 }
+                              }
+                           }
+                        }
+                     }
+                  },
+                  "description":"Thailand",
+                  "name":"Phahon Yothin Road, 1130/5",
+                  "boundedBy":{
+                     "Envelope":{
+                        "lowerCorner":"100.552005 13.805102",
+                        "upperCorner":"100.568462 13.821184"
+                     }
+                  },
+                  "Point":{
+                     "pos":"100.560234 13.813143"
+                  }
+               }
+            }
+         ]
+      }
+   }
+}

--- a/test/unit/result_test.rb
+++ b/test/unit/result_test.rb
@@ -22,6 +22,15 @@ class ResultTest < GeocoderTestCase
     end
   end
 
+  def test_yandex_result_without_admin_area_no_exception
+    assert_nothing_raised do
+      Geocoder.configure(:lookup => :yandex)
+      set_api_key!(:yandex)
+      result = Geocoder.search("no administrative area").first
+      assert_equal "", result.city
+    end
+  end
+
   def test_yandex_result_new_york
     assert_nothing_raised do
       Geocoder.configure(:lookup => :yandex)


### PR DESCRIPTION
I was running into exceptions calling `#city` on location results for coordinates in certain regions. It appears that sometimes Yandex does return `AddressDetails.Country` in the JSON, but the `Country` key doesn't include `AdministrativeArea`, which can lead to an `undefined method `has_key?' for nil:NilClass` error.

This is just a quick patch for the issue by checking for the existence of `AdministrativeArea` before checking for the key below that. If you'd prefer a different approach, let me know.