### PR TITLE
Require only needed lookup

### DIFF
--- a/lib/geocoder/lookup.rb
+++ b/lib/geocoder/lookup.rb
@@ -1,3 +1,5 @@
+require "geocoder/lookups/test"
+
 module Geocoder
   module Lookup
     extend self
@@ -83,6 +85,8 @@ module Geocoder
     #
     def spawn(name)
       if all_services.include?(name)
+        name = name.to_s
+        require "geocoder/lookups/#{name}"
         Geocoder::Lookup.const_get(classify_name(name)).new
       else
         valids = all_services.map(&:inspect).join(", ")
@@ -98,8 +102,4 @@ module Geocoder
       filename.to_s.split("_").map{ |i| i[0...1].upcase + i[1..-1] }.join
     end
   end
-end
-
-Geocoder::Lookup.all_services.each do |name|
-  require "geocoder/lookups/#{name}"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -134,6 +134,7 @@ module Geocoder
       end
     end
 
+    require 'geocoder/lookups/bing'
     class Bing
       private
       def read_fixture(file)
@@ -147,6 +148,7 @@ module Geocoder
       end
     end
 
+    require 'geocoder/lookups/google_premier'
     class GooglePremier
       private
       def fixture_prefix
@@ -154,6 +156,7 @@ module Geocoder
       end
     end
 
+    require 'geocoder/lookups/google_places_details'
     class GooglePlacesDetails
       private
       def fixture_prefix
@@ -161,6 +164,7 @@ module Geocoder
       end
     end
 
+    require 'geocoder/lookups/dstk'
     class Dstk
       private
       def fixture_prefix
@@ -168,6 +172,7 @@ module Geocoder
       end
     end
 
+    require 'geocoder/lookups/yandex'
     class Yandex
       private
       def default_fixture_filename
@@ -175,6 +180,7 @@ module Geocoder
       end
     end
 
+    require 'geocoder/lookups/freegeoip'
     class Freegeoip
       private
       def default_fixture_filename
@@ -182,6 +188,7 @@ module Geocoder
       end
     end
 
+    require 'geocoder/lookups/geoip2'
     class Geoip2
       private
 
@@ -201,6 +208,7 @@ module Geocoder
       end
     end
 
+    require 'geocoder/lookups/telize'
     class Telize
       private
       def default_fixture_filename
@@ -208,6 +216,7 @@ module Geocoder
       end
     end
 
+    require 'geocoder/lookups/pointpin'
     class Pointpin
       private
       def default_fixture_filename
@@ -215,6 +224,7 @@ module Geocoder
       end
     end
 
+    require 'geocoder/lookups/maxmind'
     class Maxmind
       private
       def default_fixture_filename
@@ -222,6 +232,7 @@ module Geocoder
       end
     end
 
+    require 'geocoder/lookups/maxmind_geoip2'
     class MaxmindGeoip2
       private
       def default_fixture_filename
@@ -229,6 +240,7 @@ module Geocoder
       end
     end
 
+    require 'geocoder/lookups/maxmind_local'
     class MaxmindLocal
       private
 
@@ -245,6 +257,7 @@ module Geocoder
       end
     end
 
+    require 'geocoder/lookups/baidu'
     class Baidu
       private
       def default_fixture_filename
@@ -252,6 +265,7 @@ module Geocoder
       end
     end
 
+    require 'geocoder/lookups/baidu_ip'
     class BaiduIp
       private
       def default_fixture_filename
@@ -259,6 +273,7 @@ module Geocoder
       end
     end
 
+    require 'geocoder/lookups/geocodio'
     class Geocodio
       private
       def default_fixture_filename
@@ -266,6 +281,7 @@ module Geocoder
       end
     end
 
+    require 'geocoder/lookups/okf'
     class Okf
       private
       def default_fixture_filename
@@ -273,6 +289,7 @@ module Geocoder
       end
     end
 
+    require 'geocoder/lookups/postcode_anywhere_uk'
     class PostcodeAnywhereUk
       private
       def fixture_prefix


### PR DESCRIPTION
Connected to #898 

@alexreisner The reason you've required all the lookups seemed to have been for the Test lookup. So I required that by default and then required the other lookups as needed.

For the test_helper, the lookups which are monkey patched needed to be required.
An example of one which isn't required in the test_helper is `yahoo` and at minimum the lookups are all tested in LookupTest `test_search_returns_empty_array_when_no_results`.
