### PR TITLE
Stop :baidu and :baidu_ip trying to use SSL

### DIFF
--- a/lib/geocoder/lookups/baidu.rb
+++ b/lib/geocoder/lookups/baidu.rb
@@ -18,6 +18,11 @@ module Geocoder::Lookup
 
     private # ---------------------------------------------------------------
 
+    # http only
+    def use_ssl?
+      false
+    end
+
     def results(query, reverse = false)
       return [] unless doc = fetch_data(query)
       case doc['status']
@@ -52,4 +57,3 @@ module Geocoder::Lookup
 
   end
 end
-

--- a/lib/geocoder/lookups/baidu_ip.rb
+++ b/lib/geocoder/lookups/baidu_ip.rb
@@ -18,6 +18,11 @@ module Geocoder::Lookup
 
     private # ---------------------------------------------------------------
 
+    # http only
+    def use_ssl?
+      false
+    end
+
     def results(query, reverse = false)
       return [] unless doc = fetch_data(query)
       case doc['status']

--- a/test/integration/http_client_test.rb
+++ b/test/integration/http_client_test.rb
@@ -22,9 +22,21 @@ class HttpClientTest < Test::Unit::TestCase
     assert_not_nil results.first
   end
 
-  def test_ssl_opt_out
+  def test_ssl_unavaible_telize
     Geocoder.configure(ip_lookup: :telize, use_https: true)
     results = Geocoder.search "74.200.247.59"
+    assert_not_nil results.first
+  end
+
+  def test_ssl_unavaible_baidu_ip
+    Geocoder.configure(ip_lookup: :baidu_ip, use_https: true, api_key: @api_keys["baidu_ip"])
+    results = Geocoder.search "74.200.247.59"
+    assert_not_nil results.first
+  end
+
+  def test_ssl_unavaible_baidu
+    Geocoder.configure(lookup: :baidu, use_https: true, api_key: @api_keys["baidu"])
+    results = Geocoder.search "27701"
     assert_not_nil results.first
   end
 end


### PR DESCRIPTION
The URL is fixed to http, so if `configuration.use_https?` is set to `true` it breaks.

This implements the same `hack` as `telize` uses.

Namely

``` ruby
# http only
def use_ssl?
  false
end
```