### PR TITLE
Emphasize form of coordinates in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Every `Geocoder::Result` object, `result`, provides the following data:
 
 * `result.latitude` - float
 * `result.longitude` - float
-* `result.coordinates` - array of the above two
+* `result.coordinates` - array of the above two in the form of `[lat,lon]`
 * `result.address` - string
 * `result.city` - string
 * `result.state` - string


### PR DESCRIPTION
Looking through the README, the only mention of the format of `coordinates` was under the MongoDB section which is all the way at the bottom of the file.