### PR TITLE
Replace timeout exception so its compatible with Ruby 1.9.3 too.

### DIFF
--- a/lib/geocoder/lookups/base.rb
+++ b/lib/geocoder/lookups/base.rb
@@ -283,7 +283,7 @@ module Geocoder
           end
           client.request(req)
         end
-      rescue Net::OpenTimeout, Net::ReadTimeout
+      rescue Timeout::Error
         raise Geocoder::LookupTimeout
       end
 


### PR DESCRIPTION
Hi, I haven't done many PR so hopefully I did this one right.

I was testing the latest version of geocoder on my rails project on ruby 1.9.3 and I ran into this error:
```
>> result = Geocoder.search("192.0.180.56", lookup: :geocoder_ca, timeout: 60)
NameError: uninitialized constant Net::OpenTimeout
        from /home/user/.rvm/gems/ruby-1.9.3-p484/gems/geocoder-1.2.11/lib/geocoder/lookups/base.rb:286:in `rescue in make_api_request'
...
 ```

This line was trying to rescue Net::OpenTimeout and Net::ReadTimeout which were introduced in July by 8b76c4520e05403b2b4dd7cfca07929ca7d77e8a. [Net::OpenTimeout](http://yard.ruby-doc.org/stdlib-2.0/Net/OpenTimeout.html) and [Net::ReadTimeout](http://yard.ruby-doc.org/stdlib-2.0/Net/ReadTimeout.html) seems to have been introduced in Ruby 2.0 but both are a subclass of Timeout::Error, which exists in Ruby 1.9.3. 

I think by replacing both those exceptions with Timeout::Error will make this work in all the rubies you mentionned in README.md file.

PS: I had trouble to test this change under 1.9.3 since running "bundle" tried to install `byebug` which is ruby 2.x only and one of the test file was using `assert_false` which does not exists in my Ruby 1.9.3. I will create other PRs for that.