### PR TITLE
fix issue with empty? doc[‘locations’] on ESRI lookup for some addresses

### DIFF
--- a/lib/geocoder/lookups/esri.rb
+++ b/lib/geocoder/lookups/esri.rb
@@ -21,7 +21,7 @@ module Geocoder::Lookup
       return [] unless doc = fetch_data(query)
 
       if (!query.reverse_geocode?)
-        return [] if doc['locations'].empty?
+        return [] if !doc['locations'] || doc['locations'].empty?
       end
 
       if (doc['error'].nil?)


### PR DESCRIPTION
stacktrace example:

/gems/geocoder-1.2.6/lib/geocoder/lookups/esri.rb:24 in "results"
/gems/geocoder-1.2.6/lib/geocoder/lookups/base.rb:47 in "search"
/gems/geocoder-1.2.6/lib/geocoder/query.rb:11 in "execute"
/gems/geocoder-1.2.6/lib/geocoder.rb:20 in "search"
/gems/geocoder-1.2.6/lib/geocoder/stores/base.rb:111 in "do_lookup"
/gems/geocoder-1.2.6/lib/geocoder/stores/active_record.rb:259 in "geocode"