### PR TITLE
Adding MaxMind's GeoIP2 Precision Service API

### DIFF
--- a/lib/geocoder/configuration.rb
+++ b/lib/geocoder/configuration.rb
@@ -55,7 +55,8 @@ module Geocoder
       :cache_prefix,
       :always_raise,
       :units,
-      :distances
+      :distances,
+      :basic_auth
     ]
 
     attr_accessor :data
@@ -96,6 +97,7 @@ module Geocoder
       @data[:api_key]      = nil         # API key for geocoding service
       @data[:cache]        = nil         # cache object (must respond to #[], #[]=, and #keys)
       @data[:cache_prefix] = "geocoder:" # prefix (string) to use for all cache keys
+      @data[:basic_auth]   = {}          # user and password for basic auth ({:user => "user", :password => "password"})
 
       # exceptions that should not be rescued by default
       # (if you want to implement custom error handling);

--- a/lib/geocoder/lookup.rb
+++ b/lib/geocoder/lookup.rb
@@ -56,7 +56,8 @@ module Geocoder
         :maxmind,
         :maxmind_local,
         :telize,
-        :pointpin
+        :pointpin,
+        :maxmind_geoip2
       ]
     end
 

--- a/lib/geocoder/lookups/base.rb
+++ b/lib/geocoder/lookups/base.rb
@@ -271,8 +271,8 @@ module Geocoder
           opts[:use_ssl] = use_ssl?
 
           http_client.start(*args, opts) do |client|
-            req = client::Get.new(uri.request_uri, configuration.http_headers)
-            if configuration.basic_auth
+            req = http_client::Get.new(uri.request_uri, configuration.http_headers)
+            if configuration.basic_auth[:user] && configuration.basic_auth[:password]
               req.basic_auth(configuration.basic_auth[:user], configuration.basic_auth[:password])
             end
             client.request(req)

--- a/lib/geocoder/lookups/base.rb
+++ b/lib/geocoder/lookups/base.rb
@@ -271,7 +271,11 @@ module Geocoder
           opts[:use_ssl] = use_ssl?
 
           http_client.start(*args, opts) do |client|
-            client.get(uri.request_uri, configuration.http_headers)
+            req = http_client::Get.new(uri.request_uri, configuration.http_headers)
+            if configuration.basic_auth
+              req.basic_auth(configuration.basic_auth[:user], configuration.basic_auth[:password])
+            end
+            http_client.request(req)
           end
         end
       end

--- a/lib/geocoder/lookups/base.rb
+++ b/lib/geocoder/lookups/base.rb
@@ -271,11 +271,11 @@ module Geocoder
           opts[:use_ssl] = use_ssl?
 
           http_client.start(*args, opts) do |client|
-            req = http_client::Get.new(uri.request_uri, configuration.http_headers)
+            req = client::Get.new(uri.request_uri, configuration.http_headers)
             if configuration.basic_auth
               req.basic_auth(configuration.basic_auth[:user], configuration.basic_auth[:password])
             end
-            http_client.request(req)
+            client.request(req)
           end
         end
       end

--- a/lib/geocoder/lookups/maxmind_geoip2.rb
+++ b/lib/geocoder/lookups/maxmind_geoip2.rb
@@ -15,7 +15,7 @@ module Geocoder::Lookup
     end
 
     def query_url(query)
-      "#{protocol}://geoip.maxmind.com/geoip/v2.1/#{configured_service!}/" + url_query_string(query)
+      "#{protocol}://geoip.maxmind.com/geoip/v2.1/#{configured_service!}/#{URI.escape(query.sanitized_text.strip)}"
     end
 
     private # ---------------------------------------------------------------

