### PR TITLE
Allow search params to be defined via geocoded_by/reverse_geocoded_by

### DIFF
--- a/lib/geocoder/models/active_record.rb
+++ b/lib/geocoder/models/active_record.rb
@@ -18,7 +18,8 @@ module Geocoder
           :units         => options[:units],
           :method        => options[:method],
           :lookup        => options[:lookup],
-          :language      => options[:language]
+          :language      => options[:language],
+          :params        => options[:params]
         )
       end
 
@@ -35,7 +36,8 @@ module Geocoder
           :units           => options[:units],
           :method          => options[:method],
           :lookup          => options[:lookup],
-          :language        => options[:language]
+          :language        => options[:language],
+          :params          => options[:params]
         )
       end
 

--- a/lib/geocoder/models/mongo_base.rb
+++ b/lib/geocoder/models/mongo_base.rb
@@ -19,7 +19,8 @@ module Geocoder
           :method        => options[:method],
           :skip_index    => options[:skip_index] || false,
           :lookup        => options[:lookup],
-          :language      => options[:language]
+          :language      => options[:language],
+          :params        => options[:params]
         )
       end
 
@@ -36,7 +37,8 @@ module Geocoder
           :method          => options[:method],
           :skip_index      => options[:skip_index] || false,
           :lookup          => options[:lookup],
-          :language        => options[:language]
+          :language        => options[:language],
+          :params          => options[:params]
         )
       end
 

--- a/lib/geocoder/stores/base.rb
+++ b/lib/geocoder/stores/base.rb
@@ -90,7 +90,7 @@ module Geocoder
           return
         end
 
-        query_options = [:lookup, :ip_lookup, :language].inject({}) do |hash, key|
+        query_options = [:lookup, :ip_lookup, :language, :params].inject({}) do |hash, key|
           if options.has_key?(key)
             val = options[key]
             hash[key] = val.respond_to?(:call) ? val.call(self) : val

--- a/test/unit/model_test.rb
+++ b/test/unit/model_test.rb
@@ -34,4 +34,10 @@ class ModelTest < GeocoderTestCase
     assert_equal :km,        PlaceReverseGeocoded.geocoder_options[:units]
     assert_equal :spherical, PlaceReverseGeocoded.geocoder_options[:method]
   end
+
+  def test_additional_params
+    params = {:category => 'City'}
+    Place.geocoded_by :address, :params => params
+    assert_equal params, Place.geocoder_options[:params]
+  end
 end


### PR DESCRIPTION
This PR allows :params to be specified with geocoded_by and reverse_geocoded_by. They are then passed to Geocoder.search when geocode is called on the model.

As far as I could tell, there was no way to pass `:params => {...}` to Geocoder.search unless it's called manually and I had a situation that kind of needed them. In my particular case, I need to pass `:params => {:category => 'City'}`, which is a thing ESRI supports.

Not sure if this is the right way to go about this. It would be nice to have a test that verifies the param made its way to Geocoder.search, but didn't see a good way to go about it. Let me know what you think, thanks!
