### PR TITLE
Fix #906 - Use different memoization variables for request

### DIFF
--- a/lib/geocoder/request.rb
+++ b/lib/geocoder/request.rb
@@ -17,7 +17,7 @@ module Geocoder
     #   corresponding to the original client IP for any request sent
     #   through a non-whitelisted proxy.
     def safe_location
-      @location ||= Geocoder.search(ip, ip_address: true).first
+      @safe_location ||= Geocoder.search(ip, ip_address: true).first
     end
 
     # There's a whole zoo of nonstandard headers added by various

--- a/test/unit/request_test.rb
+++ b/test/unit/request_test.rb
@@ -56,4 +56,14 @@ class RequestTest < GeocoderTestCase
     req = MockRequest.new({"HTTP_X_FORWARDED_FOR" => "Albequerque NM"})
     assert req.location.is_a?(Geocoder::Result::Freegeoip)
   end
+  def test_safe_location_after_location
+    req = MockRequest.new({"HTTP_X_REAL_IP" => "74.200.247.59"}, "127.0.0.1")
+    assert_equal 'US', req.location.country_code
+    assert_equal 'RD', req.safe_location.country_code
+  end
+  def test_location_after_safe_location
+    req = MockRequest.new({'HTTP_X_REAL_IP' => '74.200.247.59'}, '127.0.0.1')
+    assert_equal 'RD', req.safe_location.country_code
+    assert_equal 'US', req.location.country_code
+  end
 end


### PR DESCRIPTION
See #906 safe_location and location should not rely on the same variable,
otherwise calling one before the other will yield unexpected results
and could even cause a security risk if location is called before
safe_location