### PR TITLE
Explicitly Load Railtie in Test Env

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -67,6 +67,9 @@ end
 require 'geocoder'
 require "geocoder/lookups/base"
 
+# and initialize Railtie manually (since Rails::Railtie doesn't exist)
+Geocoder::Railtie.insert
+
 ##
 # Mock HTTP request to geocoding service.
 #


### PR DESCRIPTION
Fix #780

Test suite failed because railtie wasn't loaded (because Rails/ActiveRecord are stubbed out in test env). This initializes it explicitly in test_helper, before any models get defined.