### PR TITLE
Create a GeoIP2 object for reuse

### DIFF
--- a/lib/geocoder/lookups/geoip2.rb
+++ b/lib/geocoder/lookups/geoip2.rb
@@ -14,10 +14,12 @@ module Geocoder
           end
 
           if @gem_name == 'hive_geoip2'
-            @mmdb = Hive::GeoIP2.new(configuration[:file].to_s)
+            klass = Hive::GeoIP2
           else
-            @mmdb = MaxMindDB.new(configuration[:file].to_s)
+            klass = MaxMindDB
           end
+
+          @mmdb = klass.new(configuration[:file].to_s)
         end
         super
       end

--- a/lib/geocoder/lookups/geoip2.rb
+++ b/lib/geocoder/lookups/geoip2.rb
@@ -12,6 +12,12 @@ module Geocoder
           rescue LoadError
             raise "Could not load Maxmind DB dependency. To use the GeoIP2 lookup you must add the #{@gem_name} gem to your Gemfile or have it installed in your system."
           end
+
+          if @gem_name == 'hive_geoip2'
+            @mmdb = Hive::GeoIP2.new(configuration[:file].to_s)
+          else
+            @mmdb = MaxMindDB.new(configuration[:file].to_s)
+          end
         end
         super
       end
@@ -28,11 +34,8 @@ module Geocoder
 
       def results(query)
         return [] unless configuration[:file]
-        if @gem_name == 'hive_geoip2'
-          result = Hive::GeoIP2.lookup(query.to_s, configuration[:file].to_s)
-        else
-          result = MaxMindDB.new(configuration[:file].to_s).lookup(query.to_s)
-        end
+
+        result = @mmdb.lookup(query.to_s)
         result.nil? ? [] : [result]
       end
     end


### PR DESCRIPTION
Is there a particular reason why the GeoIP2 lookup is treated as a singleton?

On every call, you're:
- opening the MaxMind database
- doing a lookup
- closing the MaxMind database

This PR allows the caller to reuse the same database handle.

Tests seem to be happy.

![image](https://cloud.githubusercontent.com/assets/232224/11608506/7d01be5c-9b39-11e5-863e-5172dea7723c.png)
