### PR TITLE
byebug gem is only possible with Ruby 2.0+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,9 @@ group :development, :test do
   gem 'rails'
   gem 'test-unit' # needed for Ruby >=2.2.0
 
-  gem 'byebug', platforms: :mri
+  if RUBY_VERSION >= ?2
+    gem 'byebug', platforms: :mri
+  end
 
   platforms :jruby do
     gem 'jruby-openssl'


### PR DESCRIPTION
When running `bundle` under ruby 1.9.3, I got this error:

```
Gem::InstallError: byebug requires Ruby version >= 2.0.0.
An error occurred while installing byebug (6.0.2), and Bundler cannot continue.
Make sure that `gem install byebug -v '6.0.2'` succeeds before bundling.
```

Since your README.md mentions your desire to make your gem compatible with ruby 1.9.3, then wouldn't it stand to reason to make sure this is testable using 1.9.3? If so, it should not install byebug when using bundle under 1.9.3, right?

This PR is only installed byebug when ruby is 2.0 or more. I'm not sure if it's the best way to do it. Any better ways to do this?

Thanks.