### PR TITLE
`lookup.supported_protocols`

### DIFF
--- a/lib/geocoder/lookups/baidu.rb
+++ b/lib/geocoder/lookups/baidu.rb
@@ -16,6 +16,11 @@ module Geocoder::Lookup
       "http://api.map.baidu.com/geocoder/v2/?" + url_query_string(query)
     end
 
+    # HTTP only
+    def supported_protocols
+      [:http]
+    end
+
     private # ---------------------------------------------------------------
 
     def results(query, reverse = false)
@@ -52,4 +57,3 @@ module Geocoder::Lookup
 
   end
 end
-

--- a/lib/geocoder/lookups/baidu_ip.rb
+++ b/lib/geocoder/lookups/baidu_ip.rb
@@ -16,6 +16,11 @@ module Geocoder::Lookup
       "http://api.map.baidu.com/location/ip?" + url_query_string(query)
     end
 
+    # HTTP only
+    def supported_protocols
+      [:http]
+    end
+
     private # ---------------------------------------------------------------
 
     def results(query, reverse = false)

--- a/lib/geocoder/lookups/base.rb
+++ b/lib/geocoder/lookups/base.rb
@@ -86,6 +86,15 @@ module Geocoder
         @cache
       end
 
+      ##
+      # Array containing the protocols supported by the api.
+      # Should be set to [:http] if only HTTP is supported
+      # or [:https] if only HTTPS is supported.
+      #
+      def supported_protocols
+        [:http, :https]
+      end
+
       private # -------------------------------------------------------------
 
       ##
@@ -279,6 +288,9 @@ module Geocoder
       end
 
       def use_ssl?
+        return true if supported_protocols == [:https]
+        return false if supported_protocols == [:http]
+
         configuration.use_https
       end
 

--- a/lib/geocoder/lookups/google_places_details.rb
+++ b/lib/geocoder/lookups/google_places_details.rb
@@ -12,8 +12,8 @@ module Geocoder
         ["key"]
       end
 
-      def use_ssl?
-        true
+      def supported_protocols
+        [:https]
       end
 
       def query_url(query)

--- a/lib/geocoder/lookups/maxmind_geoip2.rb
+++ b/lib/geocoder/lookups/maxmind_geoip2.rb
@@ -8,10 +8,10 @@ module Geocoder::Lookup
       "MaxMind GeoIP2"
     end
 
-    def use_ssl?
-      # Maxmind's GeoIP2 Precision Services only supports HTTPS,
-      # otherwise a `404 Not Found` HTTP response will be returned
-      true
+    # Maxmind's GeoIP2 Precision Services only supports HTTPS,
+    # otherwise a `404 Not Found` HTTP response will be returned
+    def supported_protocols
+      [:https]
     end
 
     def query_url(query)

--- a/lib/geocoder/lookups/smarty_streets.rb
+++ b/lib/geocoder/lookups/smarty_streets.rb
@@ -16,11 +16,12 @@ module Geocoder::Lookup
       "#{protocol}://api.smartystreets.com/#{path}?#{url_query_string(query)}"
     end
 
-    private # ---------------------------------------------------------------
-
-    def protocol
-      "https" # required by API as of 26 March 2015
+    # required by API as of 26 March 2015
+    def supported_protocols
+      [:https]
     end
+
+    private # ---------------------------------------------------------------
 
     def zipcode_only?(query)
       !query.text.is_a?(Array) and query.to_s.strip =~ /\A\d{5}(-\d{4})?\Z/

--- a/lib/geocoder/lookups/telize.rb
+++ b/lib/geocoder/lookups/telize.rb
@@ -9,15 +9,15 @@ module Geocoder::Lookup
     end
 
     def query_url(query)
-      #currently doesn't support HTTPS
       "http://www.telize.com/geoip/#{query.sanitized_text}"
     end
 
-    private # ---------------------------------------------------------------
-
-    def use_ssl?
-      false
+    # currently doesn't support HTTPS
+    def supported_protocols
+      [:http]
     end
+
+    private # ---------------------------------------------------------------
 
     def results(query)
       # don't look up a loopback address, just return the stored result


### PR DESCRIPTION
A single function to override on a `Lookup` class
that makes it clear which lookups support which protocols.

This is an alternative fix for
https://github.com/alexreisner/geocoder/pull/863