### PR TITLE
Add batch reverse geocoding task

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ If you have just added geocoding to an existing application with a lot of object
 
     rake geocode:all CLASS=YourModel
 
+If you need reverse geocoding instead, call the task with REVERSE=true:
+
+    rake geocode:all CLASS=YourModel REVERSE=true
+
 Geocoder will print warnings if you exceed the rate limit for your geocoding service. Some services — Google notably — enforce a per-second limit in addition to a per-day limit. To avoid exceeding the per-second limit, you can add a `SLEEP` option to pause between requests for a given amount of time. You can also load objects in batches to save memory, for example:
 
     rake geocode:all CLASS=YourModel SLEEP=0.25 BATCH=100

--- a/lib/geocoder/stores/active_record.rb
+++ b/lib/geocoder/stores/active_record.rb
@@ -28,6 +28,11 @@ module Geocoder::Store
             "OR #{table_name}.#{geocoder_options[:longitude]} IS NULL")
         }
 
+        # scope: not-reverse geocoded objects
+        scope :not_reverse_geocoded, lambda {
+          where("#{table_name}.#{geocoder_options[:fetched_address]} IS NULL")
+        }
+
         ##
         # Find all objects within a radius of the given location.
         # Location may be either a string to geocode or an array of

--- a/lib/tasks/geocoder.rake
+++ b/lib/tasks/geocoder.rake
@@ -4,13 +4,22 @@ namespace :geocode do
     class_name = ENV['CLASS'] || ENV['class']
     sleep_timer = ENV['SLEEP'] || ENV['sleep']
     batch = ENV['BATCH'] || ENV['batch']
+    reverse = ENV['REVERSE'] || ENV['reverse']
     raise "Please specify a CLASS (model)" unless class_name
     klass = class_from_string(class_name)
     batch = batch.to_i unless batch.nil?
+    reverse = false unless reverse.to_s.downcase == 'true'
 
-    klass.not_geocoded.find_each(batch_size: batch) do |obj|
-      obj.geocode; obj.save
-      sleep(sleep_timer.to_f) unless sleep_timer.nil?
+    if reverse
+      klass.not_reverse_geocoded.find_each(batch_size: batch) do |obj|
+        obj.reverse_geocode; obj.save
+        sleep(sleep_timer.to_f) unless sleep_timer.nil?
+      end
+    else
+      klass.not_geocoded.find_each(batch_size: batch) do |obj|
+        obj.geocode; obj.save
+        sleep(sleep_timer.to_f) unless sleep_timer.nil?
+      end
     end
   end
 end


### PR DESCRIPTION
Added a batch reverse geocoding task; works just like the batch geocoding one but checks for null `address` rather than lat and lon.