### PR TITLE
Enable testing different database environiments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ rdoc/*
 .bundle
 Gemfile.lock
 api_keys.yml
+test/geocoder_test.sqlite

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: ruby
+env:
+  - DB=
+  - DB=sqlite
+  - DB=postgres
+  - DB=mysql
 rvm:
   - 1.9.3
   - 2.0.0

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ group :development, :test do
   gem 'geoip'
   gem 'rubyzip'
   gem 'rails'
+  gem 'sqlite3'
   gem 'test-unit' # needed for Ruby >=2.2.0
 
   gem 'byebug', platforms: :mri

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ group :development, :test do
   gem 'geoip'
   gem 'rubyzip'
   gem 'rails'
-  gem 'sqlite3'
   gem 'test-unit' # needed for Ruby >=2.2.0
 
   gem 'byebug', platforms: :mri
@@ -21,6 +20,11 @@ group :development, :test do
     gem 'rubysl', '~> 2.0'
     gem 'rubysl-test-unit'
   end
+end
+
+group :test do
+  gem 'pg'
+  gem 'sqlite3'
 end
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -23,8 +23,10 @@ group :development, :test do
 end
 
 group :test do
-  gem 'pg', platforms: :ruby
-  gem 'sqlite3'
+  platforms :ruby do
+    gem 'pg'
+    gem 'sqlite3'
+  end
 
   platforms :jruby do
     gem 'activerecord-jdbcpostgresql-adapter'

--- a/Gemfile
+++ b/Gemfile
@@ -23,13 +23,15 @@ group :development, :test do
 end
 
 group :test do
+  gem 'sqlite3', :platform => [:ruby, :mswin, :mingw]
+
   platforms :ruby do
     gem 'pg'
-    gem 'sqlite3'
     gem 'mysql2'
   end
 
   platforms :jruby do
+    gem 'jdbc-sqlite3'
     gem 'activerecord-jdbcpostgresql-adapter'
   end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ group :test do
   platforms :ruby do
     gem 'pg'
     gem 'sqlite3'
+    gem 'mysql2'
   end
 
   platforms :jruby do

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ group :test do
   end
 
   platforms :jruby do
+    gem 'jdbc-mysql'
     gem 'jdbc-sqlite3'
     gem 'activerecord-jdbcpostgresql-adapter'
   end

--- a/Gemfile
+++ b/Gemfile
@@ -23,8 +23,12 @@ group :development, :test do
 end
 
 group :test do
-  gem 'pg'
+  gem 'pg', platforms: :ruby
   gem 'sqlite3'
+
+  platforms :jruby do
+    gem 'activerecord-jdbcpostgresql-adapter'
+  end
 end
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -9,23 +9,6 @@ def config
 end
 
 namespace :db do
-  require 'active_record'
-  desc 'Migrate the database through scripts in test/db/migrate.'
-  task :migrate => :environment do
-    version = ENV['VERSION'] ? ENV['VERSION'].to_i : nil
-    ActiveRecord::Migrator.migrate('test/db/migrate', version)
-  end
-
-  task :environment do
-    require 'logger'
-    ActiveRecord::Base.logger = Logger.new(STDOUT)
-    ActiveRecord::Base.configurations = config
-    # Establish a database connection
-    db_name = ENV['DB'] || 'sqlite'
-    ActiveRecord::Base.establish_connection(db_name)
-    ActiveRecord::Base.default_timezone = :utc
-  end
-
   task :create do
     if ACCEPTED_DB_VALUES.include? ENV['DB']
       Rake::Task["db:#{ENV['DB']}:create"].invoke
@@ -38,7 +21,7 @@ namespace :db do
     end
   end
 
-  task :reset => [:drop, :create, :migrate]
+  task :reset => [:drop, :create]
 
   namespace :mysql do
     desc 'Create the MySQL test databases'

--- a/Rakefile
+++ b/Rakefile
@@ -48,8 +48,7 @@ namespace :db do
 
     desc 'Drop the MySQL test databases'
     task :drop do
-      %x( mysqladmin --user=#{config['arunit']['username']} -f drop #{config['arunit']['database']} )
-      %x( mysqladmin --user=#{config['arunit2']['username']} -f drop #{config['arunit2']['database']} )
+      `mysqladmin --user=#{config['mysql']['username']} -f drop #{config['mysql']['database']}`
     end
   end
 
@@ -63,6 +62,11 @@ namespace :db do
     task :drop do
       `dropdb #{config['postgres']['database']}`
     end
+  end
+
+  namespace :sqlite do
+    task :drop
+    task :create
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,75 @@
 require 'bundler'
 Bundler::GemHelper.install_tasks
 
+ACCEPTED_DB_VALUES = %w(sqlite postgres mysql)
+DATABASE_CONFIG_FILE = 'test/database.yml'
+
+def config
+  YAML.load(File.open(DATABASE_CONFIG_FILE))
+end
+
+namespace :db do
+  require 'active_record'
+  desc 'Migrate the database through scripts in test/db/migrate.'
+  task :migrate => :environment do
+    version = ENV['VERSION'] ? ENV['VERSION'].to_i : nil
+    ActiveRecord::Migrator.migrate('test/db/migrate', version)
+  end
+
+  task :environment do
+    require 'logger'
+    ActiveRecord::Base.logger = Logger.new(STDOUT)
+    ActiveRecord::Base.configurations = config
+    # Establish a database connection
+    db_name = ENV['DB'] || 'sqlite'
+    ActiveRecord::Base.establish_connection(db_name)
+    ActiveRecord::Base.default_timezone = :utc
+  end
+
+  task :create do
+    if ACCEPTED_DB_VALUES.include? ENV['DB']
+      Rake::Task["db:#{ENV['DB']}:create"].invoke
+    end
+  end
+
+  task :drop do
+    if ACCEPTED_DB_VALUES.include? ENV['DB']
+      Rake::Task["db:#{ENV['DB']}:drop"].invoke
+    end
+  end
+
+  task :reset => [:drop, :create, :migrate]
+
+  namespace :mysql do
+    desc 'Create the MySQL test databases'
+    task :create do
+      `mysql --user=#{config['mysql']['username']} -e "create DATABASE #{config['mysql']['database']} DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci "`
+    end
+
+    desc 'Drop the MySQL test databases'
+    task :drop do
+      %x( mysqladmin --user=#{config['arunit']['username']} -f drop #{config['arunit']['database']} )
+      %x( mysqladmin --user=#{config['arunit2']['username']} -f drop #{config['arunit2']['database']} )
+    end
+  end
+
+  namespace :postgres do
+    desc 'Create the PostgreSQL test databases'
+    task :create do
+      `createdb -E UTF8 -T template0 #{config['postgres']['database']}`
+    end
+
+    desc 'Drop the PostgreSQL test databases'
+    task :drop do
+      `dropdb #{config['postgres']['database']}`
+    end
+  end
+end
+
 require 'rake/testtask'
+desc "Use DB to test with #{ACCEPTED_DB_VALUES}, otherwise test standalone"
 Rake::TestTask.new(:test) do |test|
+  Rake::Task['db:reset'].invoke if ACCEPTED_DB_VALUES.include? ENV['DB']
   test.libs << 'lib' << 'test'
   test.pattern = 'test/unit/**/*_test.rb'
   test.verbose = true

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,7 @@ ACCEPTED_DB_VALUES = %w(sqlite postgres mysql)
 DATABASE_CONFIG_FILE = 'test/database.yml'
 
 def config
