### PR TITLE
Pass in dir variable when retreiving data files in Maxmind insert task

### DIFF
--- a/lib/maxmind_database.rb
+++ b/lib/maxmind_database.rb
@@ -21,7 +21,7 @@ module Geocoder
     end
 
     def insert(package, dir = "tmp")
-      data_files(package).each do |filepath,table|
+      data_files(package, dir).each do |filepath,table|
         print "Resetting table #{table}..."
         ActiveRecord::Base.connection.execute("DELETE FROM #{table}")
         puts "done"


### PR DESCRIPTION
Can't use a custom-located CSV when importing the maxmind DB.  This is an issue for Heroku users.