### PR TITLE
Add missing attribute "types" to Geocoder::Result::Test

### DIFF
--- a/lib/geocoder/results/test.rb
+++ b/lib/geocoder/results/test.rb
@@ -16,8 +16,8 @@ module Geocoder
       end
 
       %w[latitude longitude neighborhood city state state_code sub_state
-      sub_state_code province province_code postal_code country
-      country_code address street_address street_number route geometry].each do |attr|
+      sub_state_code province province_code postal_code country country_code
+      address street_address street_number route geometry types].each do |attr|
         add_result_attribute(attr)
       end
 


### PR DESCRIPTION
Add `types`.
via https://github.com/alexreisner/geocoder/pull/565#issuecomment-30743008. I want it, too.