### PR TITLE
Force specfify ip_lookup on search, even when ip_address? fails

### DIFF
--- a/lib/geocoder/query.rb
+++ b/lib/geocoder/query.rb
@@ -32,7 +32,7 @@ module Geocoder
     # appropriate to the Query text.
     #
     def lookup
-      if ip_address? || (options[:ip_lookup] && options[:lookup].nil?)
+      if options[:ip_address] || ip_address?
         name = options[:ip_lookup] || Configuration.ip_lookup || Geocoder::Lookup.ip_services.first
       else
         name = options[:lookup] || Configuration.lookup || Geocoder::Lookup.street_services.first

--- a/lib/geocoder/query.rb
+++ b/lib/geocoder/query.rb
@@ -32,7 +32,7 @@ module Geocoder
     # appropriate to the Query text.
     #
     def lookup
-      if ip_address?
+      if ip_address? || (options[:ip_lookup] && options[:lookup].nil?)
         name = options[:ip_lookup] || Configuration.ip_lookup || Geocoder::Lookup.ip_services.first
       else
         name = options[:lookup] || Configuration.lookup || Geocoder::Lookup.street_services.first

--- a/test/unit/query_test.rb
+++ b/test/unit/query_test.rb
@@ -50,13 +50,10 @@ class QueryTest < GeocoderTestCase
     assert_equal Geocoder::Lookup::Nominatim, query.lookup.class
   end
 
-  def test_force_specify_ip_lookup
-    query = Geocoder::Query.new("address", :ip_lookup => :baidu_ip)
+  def test_force_specify_ip_address
+    Geocoder.configure({:ip_lookup => :google})
+    query = Geocoder::Query.new("address", {:ip_address => true})
     assert !query.ip_address?
-    assert_equal Geocoder::Lookup::BaiduIp, query.lookup.class
-
-    query = Geocoder::Query.new("address", :ip_lookup => :baidu_ip, :lookup => :bing)
-    assert !query.ip_address?
-    assert_equal Geocoder::Lookup::Bing, query.lookup.class
+    assert_equal Geocoder::Lookup::Google, query.lookup.class
   end
 end

--- a/test/unit/query_test.rb
+++ b/test/unit/query_test.rb
@@ -49,4 +49,14 @@ class QueryTest < GeocoderTestCase
     query = Geocoder::Query.new("address", :lookup => :nominatim)
     assert_equal Geocoder::Lookup::Nominatim, query.lookup.class
   end
+
+  def test_force_specify_ip_lookup
+    query = Geocoder::Query.new("address", :ip_lookup => :baidu_ip)
+    assert !query.ip_address?
+    assert_equal Geocoder::Lookup::BaiduIp, query.lookup.class
+
+    query = Geocoder::Query.new("address", :ip_lookup => :baidu_ip, :lookup => :bing)
+    assert !query.ip_address?
+    assert_equal Geocoder::Lookup::Bing, query.lookup.class
+  end
 end

--- a/test/unit/query_test.rb
+++ b/test/unit/query_test.rb
@@ -56,4 +56,10 @@ class QueryTest < GeocoderTestCase
     assert !query.ip_address?
     assert_equal Geocoder::Lookup::Google, query.lookup.class
   end
+
+  def test_force_specify_ip_address_with_ip_lookup
+    query = Geocoder::Query.new("address", {:ip_address => true, :ip_lookup => :google})
+    assert !query.ip_address?
+    assert_equal Geocoder::Lookup::Google, query.lookup.class
+  end
 end


### PR DESCRIPTION
Connected to #776 