### PR TITLE
Testing against diff versions of rails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,20 @@ rvm:
 gemfile:
   - Gemfile
   - gemfiles/Gemfile.ruby1.9.3
+  - gemfiles/Gemfile.rails3.2
+  - gemfiles/Gemfile.rails4.1
 matrix:
   exclude:
     - rvm: 1.9.3
       gemfile: Gemfile
+    - rvm: 1.9.3
+      gemfile: gemfiles/Gemfile.rails3.2
+    - rvm: 1.9.3
+      gemfile: gemfiles/Gemfile.rails4.1
+    - env: DB=
+      gemfile: gemfiles/Gemfile.rails3.2
+    - env: DB=
+      gemfile: gemfiles/Gemfile.rails4.1
     - rvm: 2.0.0
       gemfile: gemfiles/Gemfile.ruby1.9.3
     - rvm: 2.1.2

--- a/gemfiles/Gemfile.rails3.2
+++ b/gemfiles/Gemfile.rails3.2
@@ -1,0 +1,38 @@
+source "https://rubygems.org"
+
+group :development, :test do
+  gem 'rake'
+  gem 'mongoid', '2.6.0'
+  gem 'bson_ext', platforms: :ruby
+  gem 'geoip'
+  gem 'rubyzip'
+  gem 'rails', '>= 3.2'
+  gem 'test-unit' # needed for Ruby >=2.2.0
+
+  gem 'byebug', platforms: :mri
+
+  platforms :jruby do
+    gem 'jruby-openssl'
+    gem 'jgeoip'
+  end
+
+  platforms :rbx do
+    gem 'rubysl', '~> 2.0'
+    gem 'rubysl-test-unit'
+  end
+end
+
+group :test do
+  gem 'sqlite3', :platform => [:ruby, :mswin, :mingw]
+
+  platforms :ruby do
+    gem 'pg'
+    gem 'mysql2'
+  end
+
+  platforms :jruby do
+    gem 'jdbc-mysql'
+    gem 'jdbc-sqlite3'
+    gem 'activerecord-jdbcpostgresql-adapter'
+  end
+end

--- a/gemfiles/Gemfile.rails4.1
+++ b/gemfiles/Gemfile.rails4.1
@@ -1,0 +1,38 @@
+source "https://rubygems.org"
+
+group :development, :test do
+  gem 'rake'
+  gem 'mongoid', '4.0.2'
+  gem 'bson_ext', platforms: :ruby
+  gem 'geoip'
+  gem 'rubyzip'
+  gem 'rails', '>= 4.1'
+  gem 'test-unit' # needed for Ruby >=2.2.0
+
+  gem 'byebug', platforms: :mri
+
+  platforms :jruby do
+    gem 'jruby-openssl'
+    gem 'jgeoip'
+  end
+
+  platforms :rbx do
+    gem 'rubysl', '~> 2.0'
+    gem 'rubysl-test-unit'
+  end
+end
+
+group :test do
+  gem 'sqlite3', :platform => [:ruby, :mswin, :mingw]
+
+  platforms :ruby do
+    gem 'pg'
+    gem 'mysql2'
+  end
+
+  platforms :jruby do
+    gem 'jdbc-mysql'
+    gem 'jdbc-sqlite3'
+    gem 'activerecord-jdbcpostgresql-adapter'
+  end
+end

--- a/test/unit/logger_test.rb
+++ b/test/unit/logger_test.rb
@@ -18,7 +18,7 @@ class LoggerTest < GeocoderTestCase
 
   def test_set_logger_logs
     assert_equal nil, Geocoder.log(:warn, "should log")
-    assert_equal "should log\n", @tempfile.read
+    assert_match /should log\n$/, @tempfile.read
   end
 
   def test_set_logger_does_not_log_severity_too_low

--- a/test/unit/mongoid_test.rb
+++ b/test/unit/mongoid_test.rb
@@ -33,7 +33,11 @@ class MongoidTest < GeocoderTestCase
   end
 
   def test_index_is_skipped_if_skip_option_flag
-    result = PlaceUsingMongoidWithoutIndex.index_options.keys.flatten[0] == :coordinates
+    if PlaceUsingMongoidWithoutIndex.respond_to?(:index_options)
+      result = PlaceUsingMongoidWithoutIndex.index_options.keys.flatten[0] == :coordinates
+    else
+      result = PlaceUsingMongoidWithoutIndex.index_specifications[0] == :coordinates
+    end
     assert !result
   end
 


### PR DESCRIPTION
Work in Progress
-------------------------
Connected to #813 

There are very few test failures so far with rails 4.1 gemfile.

The mongoid one is due to:
```
#3037 Model indexes are no longer stored in an index_options hash on the model class. Instead, an array named index_specifications now exists on the class which contains a list of Indexable::Specification objects. This is so we could properly handle the case of indexes with the same keys but different order.
```
Non-backward compatible change in Mongoid 4.0. I think this is only in our test case that `index_options` is used.  