### PR TITLE
Retrieve city when esri query returns a city POI

### DIFF
--- a/lib/geocoder/results/esri.rb
+++ b/lib/geocoder/results/esri.rb
@@ -9,7 +9,11 @@ module Geocoder::Result
     end
 
     def city
-      attributes['City']
+      if !reverse_geocode? && is_city?
+        attributes['PlaceName']
+      else
+        attributes['City']
+      end
     end
 
     def state_code
@@ -47,5 +51,8 @@ module Geocoder::Result
       @data['locations'].nil?
     end
 
+    def is_city?
+      ['City', 'State Capital', 'National Capital'].include?(attributes['Type'])
+    end
   end
 end

--- a/test/fixtures/esri_austin_tx
+++ b/test/fixtures/esri_austin_tx
@@ -1,0 +1,63 @@
+{
+ "spatialReference": {
+  "wkid": 4326,
+  "latestWkid": 4326
+ },
+ "locations": [
+  {
+   "name": "Austin, Texas, United States",
+   "extent": {
+    "xmin": -97.935057,
+    "ymin": 30.075146,
+    "xmax": -97.551057,
+    "ymax": 30.459146
+   },
+   "feature": {
+    "geometry": {
+     "x": -97.743055550999657,
+     "y": 30.267145960000448
+    },
+    "attributes": {
+     "Loc_name": "Gaz.WorldGazetteer.POI1",
+     "Score": 100,
+     "Match_addr": "Austin, Texas, United States",
+     "Addr_type": "POI",
+     "Type": "State Capital",
+     "PlaceName": "Austin",
+     "Place_addr": "",
+     "Phone": "",
+     "URL": "",
+     "Rank": "3",
+     "AddBldg": "",
+     "AddNum": "",
+     "AddNumFrom": "",
+     "AddNumTo": "",
+     "Side": "",
+     "StPreDir": "",
+     "StPreType": "",
+     "StName": "",
+     "StType": "",
+     "StDir": "",
+     "StAddr": "",
+     "Nbrhd": "",
+     "City": "",
+     "Subregion": "Travis",
+     "Region": "Texas",
+     "Postal": "",
+     "PostalExt": "",
+     "Country": "USA",
+     "LangCode": "",
+     "Distance": 0,
+     "X": -97.743056999999993,
+     "Y": 30.267146,
+     "DisplayX": -97.743056999999993,
+     "DisplayY": 30.267146,
+     "Xmin": -97.935057,
+     "Xmax": -97.551057,
+     "Ymin": 30.075146,
+     "Ymax": 30.459146
+    }
+   }
+  }
+ ]
+}

--- a/test/fixtures/esri_new_york_ny
+++ b/test/fixtures/esri_new_york_ny
@@ -1,0 +1,63 @@
+{
+ "spatialReference": {
+  "wkid": 4326,
+  "latestWkid": 4326
+ },
+ "locations": [
+  {
+   "name": "New York City, New York, United States",
+   "extent": {
+    "xmin": -74.165970999999999,
+    "ymin": 40.554268999999998,
+    "xmax": -73.845971000000006,
+    "ymax": 40.874268999999998
+   },
+   "feature": {
+    "geometry": {
+     "x": -74.005969928999662,
+     "y": 40.714269404000447
+    },
+    "attributes": {
+     "Loc_name": "Gaz.WorldGazetteer.POI1",
+     "Score": 100,
+     "Match_addr": "New York City, New York, United States",
+     "Addr_type": "POI",
+     "Type": "City",
+     "PlaceName": "New York City",
+     "Place_addr": "",
+     "Phone": "",
+     "URL": "",
+     "Rank": "2.5",
+     "AddBldg": "",
+     "AddNum": "",
+     "AddNumFrom": "",
+     "AddNumTo": "",
+     "Side": "",
+     "StPreDir": "",
+     "StPreType": "",
+     "StName": "",
+     "StType": "",
+     "StDir": "",
+     "StAddr": "",
+     "Nbrhd": "",
+     "City": "",
+     "Subregion": "New York",
+     "Region": "New York",
+     "Postal": "",
+     "PostalExt": "",
+     "Country": "USA",
+     "LangCode": "",
+     "Distance": 0,
+     "X": -74.005971000000002,
+     "Y": 40.714269000000002,
+     "DisplayX": -74.005971000000002,
+     "DisplayY": 40.714269000000002,
+     "Xmin": -74.165970999999999,
+     "Xmax": -73.845971000000006,
+     "Ymin": 40.554268999999998,
+     "Ymax": 40.874268999999998
+    }
+   }
+  }
+ ]
+}