+  require 'yaml'
   YAML.load(File.open(DATABASE_CONFIG_FILE))
 end
 

--- a/gemfiles/Gemfile.ruby1.9.3
+++ b/gemfiles/Gemfile.ruby1.9.3
@@ -13,6 +13,7 @@ group :development, :test do
 
   # i18n gem >=0.7.0 does not work with Ruby 1.9.2
   gem 'i18n', '0.6.1'
+  gem 'test-unit' # needed for Ruby >=2.2.0
 
   gem 'debugger'
 

--- a/gemfiles/Gemfile.ruby1.9.3
+++ b/gemfiles/Gemfile.ruby1.9.3
@@ -8,6 +8,8 @@ group :development, :test do
   gem 'rubyzip'
   gem 'rails'
   gem 'sqlite3'
+  gem 'pg'
+  gem 'mysql2'
 
   # i18n gem >=0.7.0 does not work with Ruby 1.9.2
   gem 'i18n', '0.6.1'

--- a/gemfiles/Gemfile.ruby1.9.3
+++ b/gemfiles/Gemfile.ruby1.9.3
@@ -7,6 +7,7 @@ group :development, :test do
   gem 'geoip'
   gem 'rubyzip'
   gem 'rails'
+  gem 'sqlite3'
 
   # i18n gem >=0.7.0 does not work with Ruby 1.9.2
   gem 'i18n', '0.6.1'

