### PR TITLE
Update hash syntax

### DIFF
--- a/lib/generators/geocoder/config/templates/initializer.rb
+++ b/lib/generators/geocoder/config/templates/initializer.rb
@@ -1,21 +1,21 @@
 Geocoder.configure(
-  # geocoding options
-  # :timeout      => 3,           # geocoding service timeout (secs)
-  # :lookup       => :google,     # name of geocoding service (symbol)
-  # :language     => :en,         # ISO-639 language code
-  # :use_https    => false,       # use HTTPS for lookup requests? (if supported)
-  # :http_proxy   => nil,         # HTTP proxy server (user:pass@host:port)
-  # :https_proxy  => nil,         # HTTPS proxy server (user:pass@host:port)
-  # :api_key      => nil,         # API key for geocoding service
-  # :cache        => nil,         # cache object (must respond to #[], #[]=, and #keys)
-  # :cache_prefix => "geocoder:", # prefix (string) to use for all cache keys
+  # Geocoding options
+  # timeout: 3,                 # geocoding service timeout (secs)
+  # lookup: :google,            # name of geocoding service (symbol)
+  # language: :en,              # ISO-639 language code
+  # use_https: false,           # use HTTPS for lookup requests? (if supported)
+  # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)
+  # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
+  # api_key: nil,               # API key for geocoding service
+  # cache: nil,                 # cache object (must respond to #[], #[]=, and #keys)
+  # cache_prefix: 'geocoder:',  # prefix (string) to use for all cache keys
 
-  # exceptions that should not be rescued by default
+  # Exceptions that should not be rescued by default
   # (if you want to implement custom error handling);
   # supports SocketError and TimeoutError
-  # :always_raise => [],
+  # always_raise: [],
 
-  # calculation options
-  # :units     => :mi,       # :km for kilometers or :mi for miles
-  # :distances => :linear    # :spherical or :linear
+  # Calculation options
+  # units: :mi,                 # :km for kilometers or :mi for miles
+  # distances: :linear          # :spherical or :linear
 )


### PR DESCRIPTION
Move away from generating a `geocoder.rb` initializer with old school ruby hash syntax in favor of the new/current style.