### PR TITLE
Fix Geocoder::Calculations.endpoint comment

### DIFF
--- a/lib/geocoder/calculations.rb
+++ b/lib/geocoder/calculations.rb
@@ -263,7 +263,7 @@ module Geocoder
     end
 
     ##
-    # Given a start point, heading (in degrees), and distance provides
+    # Given a start point, heading (in degrees), and distance, provides
     # an endpoint.
     # The starting point is given in the same way that points are given to all
     # Geocoder methods that accept points as arguments. It can be:

--- a/lib/geocoder/calculations.rb
+++ b/lib/geocoder/calculations.rb
@@ -263,7 +263,7 @@ module Geocoder
     end
 
     ##
-    # Given a start point, distance, and heading (in degrees), provides
+    # Given a start point, heading (in degrees), and distance provides
     # an endpoint.
     # The starting point is given in the same way that points are given to all
     # Geocoder methods that accept points as arguments. It can be:


### PR DESCRIPTION
I just spent a few hours trying to get this function to work, then realized I had my parameters in the wrong order. I was following the order listed in the comment, rather than the actual method definition! *facepalm* Anyhow, this fixes the comment, for the next person to read it.