--- a/lib/geocoder/lookups/maxmind_geoip2.rb
+++ b/lib/geocoder/lookups/maxmind_geoip2.rb
@@ -1,0 +1,70 @@
+require 'geocoder/lookups/base'
+require 'geocoder/results/maxmind_geoip2'
+require 'csv'
+
+module Geocoder::Lookup
+  class MaxmindGeoip2 < Base
+
+    def name
+      "MaxMind GeoIP2"
+    end
+
+    def use_ssl?
+      # Maxmind's GeoIP2 Precision Services only supports HTTPS, 
+      # otherwise a `404 Not Found` HTTP response will be returned
+      true
+    end
+
+    def query_url(query)
+      "#{protocol}://geoip.maxmind.com/geoip/v2.1/#{configured_service!}/" + url_query_string(query)
+    end
+
+    private # ---------------------------------------------------------------
+
+    ##
+    # Return the name of the configured service, or raise an exception.
+    #
+    def configured_service!
+      if s = configuration[:service] and services.include?(s) and configuration[:basic_auth][:user] and configuration[:basic_auth][:password]
+        return s
+      else
+        raise(
+          Geocoder::ConfigurationError,
+          "When using MaxMind GeoIP2 you MUST specify a service name and basic_auth: " +
+          "Geocoder.configure(:maxmind_geoip2 => {:service => ...}, " + 
+          ":basic_auth => {:user ..., :password => ...}), " +
+          "where service is one of: #{services.inspect}"
+        )
+      end
+    end
+
+    def data_contains_error?(doc)
+      (["code", "error"] - doc.keys).empty?
+    end
+
+    ##
+    # Service names used in URL.
+    #
+    def services
+      [
+        :country,
+        :city,
+        :insights,
+      ]
+    end
+
+    def results(query)
+      # don't look up a loopback address
+      return [] if query.loopback_ip_address?
+      doc = fetch_data(query)
+      if doc 
+        if !data_contains_error?(doc)
+          return [doc]
+        else
+          warn "MaxMind GeoIP2 Geocoding API error: #{doc['code']} (#{doc['error']})."
+        end
+      end
+      return []
+    end
+  end
+end

--- a/lib/geocoder/lookups/maxmind_geoip2.rb
+++ b/lib/geocoder/lookups/maxmind_geoip2.rb
@@ -1,6 +1,5 @@
 require 'geocoder/lookups/base'
 require 'geocoder/results/maxmind_geoip2'
-require 'csv'
 
 module Geocoder::Lookup
   class MaxmindGeoip2 < Base

--- a/lib/geocoder/results/maxmind_geoip2.rb
+++ b/lib/geocoder/results/maxmind_geoip2.rb
@@ -1,4 +1,4 @@
-require 'geocoder/results/base'
+require 'geocoder/results/geoip2'
 
 module Geocoder::Result
   class MaxmindGeoip2 < Geoip2

--- a/lib/geocoder/results/maxmind_geoip2.rb
+++ b/lib/geocoder/results/maxmind_geoip2.rb
@@ -1,0 +1,9 @@
+require 'geocoder/results/base'
+
+module Geocoder::Result
+  class MaxmindGeoip2 < Geoip2
+    # MindmindGeoip2 has the same results as Geoip2 because both are from MaxMind's GeoIP2 Precision Services
+    # See http://dev.maxmind.com/geoip/geoip2/web-services/ The difference being that Maxmind calls the service
+    # directly while GeoIP2 uses Hive::GeoIP2. See https://github.com/desuwa/hive_geoip2
+  end
+end

--- a/test/fixtures/maxmind_geoip2_1_2_3_4
+++ b/test/fixtures/maxmind_geoip2_1_2_3_4
@@ -1,0 +1,116 @@
+{
+  "city":  {
+      "confidence":  25,
+      "geoname_id": 54321,
+      "names":  {
+          "de":    "Los Angeles",
+          "en":    "Los Angeles",
+          "es":    "Los Ángeles",
+          "fr":    "Los Angeles",
+          "ja":    "ロサンゼルス市",
+          "pt-BR":  "Los Angeles",
+          "ru":    "Лос-Анджелес",
+          "zh-CN": "洛杉矶"
+      }
+  },
+  "continent":  {
+      "code":       "NA",
+      "geoname_id": 123456,
+      "names":  {
+          "de":    "Nordamerika",
+          "en":    "North America",
+          "es":    "América del Norte",
+          "fr":    "Amérique du Nord",
+          "ja":    "北アメリカ",
+          "pt-BR": "América do Norte",
+          "ru":    "Северная Америка",
+          "zh-CN": "北美洲"
+ 
+      }
+  },
+  "country":  {
+      "confidence":  75,
+      "geoname_id":  6252001,
+      "iso_code":    "US",
+      "names":  {
+          "de":     "USA",
+          "en":     "United States",
+          "es":     "Estados Unidos",
+          "fr":     "États-Unis",
+          "ja":     "アメリカ合衆国",
+          "pt-BR":  "Estados Unidos",
+          "ru":     "США",
+          "zh-CN":  "美国"
+      }
+  },
+  "location":  {
+      "accuracy_radius":   20,
+      "latitude":          37.6293,
+      "longitude":         -122.1163,
+      "metro_code":        807,
+      "time_zone":         "America/Los_Angeles"
+  },
+  "postal": {
+      "code":       "90001",
+      "confidence": 10
+  },
+  "registered_country":  {
+      "geoname_id":  6252001,
+      "iso_code":    "US",
+      "names":  {
+          "de":     "USA",
+          "en":     "United States",
+          "es":     "Estados Unidos",
+          "fr":     "États-Unis",
+          "ja":     "アメリカ合衆国",
+          "pt-BR":  "Estados Unidos",
+          "ru":     "США",
+          "zh-CN":  "美国"
+      }
+  },
+  "represented_country":  {
+      "geoname_id":  6252001,
+      "iso_code":    "US",
+      "names":  {
+          "de":     "USA",
+          "en":     "United States",
+          "es":     "Estados Unidos",
+          "fr":     "États-Unis",
+          "ja":     "アメリカ合衆国",
+          "pt-BR":  "Estados Unidos",
+          "ru":     "США",
+          "zh-CN":  "美国"
+      },
+      "type": "military"
+  },
+  "subdivisions":  [
+      {
+          "confidence":  50,
+          "geoname_id":  5332921,
+          "iso_code":    "CA",
+          "names":  {
+              "de":    "Kalifornien",
+              "en":    "California",
+              "es":    "California",
+              "fr":    "Californie",
+              "ja":    "カリフォルニア",
+              "ru":    "Калифорния",
+              "zh-CN": "加州"
+          }
+      }
+  ],
+  "traits": {
+      "autonomous_system_number":      1239,
+      "autonomous_system_organization": "Linkem IR WiMax Network",
+      "domain":                        "example.com",
+      "is_anonymous_proxy":            true,
+      "is_satellite_provider":         true,
+      "isp":                           "Linkem spa",
+      "ip_address":                    "1.2.3.4",
+      "organization":                  "Linkem IR WiMax Network",
+      "user_type":                     "traveler"
+  },
+  "maxmind": {
+      "queries_remaining":            54321
+  }
+}

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -206,6 +206,13 @@ module Geocoder
       end
     end
 
