### PR TITLE
Add license to gemspec

### DIFF
--- a/geocoder.gemspec
+++ b/geocoder.gemspec
@@ -17,4 +17,5 @@ Gem::Specification.new do |s|
   s.files       = `git ls-files`.split("\n") - %w[geocoder.gemspec Gemfile init.rb]
   s.require_paths = ["lib"]
   s.executables = ["geocode"]
+  s.license     = 'MIT'
 end


### PR DESCRIPTION
I was trying to determine the licenses for my dependencies. I found that the RubyGems API will return the license, but only if it is specified in your gemspec file.