### PR TITLE
use builtin libs to validate ips

### DIFF
--- a/lib/geocoder/ip_address.rb
+++ b/lib/geocoder/ip_address.rb
@@ -1,3 +1,4 @@
+require 'resolv'
 module Geocoder
   class IpAddress < String
 
@@ -6,16 +7,7 @@ module Geocoder
     end
 
     def valid?
-      ipregex = %r{
-        \A(                                     # String Starts
-        ((::ffff:)?((\d{1,3})\.){3}\d{1,3})     # Check for IPv4
-        |                                       # .... Or
-        (\S+?(:\S+?){6}\S+)                     # Check for IPv6
-        |                                       # .... Or
-        (::1)                                   # IPv6 loopback
-        )\z                                     
-      }x
-      !!self.match(ipregex)
+      !!((self =~ Resolv::IPv4::Regex) || (self =~ Resolv::IPv6::Regex))
     end
   end
 end

--- a/test/unit/ip_address_test.rb
+++ b/test/unit/ip_address_test.rb
@@ -6,7 +6,7 @@ class IpAddressTest < GeocoderTestCase
 
   def test_valid
     assert Geocoder::IpAddress.new("232.65.123.94").valid?
-    assert Geocoder::IpAddress.new("666.65.123.94").valid? # technically invalid
+    assert !Geocoder::IpAddress.new("666.65.123.94").valid?
     assert Geocoder::IpAddress.new("::ffff:12.34.56.78").valid?
     assert Geocoder::IpAddress.new("3ffe:0b00:0000:0000:0001:0000:0000:000a").valid?
     assert Geocoder::IpAddress.new("::1").valid?


### PR DESCRIPTION
Ruby has already good Regex for checking IP addresses 
```Resolv::IPv4::Regex``` and ```Resolv::IPv6::Regex```

No need to reinvent the wheel.

666.65.123.94 - technically or not, this address is not valid