### PR TITLE
Never default to Puts for all debug messages

### DIFF
--- a/lib/geocoder/logger.rb
+++ b/lib/geocoder/logger.rb
@@ -37,8 +37,8 @@ module Geocoder
 
     def kernel_log(level, message)
       case level
-      when :debug, :info
-        puts message
+      # when :debug, :info
+      #  puts message
       when :warn
         warn message
       when :error


### PR DESCRIPTION
This creates a mess of all terminal output. This should not be the default behavior.