### PR TITLE
Update Telize lookup to use new API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -673,14 +673,15 @@ This uses the PostcodeAnywhere UK Geocode service, this will geocode any string 
 
 #### Telize (`:telize`)
 
-* **API key**: none
-* **Quota**: none
+* **API key**: required
+* **Quota**: 1,000/day for $7/mo through 100,000/day for $100/mo
 * **Region**: world
-* **SSL support**: no
+* **SSL support**: yes
 * **Languages**: English
-* **Documentation**: http://www.telize.com/
+* **Documentation**: https://market.mashape.com/fcambus/telize
 * **Terms of Service**: ?
 * **Limitations**: ?
+* **Notes**: To use Telize set `Geocoder.configure(:ip_lookup => :telize, :api_key => "your_api_key")`.
 
 #### MaxMind Legacy Web Services (`:maxmind`)
 

--- a/lib/geocoder/lookups/telize.rb
+++ b/lib/geocoder/lookups/telize.rb
@@ -8,13 +8,16 @@ module Geocoder::Lookup
       "Telize"
     end
 
-    def query_url(query)
-      "#{protocol}://www.telize.com/geoip/#{query.sanitized_text}"
+    def required_api_key_parts
+      ["key"]
     end
 
-    # currently doesn't support HTTPS
+    def query_url(query)
+      "#{protocol}://telize-v1.p.mashape.com/geoip/#{query.sanitized_text}?mashape-key=#{api_key}"
+    end
+
     def supported_protocols
-      [:http]
+      [:https]
     end
 
     private # ---------------------------------------------------------------
@@ -35,6 +38,10 @@ module Geocoder::Lookup
 
     def reserved_result(ip)
       {"message" => "Input string is not a valid IP address", "code" => 401}
+    end
+
+    def api_key
+      configuration.api_key
     end
   end
 end

--- a/test/unit/lookup_test.rb
+++ b/test/unit/lookup_test.rb
@@ -138,6 +138,12 @@ class LookupTest < GeocoderTestCase
     assert_match "showpostal=1", g.query_url(Geocoder::Query.new("Madison Square Garden, New York, NY  10001, United States"))
   end
 
+  def test_telize_api_key
+    Geocoder.configure(:api_key => "MY_KEY")
+    g = Geocoder::Lookup::Telize.new
+    assert_match "mashape-key=MY_KEY", g.query_url(Geocoder::Query.new("232.65.123.94"))
+  end
+
   def test_raises_configuration_error_on_missing_key
     [:bing, :baidu].each do |l|
       assert_raises Geocoder::ConfigurationError do

--- a/test/unit/lookups/telize_test.rb
+++ b/test/unit/lookups/telize_test.rb
@@ -26,10 +26,4 @@ class TelizeTest < GeocoderTestCase
     results = Geocoder.search("555.555.555.555", ip_address: true)
     assert_equal 0, results.length
   end
-
-  def test_uses_http_even_if_use_https_true
-    Geocoder.configure(use_https: true)
-    result = Geocoder.search("74.200.247.59").first
-    assert result.is_a?(Geocoder::Result::Telize)
-  end
 end


### PR DESCRIPTION
The Telize API has changed:

1) Moved to Mashape, different URL
2) Now requires an API key
3) Now uses HTTPS

More info: http://www.telize.com/
