### PR TITLE
Safer timeouts

### DIFF
--- a/lib/geocoder/exceptions.rb
+++ b/lib/geocoder/exceptions.rb
@@ -29,4 +29,7 @@ module Geocoder
   class ServiceUnavailable < Error
   end
 
+  class LookupTimeout < ::Timeout::Error
+  end
+
 end

--- a/lib/geocoder/lookups/base.rb
+++ b/lib/geocoder/lookups/base.rb
@@ -263,18 +263,16 @@ module Geocoder
       # return the response object.
       #
       def make_api_request(query)
-        timeout(configuration.timeout) do
-          uri = URI.parse(query_url(query))
-          http_client.start(uri.host, uri.port, use_ssl: use_ssl?) do |client|
-            req = Net::HTTP::Get.new(uri.request_uri, configuration.http_headers)
-            if configuration.basic_auth[:user] and configuration.basic_auth[:password]
-              req.basic_auth(
-                configuration.basic_auth[:user],
-                configuration.basic_auth[:password]
-              )
-            end
-            client.request(req)
+        uri = URI.parse(query_url(query))
+        http_client.start(uri.host, uri.port, use_ssl: use_ssl?, open_timeout: configuration.timeout, read_timeout: configuration.timeout) do |client|
+          req = Net::HTTP::Get.new(uri.request_uri, configuration.http_headers)
+          if configuration.basic_auth[:user] and configuration.basic_auth[:password]
+            req.basic_auth(
+              configuration.basic_auth[:user],
+              configuration.basic_auth[:password]
+            )
           end
+          client.request(req)
         end
       end
 

--- a/lib/geocoder/lookups/base.rb
+++ b/lib/geocoder/lookups/base.rb
@@ -274,6 +274,8 @@ module Geocoder
           end
           client.request(req)
         end
+      rescue Net::OpenTimeout, Net::ReadTimeout
+        raise Geocoder::LookupTimeout
       end
 
       def use_ssl?


### PR DESCRIPTION
Hi, thanks for the awesome work on this gem!

Ruby's timeout API is [inherently unsafe](http://www.mikeperham.com/2015/05/08/timeout-rubys-most-dangerous-api/). This PR replaces it with a safe method.

Open timeouts raise `Net::OpenTimeout` and read timeouts raise `Net::ReadTimeout`.  Both inherit from `Timeout::Error` (which is also defined as `TimeoutError`), so this should be a safe change, but we could always catch and re-raise a `Timeout::Error` you think that's better.

Let me know your thoughts. Thanks!