--- a/test/fixtures/esri_washington_dc
+++ b/test/fixtures/esri_washington_dc
@@ -1,0 +1,63 @@
+{
+ "spatialReference": {
+  "wkid": 4326,
+  "latestWkid": 4326
+ },
+ "locations": [
+  {
+   "name": "Washington, D. C., District of Columbia, United States",
+   "extent": {
+    "xmin": -77.176366999999999,
+    "ymin": 38.755108,
+    "xmax": -76.896366999999998,
+    "ymax": 39.035108000000001
+   },
+   "feature": {
+    "geometry": {
+     "x": -77.036365517999627,
+     "y": 38.895107833000452
+    },
+    "attributes": {
+     "Loc_name": "Gaz.WorldGazetteer.POI1",
+     "Score": 100,
+     "Match_addr": "Washington, D. C., District of Columbia, United States",
+     "Addr_type": "POI",
+     "Type": "National Capital",
+     "PlaceName": "Washington",
+     "Place_addr": "",
+     "Phone": "",
+     "URL": "",
+     "Rank": "1.75",
+     "AddBldg": "",
+     "AddNum": "",
+     "AddNumFrom": "",
+     "AddNumTo": "",
+     "Side": "",
+     "StPreDir": "",
+     "StPreType": "",
+     "StName": "",
+     "StType": "",
+     "StDir": "",
+     "StAddr": "",
+     "Nbrhd": "",
+     "City": "",
+     "Subregion": "District of Columbia",
+     "Region": "District of Columbia",
+     "Postal": "",
+     "PostalExt": "",
+     "Country": "USA",
+     "LangCode": "",
+     "Distance": 0,
+     "X": -77.036366999999998,
+     "Y": 38.895108,
+     "DisplayX": -77.036366999999998,
+     "DisplayY": 38.895108,
+     "Xmin": -77.176366999999999,
+     "Xmax": -76.896366999999998,
+     "Ymin": 38.755108,
+     "Ymax": 39.035108000000001
+    }
+   }
+  }
+ ]
+}

--- a/test/unit/lookups/esri_test.rb
+++ b/test/unit/lookups/esri_test.rb
@@ -34,6 +34,36 @@ class EsriTest < GeocoderTestCase
     assert_equal(-73.99423889799965, result.coordinates[1])
   end
 
+  def test_results_component_when_location_type_is_national_capital
+    result = Geocoder.search("washington dc").first
+    assert_equal "Washington", result.city
+    assert_equal "District of Columbia", result.state
+    assert_equal "USA", result.country
+    assert_equal "Washington, D. C., District of Columbia, United States", result.address
+    assert_equal(38.895107833000452, result.coordinates[0])
+    assert_equal(-77.036365517999627, result.coordinates[1])
+  end
+
+  def test_results_component_when_location_type_is_state_capital
+    result = Geocoder.search("austin tx").first
+    assert_equal "Austin", result.city
+    assert_equal "Texas", result.state
+    assert_equal "USA", result.country
+    assert_equal "Austin, Texas, United States", result.address
+    assert_equal(30.267145960000448, result.coordinates[0])
+    assert_equal(-97.743055550999657, result.coordinates[1])
+  end
+
+  def test_results_component_when_location_type_is_city
+    result = Geocoder.search("new york ny").first
+    assert_equal "New York City", result.city
+    assert_equal "New York", result.state
+    assert_equal "USA", result.country
+    assert_equal "New York City, New York, United States", result.address
+    assert_equal(40.714269404000447, result.coordinates[0])
+    assert_equal(-74.005969928999662, result.coordinates[1])
+  end
+
   def test_results_component_when_reverse_geocoding
     result = Geocoder.search([45.423733, -75.676333]).first
     assert_equal "75007", result.postal_code


### PR DESCRIPTION
When querying for a city directly (e.g. Washington DC), the current esri result object returns a blank city. 

I tested a wide range of cities and determined that the city attribute is blank for esri results with the types 'City', 'State Capital', and 'National Capital'. However the PlaceName attribute contains the correct city name. I believe this is because the city itself is coming back as a POI, so there's not much point in them duplicating the city value.

This change returns the city by looking at the PlaceName attribute if the result is a city POI. I included tests with the three city location types I was able to determine. I couldn't find a list anywhere in esri's docs, but I queried for a lot of cities and only found these three types.

Let me know if you have any feedback, thanks!