--- a/test/database.yml
+++ b/test/database.yml
@@ -1,7 +1,7 @@
 # test/database.yml
 sqlite:
   adapter: sqlite3
-  database: ":memory:"
+  database: "test/geocoder_test.sqlite"
   timeout: 500
 mysql:
   adapter: mysql2
@@ -11,4 +11,4 @@ mysql:
 postgres:
   adapter: postgresql
   database: geocoder_test
-  username: postgres
+  username:

--- a/test/database.yml
+++ b/test/database.yml
@@ -1,7 +1,7 @@
 # test/database.yml
 sqlite:
   adapter: sqlite3
-  database: "test/geocoder_test.sqlite"
+  database: ":memory:"
   timeout: 500
 mysql:
   adapter: mysql2

--- a/test/database.yml
+++ b/test/database.yml
@@ -1,0 +1,14 @@
+# test/database.yml
+sqlite:
+  adapter: sqlite3
+  database: ":memory:"
+  timeout: 500
+mysql:
+  adapter: mysql2
+  database: geocoder_test
+  username:
+  encoding: utf8
+postgres:
+  adapter: postgresql
+  database: geocoder_test
+  username: postgres

--- a/test/database.yml
+++ b/test/database.yml
@@ -6,7 +6,7 @@ sqlite:
 mysql:
   adapter: mysql2
   database: geocoder_test
-  username:
+  username: travis
   encoding: utf8
 postgres:
   adapter: postgresql

--- a/test/db/migrate/001_create_test_schema.rb
+++ b/test/db/migrate/001_create_test_schema.rb
@@ -1,0 +1,54 @@
+# CreateTestSchema creates the tables used in test_helper.rb
+class CreateTestSchema < ActiveRecord::Migration
+  def self.up
+    [
+      :places,
+      :place_reverse_geocodeds
+    ].each do |table|
+      create_table table do |t|
+        t.column :name, :string
+        t.column :address, :string
+        t.column :latitude, :decimal
+        t.column :longitude, :decimal
+      end
+    end
+
+    [
+      :place_with_custom_lookup_procs,
+      :place_with_custom_lookups,
+      :place_reverse_geocoded_with_custom_lookups
+    ].each do |table|
+      create_table table do |t|
+        t.column :name, :string
+        t.column :address, :string
+        t.column :latitude, :decimal
+        t.column :longitude, :decimal
+        t.column :result_class, :string
+      end
+    end
+
+    create_table :place_with_forward_and_reverse_geocodings do |t|
+      t.column :name, :string
+      t.column :location, :string
+      t.column :lat, :decimal
+      t.column :lon, :decimal
+      t.column :address, :string
+    end
+
+    create_table :place_reverse_geocoded_with_custom_results_handlings do |t|
+      t.column :name, :string
+      t.column :address, :string
+      t.column :latitude, :decimal
+      t.column :longitude, :decimal
+      t.column :country, :string
+    end
+
+    create_table :place_with_custom_results_handlings do |t|
+      t.column :name, :string
+      t.column :address, :string
+      t.column :latitude, :decimal
+      t.column :longitude, :decimal
+      t.column :coords_string, :string
+    end
+  end
+end

--- a/test/db/migrate/001_create_test_schema.rb
+++ b/test/db/migrate/001_create_test_schema.rb
@@ -8,8 +8,8 @@ class CreateTestSchema < ActiveRecord::Migration
       create_table table do |t|
         t.column :name, :string
         t.column :address, :string
-        t.column :latitude, :decimal
-        t.column :longitude, :decimal
+        t.column :latitude, :decimal, :precision => 16, :scale => 6
+        t.column :longitude, :decimal, :precision => 16, :scale => 6
       end
     end
 
@@ -21,8 +21,8 @@ class CreateTestSchema < ActiveRecord::Migration
       create_table table do |t|
         t.column :name, :string
         t.column :address, :string
-        t.column :latitude, :decimal
-        t.column :longitude, :decimal
+        t.column :latitude, :decimal, :precision => 16, :scale => 6
+        t.column :longitude, :decimal, :precision => 16, :scale => 6
         t.column :result_class, :string
       end
     end
