### PR TITLE
Add county accessor for map quest results

### DIFF
--- a/lib/geocoder/results/mapquest.rb
+++ b/lib/geocoder/results/mapquest.rb
@@ -26,6 +26,10 @@ module Geocoder::Result
       @data['adminArea3']
     end
 
+    def county
+      @data['adminArea4']
+    end
+
     alias_method :state_code, :state
 
     #FIXME: these might not be right, unclear with MQ documentation


### PR DESCRIPTION
Trivial change to expose the County in the mapquests results. 

Test cases run and I've tested the gem in my own application.