+    class MaxmindGeoip2
+      private
+      def default_fixture_filename
+        "maxmind_geoip2_1_2_3_4"
+      end
+    end
+
     class MaxmindLocal
       private
 
@@ -395,7 +402,9 @@ class GeocoderTestCase < Test::Unit::TestCase
   def setup
     super
     Geocoder::Configuration.instance.set_defaults
-    Geocoder.configure(:maxmind => {:service => :city_isp_org})
+    Geocoder.configure(
+      :maxmind => {:service => :city_isp_org},
+      :maxmind_geoip2 => {:service => :insights, :basic_auth => {:user => "user", :password => "password"}})
   end
 
   def geocoded_object_params(abbrev)

--- a/test/unit/lookup_test.rb
+++ b/test/unit/lookup_test.rb
@@ -23,7 +23,7 @@ class LookupTest < GeocoderTestCase
 
   def test_query_url_contains_values_in_params_hash
     Geocoder::Lookup.all_services_except_test.each do |l|
-      next if [:freegeoip, :maxmind_local, :telize, :pointpin, :geoip2].include? l # does not use query string
+      next if [:freegeoip, :maxmind_local, :telize, :pointpin, :geoip2, :maxmind_geoip2].include? l # does not use query string
       set_api_key!(l)
       url = Geocoder::Lookup.get(l).query_url(Geocoder::Query.new(
         "test", :params => {:one_in_the_hand => "two in the bush"}

--- a/test/unit/lookups/maxmind_geoip2_test.rb
+++ b/test/unit/lookups/maxmind_geoip2_test.rb
@@ -1,0 +1,32 @@
+# encoding: utf-8
+require 'test_helper'
+
+class MaxmindGeoip2Test < GeocoderTestCase
+  def setup
+    Geocoder.configure(ip_lookup: :maxmind_geoip2)
+  end
+
+  def test_result_attributes
+    result = Geocoder.search('1.2.3.4').first
+    assert_equal 'Los Angeles, CA 90001, United States', result.address
+    assert_equal 'Los Angeles', result.city
+    assert_equal 'CA', result.state_code
+    assert_equal 'California', result.state
+    assert_equal 'United States', result.country
+    assert_equal 'US', result.country_code
+    assert_equal '90001', result.postal_code
+    assert_equal 37.6293, result.latitude
+    assert_equal -122.1163, result.longitude
+    assert_equal [37.6293, -122.1163], result.coordinates
+  end
+
+  def test_loopback
+    results = Geocoder.search('127.0.0.1')
+    assert_equal [], results
+  end
+
+  def test_no_results
+    results = Geocoder.search("no results")
+    assert_equal 0, results.length
+  end
+end


### PR DESCRIPTION
Connected to #594 

I know that geocoder currently has a geoip2 lookup defined which uses Hive::Geoip2 

- though I believe this is the lite version using the free database? 
- should I be adding this functionality to :geoip2 directly and have some logic that understands to use the Precision Service API?

I ran the test cases, but locally `bundle exec rake test` seems to indicate that the test_helper's version of MaxmindGeoip2 might not actually be used 

- Do I have something configured wrong for the tests?