@@ -30,24 +30,24 @@ class CreateTestSchema < ActiveRecord::Migration
     create_table :place_with_forward_and_reverse_geocodings do |t|
       t.column :name, :string
       t.column :location, :string
-      t.column :lat, :decimal
-      t.column :lon, :decimal
+      t.column :lat, :decimal, :precision => 16, :scale => 6
+      t.column :lon, :decimal, :precision => 16, :scale => 6
       t.column :address, :string
     end
 
     create_table :place_reverse_geocoded_with_custom_results_handlings do |t|
       t.column :name, :string
       t.column :address, :string
-      t.column :latitude, :decimal
-      t.column :longitude, :decimal
+      t.column :latitude, :decimal, :precision => 16, :scale => 6
+      t.column :longitude, :decimal, :precision => 16, :scale => 6
       t.column :country, :string
     end
 
     create_table :place_with_custom_results_handlings do |t|
       t.column :name, :string
       t.column :address, :string
-      t.column :latitude, :decimal
-      t.column :longitude, :decimal
+      t.column :latitude, :decimal, :precision => 16, :scale => 6
+      t.column :longitude, :decimal, :precision => 16, :scale => 6
       t.column :coords_string, :string
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,17 +4,20 @@ require 'test/unit'
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 
-if ENV['DB']
-  require 'rails'
+require 'yaml'
+configs = YAML.load_file('test/database.yml')
+
+if configs.keys.include? ENV['DB']
   require 'active_record'
 
   # Establish a database connection
-  configs = YAML.load_file('test/database.yml')
   ActiveRecord::Base.configurations = configs
 
   db_name = ENV['DB']
   ActiveRecord::Base.establish_connection(db_name)
   ActiveRecord::Base.default_timezone = :utc
+
+  ActiveRecord::Migrator.migrate('test/db/migrate', nil)
 else
   class MysqlConnection
     def adapter_name
@@ -69,10 +72,10 @@ else
       end
     end
   end
+end
 
-  # simulate Rails module so Railtie gets loaded
-  module Rails
-  end
+# simulate Rails module so Railtie gets loaded
+module Rails
 end
 
 # Require Geocoder after ActiveRecord simulator.

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,24 +1,83 @@
 require 'rubygems'
 require 'test/unit'
-require 'rails'
-require 'active_record'
-require 'factory_girl'
 
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 
+if ENV['DB']
+  require 'rails'
+  require 'active_record'
+
+  # Establish a database connection
+  configs = YAML.load_file('test/database.yml')
+  ActiveRecord::Base.configurations = configs
+
+  db_name = ENV['DB']
+  ActiveRecord::Base.establish_connection(db_name)
+  ActiveRecord::Base.default_timezone = :utc
+else
+  class MysqlConnection
+    def adapter_name
+      "mysql"
+    end
+  end
+
+  ##
+  # Simulate enough of ActiveRecord::Base that objects can be used for testing.
+  #
+  module ActiveRecord
+    class Base
+
+      def initialize
+        @attributes = {}
+      end
+
+      def read_attribute(attr_name)
+        @attributes[attr_name.to_sym]
+      end
+
+      def write_attribute(attr_name, value)
+        @attributes[attr_name.to_sym] = value
+      end
+
+      def update_attribute(attr_name, value)
+        write_attribute(attr_name.to_sym, value)
+      end
+
+      def self.scope(*args); end
+
+      def self.connection
+        MysqlConnection.new
+      end
+
+      def method_missing(name, *args, &block)
+        if name.to_s[-1..-1] == "="
+          write_attribute name.to_s[0...-1], *args
+        else
+          read_attribute name
+        end
+      end
+
+      class << self
+        def table_name
+          'test_table_name'
+        end
+
+        def primary_key
+          :id
+        end
+      end
+    end
+  end
+
+  # simulate Rails module so Railtie gets loaded
+  module Rails
+  end
+end
+
 # Require Geocoder after ActiveRecord simulator.
 require 'geocoder'
 require 'geocoder/lookups/base'
-
-# Establish a database connection
-
-configs = YAML.load_file('test/database.yml')
-ActiveRecord::Base.configurations = configs
-
-db_name = ENV['DB'] || 'sqlite'
-ActiveRecord::Base.establish_connection(db_name)
-ActiveRecord::Base.default_timezone = :utc
 
 # and initialize Railtie manually (since Rails::Railtie doesn't exist)
 Geocoder::Railtie.insert

