### PR TITLE
Fix yandex geocoder redirect to https

### DIFF
--- a/lib/geocoder/lookups/yandex.rb
+++ b/lib/geocoder/lookups/yandex.rb
@@ -15,6 +15,10 @@ module Geocoder::Lookup
     def query_url(query)
       "#{protocol}://geocode-maps.yandex.ru/1.x/?" + url_query_string(query)
     end
+    
+    def supported_protocols
+      [:https]
+    end
 
     private # ---------------------------------------------------------------
 


### PR DESCRIPTION
I added supported_protocols method with https only.