### PR TITLE
Handle freegoip's updated response format

### DIFF
--- a/lib/geocoder/results/freegeoip.rb
+++ b/lib/geocoder/results/freegeoip.rb
@@ -29,7 +29,7 @@ module Geocoder::Result
     end
 
     def postal_code
-      @data['zipcode']
+      @data['zipcode'] || @data['zip_code']
     end
 
     def self.response_attributes


### PR DESCRIPTION
It seems that freegeoip.net now returns `zip_code` (with an underscore) instead of `zip_code`. This pull request handles both responses.