--- a/test/unit/near_test.rb
+++ b/test/unit/near_test.rb
@@ -6,7 +6,8 @@ class NearTest < GeocoderTestCase
 
   def test_near_scope_options_without_sqlite_includes_bounding_box_condition
     result = PlaceWithCustomResultsHandling.send(:near_scope_options, 1.0, 2.0, 5)
-    assert_match(/test_table_name.latitude BETWEEN 0.9276\d* AND 1.0723\d* AND test_table_name.longitude BETWEEN 1.9276\d* AND 2.0723\d* AND /, result[:conditions][0])
+    table_name = PlaceWithCustomResultsHandling.table_name
+    assert_match(/#{table_name}.latitude BETWEEN 0.9276\d* AND 1.0723\d* AND #{table_name}.longitude BETWEEN 1.9276\d* AND 2.0723\d* AND /, result[:conditions][0])
   end
 
   def test_near_scope_options_without_sqlite_includes_radius_condition

--- a/test/unit/near_test.rb
+++ b/test/unit/near_test.rb
@@ -4,36 +4,38 @@ require 'test_helper'
 
 class NearTest < GeocoderTestCase
 
-  def test_near_scope_options_without_sqlite_includes_bounding_box_condition
-    result = PlaceWithCustomResultsHandling.send(:near_scope_options, 1.0, 2.0, 5)
-    table_name = PlaceWithCustomResultsHandling.table_name
-    assert_match(/#{table_name}.latitude BETWEEN 0.9276\d* AND 1.0723\d* AND #{table_name}.longitude BETWEEN 1.9276\d* AND 2.0723\d* AND /, result[:conditions][0])
-  end
+  if ENV['DB'] != 'sqlite'
+    def test_near_scope_options_without_sqlite_includes_bounding_box_condition
+      result = PlaceWithCustomResultsHandling.send(:near_scope_options, 1.0, 2.0, 5)
+      table_name = PlaceWithCustomResultsHandling.table_name
+      assert_match(/#{table_name}.latitude BETWEEN 0.9276\d* AND 1.0723\d* AND #{table_name}.longitude BETWEEN 1.9276\d* AND 2.0723\d* AND /, result[:conditions][0])
+    end
 
-  def test_near_scope_options_without_sqlite_includes_radius_condition
-    result = Place.send(:near_scope_options, 1.0, 2.0, 5)
-    assert_match(/BETWEEN \? AND \?$/, result[:conditions][0])
-  end
+    def test_near_scope_options_without_sqlite_includes_radius_condition
+      result = Place.send(:near_scope_options, 1.0, 2.0, 5)
+      assert_match(/BETWEEN \? AND \?$/, result[:conditions][0])
+    end
 
-  def test_near_scope_options_without_sqlite_includes_radius_default_min_radius
-    result = Place.send(:near_scope_options, 1.0, 2.0, 5)
+    def test_near_scope_options_without_sqlite_includes_radius_default_min_radius
+      result = Place.send(:near_scope_options, 1.0, 2.0, 5)
 
-    assert_equal(0, result[:conditions][1])
-    assert_equal(5, result[:conditions][2])
-  end
+      assert_equal(0, result[:conditions][1])
+      assert_equal(5, result[:conditions][2])
+    end
 
-  def test_near_scope_options_without_sqlite_includes_radius_custom_min_radius
-    result = Place.send(:near_scope_options, 1.0, 2.0, 5, :min_radius => 3)
+    def test_near_scope_options_without_sqlite_includes_radius_custom_min_radius
+      result = Place.send(:near_scope_options, 1.0, 2.0, 5, :min_radius => 3)
 
-    assert_equal(3, result[:conditions][1])
-    assert_equal(5, result[:conditions][2])
-  end
+      assert_equal(3, result[:conditions][1])
+      assert_equal(5, result[:conditions][2])
+    end
 
-  def test_near_scope_options_without_sqlite_includes_radius_bogus_min_radius
-    result = Place.send(:near_scope_options, 1.0, 2.0, 5, :min_radius => 'bogus')
+    def test_near_scope_options_without_sqlite_includes_radius_bogus_min_radius
+      result = Place.send(:near_scope_options, 1.0, 2.0, 5, :min_radius => 'bogus')
 
-    assert_equal(0, result[:conditions][1])
-    assert_equal(5, result[:conditions][2])
+      assert_equal(0, result[:conditions][1])
+      assert_equal(5, result[:conditions][2])
+    end
   end
 
   def test_near_scope_options_with_defaults

--- a/test/unit/near_test.rb
+++ b/test/unit/near_test.rb
@@ -4,38 +4,46 @@ require 'test_helper'
 
 class NearTest < GeocoderTestCase
 
-  if ENV['DB'] != 'sqlite'
-    def test_near_scope_options_without_sqlite_includes_bounding_box_condition
-      result = PlaceWithCustomResultsHandling.send(:near_scope_options, 1.0, 2.0, 5)
-      table_name = PlaceWithCustomResultsHandling.table_name
-      assert_match(/#{table_name}.latitude BETWEEN 0.9276\d* AND 1.0723\d* AND #{table_name}.longitude BETWEEN 1.9276\d* AND 2.0723\d* AND /, result[:conditions][0])
-    end
+  def test_near_scope_options_without_sqlite_includes_bounding_box_condition
+    omit("Not applicable to SQLite") if ENV['DB'] == 'sqlite'
 
-    def test_near_scope_options_without_sqlite_includes_radius_condition
-      result = Place.send(:near_scope_options, 1.0, 2.0, 5)
-      assert_match(/BETWEEN \? AND \?$/, result[:conditions][0])
-    end
+    result = PlaceWithCustomResultsHandling.send(:near_scope_options, 1.0, 2.0, 5)
+    table_name = PlaceWithCustomResultsHandling.table_name
+    assert_match(/#{table_name}.latitude BETWEEN 0.9276\d* AND 1.0723\d* AND #{table_name}.longitude BETWEEN 1.9276\d* AND 2.0723\d* AND /, result[:conditions][0])
+  end
 
-    def test_near_scope_options_without_sqlite_includes_radius_default_min_radius
-      result = Place.send(:near_scope_options, 1.0, 2.0, 5)
+  def test_near_scope_options_without_sqlite_includes_radius_condition
+    omit("Not applicable to SQLite") if ENV['DB'] == 'sqlite'
 
-      assert_equal(0, result[:conditions][1])
-      assert_equal(5, result[:conditions][2])
-    end
+    result = Place.send(:near_scope_options, 1.0, 2.0, 5)
+    assert_match(/BETWEEN \? AND \?$/, result[:conditions][0])
+  end
 
-    def test_near_scope_options_without_sqlite_includes_radius_custom_min_radius
-      result = Place.send(:near_scope_options, 1.0, 2.0, 5, :min_radius => 3)
+  def test_near_scope_options_without_sqlite_includes_radius_default_min_radius
+    omit("Not applicable to SQLite") if ENV['DB'] == 'sqlite'
 
-      assert_equal(3, result[:conditions][1])
-      assert_equal(5, result[:conditions][2])
-    end
+    result = Place.send(:near_scope_options, 1.0, 2.0, 5)
 
-    def test_near_scope_options_without_sqlite_includes_radius_bogus_min_radius
-      result = Place.send(:near_scope_options, 1.0, 2.0, 5, :min_radius => 'bogus')
+    assert_equal(0, result[:conditions][1])
+    assert_equal(5, result[:conditions][2])
+  end
 
-      assert_equal(0, result[:conditions][1])
-      assert_equal(5, result[:conditions][2])
-    end
+  def test_near_scope_options_without_sqlite_includes_radius_custom_min_radius
+    omit("Not applicable to SQLite") if ENV['DB'] == 'sqlite'
+
+    result = Place.send(:near_scope_options, 1.0, 2.0, 5, :min_radius => 3)
+
+    assert_equal(3, result[:conditions][1])
+    assert_equal(5, result[:conditions][2])
+  end
+
+  def test_near_scope_options_without_sqlite_includes_radius_bogus_min_radius
+    omit("Not applicable to SQLite") if ENV['DB'] == 'sqlite'
+    
+    result = Place.send(:near_scope_options, 1.0, 2.0, 5, :min_radius => 'bogus')
+
+    assert_equal(0, result[:conditions][1])
+    assert_equal(5, result[:conditions][2])
   end
 
   def test_near_scope_options_with_defaults


### PR DESCRIPTION
Summary:
Enabled running tests using `rake test DB=`, with options mysql, sqlite, and postgres. If DB is not set (or is nil) the tests will run as before (using mocked ActiveRecord::Base).

Also configured to run them on travis-ci