### PR TITLE
Removed 'LIMIT 1' in maxmind local lookup that prevented from using database index.

### DIFF
--- a/lib/geocoder/lookups/maxmind_local.rb
+++ b/lib/geocoder/lookups/maxmind_local.rb
@@ -36,7 +36,7 @@ module Geocoder::Lookup
         addr = IPAddr.new(query.text).to_i
         q = "SELECT l.country, l.region, l.city, l.latitude, l.longitude
           FROM maxmind_geolite_city_location l WHERE l.loc_id = (SELECT b.loc_id FROM maxmind_geolite_city_blocks b
-          WHERE b.start_ip_num <= #{addr} AND #{addr} <= b.end_ip_num LIMIT 1)"
+          WHERE b.start_ip_num <= #{addr} AND #{addr} <= b.end_ip_num)"
         format_result(q, [:country_name, :region_name, :city_name, :latitude, :longitude])
       elsif configuration[:package] == :country
         addr = IPAddr.new(query.text).to_i


### PR DESCRIPTION
Database index index_maxmind_geolite_city_blocks_on_end_ip_num_range was not used while querying the database by IP address.

Before:
```
=> EXPLAIN ANALYZE SELECT l.country, l.region, l.city, l.latitude, l.longitude FROM maxmind_geolite_city_location l WHERE l.loc_id = (SELECT b.loc_id FROM maxmind_geolite_city_blocks b WHERE b.start_ip_num <= 2467698198 AND 2467698198 <= b.end_ip_num LIMIT 1);
                                                                                    QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Index Scan using index_maxmind_geolite_city_location_on_loc_id on maxmind_geolite_city_location l  (cost=0.14..4.14 rows=1 width=31) (actual time=89.990..89.991 rows=1 loops=1)
   Index Cond: (loc_id = $0)
   InitPlan 1 (returns $0)
     ->  Limit  (cost=0.00..0.05 rows=1 width=8) (actual time=89.973..89.974 rows=1 loops=1)
           ->  Seq Scan on maxmind_geolite_city_blocks b  (cost=0.00..21887.90 rows=428712 width=8) (actual time=89.971..89.971 rows=1 loops=1)
                 Filter: ((start_ip_num <= 2467698198::bigint) AND (2467698198::bigint <= end_ip_num))
                 Rows Removed by Filter: 723655
 Total runtime: 90.015 ms
(8 rows)
```

After:
```
=> EXPLAIN ANALYZE SELECT l.country, l.region, l.city, l.latitude, l.longitude FROM maxmind_geolite_city_location l WHERE l.loc_id IN (SELECT b.loc_id FROM maxmind_geolite_city_blocks b WHERE b.start_ip_num <= 2467698198 AND 2467698198 <= b.end_ip_num);
                                                                                                QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Nested Loop  (cost=20608.41..21256.37 rows=22546 width=31) (actual time=18.846..18.856 rows=1 loops=1)
   ->  HashAggregate  (cost=20608.32..20622.06 rows=4580 width=8) (actual time=18.831..18.840 rows=1 loops=1)
         ->  Index Scan using index_maxmind_geolite_city_blocks_on_end_ip_num_range on maxmind_geolite_city_blocks b  (cost=0.09..20393.97 rows=428712 width=8) (actual time=0.010..18.824 rows=1 loops=1)
               Index Cond: ((2467698198::bigint <= end_ip_num) AND (start_ip_num <= 2467698198::bigint))
   ->  Index Scan using index_maxmind_geolite_city_location_on_loc_id on maxmind_geolite_city_location l  (cost=0.08..0.14 rows=1 width=39) (actual time=0.009..0.010 rows=1 loops=1)
         Index Cond: (loc_id = b.loc_id)
 Total runtime: 18.902 ms
(7 rows)
```
