### PR TITLE
Suppress Geocoder API warning when no results are returned

### DIFF
--- a/test/unit/lookups/geoportail_lu_test.rb
+++ b/test/unit/lookups/geoportail_lu_test.rb
@@ -52,7 +52,7 @@ class GeoportailLuTest < GeocoderTestCase
   end
 
   def test_no_results
-    results = Geocoder.search('no results')
+    results = Geocoder.search('')
     assert_equal 0, results.length
   end
 


### PR DESCRIPTION
Took a shot at fixing this warning, hopefully I'm doing this right. The Geocoder API warning occurs in the test_no_results unit test, where no results being returned is the expected behaviour. Added a warning suppression line based on prior example.