### PR TITLE
Google geocoder results - expose partial_match and place_id fields

### DIFF
--- a/lib/geocoder/results/google.rb
+++ b/lib/geocoder/results/google.rb
@@ -120,5 +120,13 @@ module Geocoder::Result
     def precision
       geometry['location_type'] if geometry
     end
+    
+    def partial_match
+      @data['partial_match']
+    end
+    
+    def place_id
+      @data['place_id']
+    end  
   end
 end


### PR DESCRIPTION
Pretty self-explanatory.  It's great you can access it via `data` but these are very useful fields to expose.