### PR TITLE
Don't include test files in the exported gem

### DIFF
--- a/geocoder.gemspec
+++ b/geocoder.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.date        = Date.today.to_s
   s.summary     = "Complete geocoding solution for Ruby."
   s.description = "Provides object geocoding (by street or IP address), reverse geocoding (coordinates to street address), distance queries for ActiveRecord and Mongoid, result caching, and more. Designed for Rails but works with Sinatra and other Rack frameworks too."
-  s.files       = Dir['CHANGELOG.md', 'LICENSE', 'README.rdoc', 'examples/**/*', 'lib/**/*', 'bin/*']
+  s.files       = Dir['CHANGELOG.md', 'LICENSE', 'README.md', 'examples/**/*', 'lib/**/*', 'bin/*']
   s.require_paths = ["lib"]
   s.executables = ["geocode"]
   s.license     = 'MIT'

--- a/geocoder.gemspec
+++ b/geocoder.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.date        = Date.today.to_s
   s.summary     = "Complete geocoding solution for Ruby."
   s.description = "Provides object geocoding (by street or IP address), reverse geocoding (coordinates to street address), distance queries for ActiveRecord and Mongoid, result caching, and more. Designed for Rails but works with Sinatra and other Rack frameworks too."
-  s.files       = `git ls-files`.split("\n") - %w[geocoder.gemspec Gemfile init.rb]
+  s.files       = Dir['CHANGELOG.md', 'LICENSE', 'README.rdoc', 'examples/**/*', 'lib/**/*', 'bin/*']
   s.require_paths = ["lib"]
   s.executables = ["geocode"]
   s.license     = 'MIT'


### PR DESCRIPTION
Will make the exported gem size smaller.

Before: 1.1M
![screen shot 2015-03-21 at 10 32 28 am](https://cloud.githubusercontent.com/assets/2117313/6765413/ce5b1852-cfb5-11e4-9388-c6b06b820fd2.png)

After: 516k
![screen shot 2015-03-21 at 10 43 12 am](https://cloud.githubusercontent.com/assets/2117313/6765444/18d433a4-cfb7-11e4-8059-22eaba365793.png)


Note: size found using `bundle list geocoder` then `du -h` on the file path it gave.  
