### PR TITLE
Always validate an IP address

### DIFF
--- a/lib/geocoder/query.rb
+++ b/lib/geocoder/query.rb
@@ -32,7 +32,7 @@ module Geocoder
     # appropriate to the Query text.
     #
     def lookup
-      if !options[:street_address] and (options[:ip_address] or ip_address?)
+      if !options[:street_address] and ip_address?
         name = options[:ip_lookup] || Configuration.ip_lookup || Geocoder::Lookup.ip_services.first
       else
         name = options[:lookup] || Configuration.lookup || Geocoder::Lookup.street_services.first


### PR DESCRIPTION
Calls to `Geocoder::Request#location` don't check if the IP address is valid because the option `ip_address` is true. In either case, whether the `ip_address` option is true or not, if we're doing a lookup by IP, it should still be validated.