### PR TITLE
Add viewport method to results that provide one

### DIFF
--- a/lib/geocoder/results/bing.rb
+++ b/lib/geocoder/results/bing.rb
@@ -35,6 +35,10 @@ module Geocoder::Result
       @data['address']
     end
 
+    def viewport
+      @data['bbox']
+    end
+
     def self.response_attributes
       %w[bbox name confidence entityType]
     end

--- a/lib/geocoder/results/esri.rb
+++ b/lib/geocoder/results/esri.rb
@@ -46,6 +46,14 @@ module Geocoder::Result
       [geometry["y"], geometry["x"]]
     end
 
+    def viewport
+      north = attributes['Ymax']
+      south = attributes['Ymin']
+      east = attributes['Xmax']
+      west = attributes['Xmin']
+      [south, west, north, east]
+    end
+
     private
 
     def attributes

--- a/lib/geocoder/results/google.rb
+++ b/lib/geocoder/results/google.rb
@@ -131,9 +131,9 @@ module Geocoder::Result
 
     def viewport
       viewport = geometry['viewport'] || fail
-      southwest = %w(lat lng).map { |c| viewport['southwest'][c] }
-      northeast = %w(lat lng).map { |c| viewport['northeast'][c] }
-      [southwest, northeast]
+      south, west = %w(lat lng).map { |c| viewport['southwest'][c] }
+      north, east = %w(lat lng).map { |c| viewport['northeast'][c] }
+      [south, west, north, east]
     end
   end
 end

--- a/lib/geocoder/results/google.rb
+++ b/lib/geocoder/results/google.rb
@@ -129,7 +129,7 @@ module Geocoder::Result
       @data['place_id']
     end  
 
-    def bounding_box
+    def viewport
       viewport = geometry['viewport'] || fail
       southwest = %w(lat lng).map { |c| viewport['southwest'][c] }
       northeast = %w(lat lng).map { |c| viewport['northeast'][c] }

--- a/lib/geocoder/results/google.rb
+++ b/lib/geocoder/results/google.rb
@@ -128,5 +128,12 @@ module Geocoder::Result
     def place_id
       @data['place_id']
     end  
+
+    def bounding_box
+      viewport = geometry['viewport'] || fail
+      southwest = %w(lat lng).map { |c| viewport['southwest'][c] }
+      northeast = %w(lat lng).map { |c| viewport['northeast'][c] }
+      [southwest, northeast]
+    end
   end
 end

--- a/lib/geocoder/results/here.rb
+++ b/lib/geocoder/results/here.rb
@@ -53,6 +53,19 @@ module Geocoder::Result
       address_data['Country']
     end
 
+    def bounding_box
+      map_view = data['Location']['MapView'] || fail
+      southwest = [
+        map_view['BottomRight']['Latitude'],
+        map_view['TopLeft']['Longitude']
+      ]
+      northeast = [
+        map_view['TopLeft']['Latitude'],
+        map_view['BottomRight']['Longitude']
+      ]
+      [southwest, northeast]
+    end
+
     private # ----------------------------------------------------------------
 
     def address_data

--- a/lib/geocoder/results/here.rb
+++ b/lib/geocoder/results/here.rb
@@ -53,7 +53,7 @@ module Geocoder::Result
       address_data['Country']
     end
 
-    def bounding_box
+    def viewport
       map_view = data['Location']['MapView'] || fail
       southwest = [
         map_view['BottomRight']['Latitude'],

--- a/lib/geocoder/results/here.rb
+++ b/lib/geocoder/results/here.rb
@@ -55,15 +55,11 @@ module Geocoder::Result
 
     def viewport
       map_view = data['Location']['MapView'] || fail
-      southwest = [
-        map_view['BottomRight']['Latitude'],
-        map_view['TopLeft']['Longitude']
-      ]
-      northeast = [
-        map_view['TopLeft']['Latitude'],
-        map_view['BottomRight']['Longitude']
-      ]
-      [southwest, northeast]
+      south = map_view['BottomRight']['Latitude']
+      west = map_view['TopLeft']['Longitude']
+      north = map_view['TopLeft']['Latitude']
+      east = map_view['BottomRight']['Longitude']
+      [south, west, north, east]
     end
 
     private # ----------------------------------------------------------------

--- a/lib/geocoder/results/nominatim.rb
+++ b/lib/geocoder/results/nominatim.rb
@@ -78,6 +78,11 @@ module Geocoder::Result
       @data['type']
     end
 
+    def viewport
+      south, north, west, east = @data['boundingbox'].map(&:to_f)
+      [south, west, north, east]
+    end
+
     def self.response_attributes
       %w[place_id osm_type osm_id boundingbox license
          polygonpoints display_name class type stadium]

--- a/lib/geocoder/results/opencagedata.rb
+++ b/lib/geocoder/results/opencagedata.rb
@@ -66,6 +66,14 @@ module Geocoder::Result
     def coordinates
       [@data['geometry']['lat'].to_f, @data['geometry']['lng'].to_f]
     end
+
+    def viewport
+      bounds = @data['bounds'] || fail
+      south, west = %w(lat lng).map { |i| bounds['southwest'][i] }
+      north, east = %w(lat lng).map { |i| bounds['northeast'][i] }
+      [south, west, north, east]
+    end
+
     def self.response_attributes
       %w[boundingbox license 
         formatted stadium]

--- a/lib/geocoder/results/ovi.rb
+++ b/lib/geocoder/results/ovi.rb
@@ -53,6 +53,15 @@ module Geocoder::Result
       address_data['Country']
     end
 
+    def viewport
+      map_view = data['Location']['MapView'] || fail
+      south = map_view['BottomRight']['Latitude']
+      west = map_view['TopLeft']['Longitude']
+      north = map_view['TopLeft']['Latitude']
+      east = map_view['BottomRight']['Longitude']
+      [south, west, north, east]
+    end
+
     private # ----------------------------------------------------------------
 
     def address_data

--- a/lib/geocoder/results/yahoo.rb
+++ b/lib/geocoder/results/yahoo.rb
@@ -35,6 +35,11 @@ module Geocoder::Result
       @data['hash']
     end
 
+    def viewport
+      boundingbox = @data['boundingbox'] || fail
+      %w(south west north east).map{ |i| boundingbox[i].to_f }
+    end
+
     def self.response_attributes
       %w[quality offsetlat offsetlon radius boundingbox name
         line1 line2 line3 line4 cross house street xstreet unittype unit

--- a/lib/geocoder/results/yandex.rb
+++ b/lib/geocoder/results/yandex.rb
@@ -68,6 +68,13 @@ module Geocoder::Result
       @data['GeoObject']['metaDataProperty']['GeocoderMetaData']['precision']
     end
 
+    def viewport
+      envelope = @data['GeoObject']['boundedBy']['Envelope'] || fail
+      east, north = envelope['upperCorner'].split(' ').map(&:to_f)
+      west, south = envelope['lowerCorner'].split(' ').map(&:to_f)
+      [south, west, north, east]
+    end
+
     private # ----------------------------------------------------------------
 
     def address_details

--- a/test/unit/lookups/bing_test.rb
+++ b/test/unit/lookups/bing_test.rb
@@ -21,6 +21,16 @@ class BingTest < GeocoderTestCase
     assert_equal "New York", result.city
   end
 
+  def test_result_viewport
+    result = Geocoder.search("Madison Square Garden, New York, NY").first
+    assert_equal [
+      40.744944289326668,
+      -74.002353921532631,
+      40.755675807595253,
+      -73.983625397086143
+    ], result.viewport
+  end
+
   def test_no_results
     results = Geocoder.search("no results")
     assert_equal 0, results.length

--- a/test/unit/lookups/esri_test.rb
+++ b/test/unit/lookups/esri_test.rb
@@ -84,4 +84,10 @@ class EsriTest < GeocoderTestCase
     assert_equal(48.858129997357558, result.coordinates[0])
     assert_equal(2.2956200048981574, result.coordinates[1])
   end
+
+  def test_results_viewport
+    result = Geocoder.search("Madison Square Garden, New York, NY").first
+    assert_equal [40.744050000000001, -74.000241000000003, 40.756050000000002, -73.988241000000002],
+      result.viewport
+  end
 end

--- a/test/unit/lookups/google_test.rb
+++ b/test/unit/lookups/google_test.rb
@@ -42,10 +42,10 @@ class GoogleTest < GeocoderTestCase
       result.precision
   end
 
-  def test_google_bounding_box
+  def test_google_viewport
     result = Geocoder.search("Madison Square Garden, New York, NY").first
     assert_equal [[40.7473324, -73.9965316], [40.7536276, -73.9902364]],
-      result.bounding_box
+      result.viewport
   end
 
   def test_google_query_url_contains_bounds

--- a/test/unit/lookups/google_test.rb
+++ b/test/unit/lookups/google_test.rb
@@ -44,7 +44,7 @@ class GoogleTest < GeocoderTestCase
 
   def test_google_viewport
     result = Geocoder.search("Madison Square Garden, New York, NY").first
-    assert_equal [[40.7473324, -73.9965316], [40.7536276, -73.9902364]],
+    assert_equal [40.7473324, -73.9965316, 40.7536276, -73.9902364],
       result.viewport
   end
 

--- a/test/unit/lookups/google_test.rb
+++ b/test/unit/lookups/google_test.rb
@@ -42,6 +42,12 @@ class GoogleTest < GeocoderTestCase
       result.precision
   end
 
+  def test_google_bounding_box
+    result = Geocoder.search("Madison Square Garden, New York, NY").first
+    assert_equal [[40.7473324, -73.9965316], [40.7536276, -73.9902364]],
+      result.bounding_box
+  end
+
   def test_google_query_url_contains_bounds
     lookup = Geocoder::Lookup::Google.new
     url = lookup.query_url(Geocoder::Query.new(

--- a/test/unit/lookups/here_test.rb
+++ b/test/unit/lookups/here_test.rb
@@ -9,10 +9,10 @@ class HereTest < GeocoderTestCase
     set_api_key!(:here)
   end
 
-  def test_here_bounding_box
+  def test_here_viewport
     result = Geocoder.search("Madison Square Garden, New York, NY").first
     assert_equal [[40.7493451, -73.9948616], [40.7515934, -73.9918938]],
-      result.bounding_box
+      result.viewport
   end
 
 end

--- a/test/unit/lookups/here_test.rb
+++ b/test/unit/lookups/here_test.rb
@@ -11,7 +11,7 @@ class HereTest < GeocoderTestCase
 
   def test_here_viewport
     result = Geocoder.search("Madison Square Garden, New York, NY").first
-    assert_equal [[40.7493451, -73.9948616], [40.7515934, -73.9918938]],
+    assert_equal [40.7493451, -73.9948616, 40.7515934, -73.9918938],
       result.viewport
   end
 

--- a/test/unit/lookups/here_test.rb
+++ b/test/unit/lookups/here_test.rb
@@ -1,0 +1,18 @@
+# encoding: utf-8
+$: << File.join(File.dirname(__FILE__), "..", "..")
+require 'test_helper'
+
+class HereTest < GeocoderTestCase
+
+  def setup
+    Geocoder.configure(lookup: :here)
+    set_api_key!(:here)
+  end
+
+  def test_here_bounding_box
+    result = Geocoder.search("Madison Square Garden, New York, NY").first
+    assert_equal [[40.7493451, -73.9948616], [40.7515934, -73.9918938]],
+      result.bounding_box
+  end
+
+end

--- a/test/unit/lookups/nominatim_test.rb
+++ b/test/unit/lookups/nominatim_test.rb
@@ -14,6 +14,12 @@ class NominatimTest < GeocoderTestCase
     assert_equal "Madison Square Garden, West 31st Street, Long Island City, New York City, New York, 10001, United States of America", result.address
   end
 
+  def test_result_viewport
+    result = Geocoder.search("Madison Square Garden, New York, NY").first
+    assert_equal [40.749828338623, -73.9943389892578, 40.7511596679688, -73.9926528930664],
+      result.viewport
+  end
+
   def test_host_configuration
     Geocoder.configure(nominatim: {host: "local.com"})
     query = Geocoder::Query.new("Bluffton, SC")

--- a/test/unit/lookups/opencagedata_test.rb
+++ b/test/unit/lookups/opencagedata_test.rb
@@ -15,6 +15,12 @@ class OpencagedataTest < GeocoderTestCase
 
   end
 
+  def test_opencagedata_viewport
+    result = Geocoder.search("Madison Square Garden, New York, NY").first
+    assert_equal [40.7498531, -73.9944444, 40.751161, -73.9925922],
+      result.viewport
+  end
+
   def test_opencagedata_query_url_contains_bounds
     lookup = Geocoder::Lookup::Opencagedata.new
     url = lookup.query_url(Geocoder::Query.new(

--- a/test/unit/lookups/ovi_test.rb
+++ b/test/unit/lookups/ovi_test.rb
@@ -1,0 +1,17 @@
+# encoding: utf-8
+$: << File.join(File.dirname(__FILE__), "..", "..")
+require 'test_helper'
+
+class OviTest < GeocoderTestCase
+
+  def setup
+    Geocoder.configure(lookup: :ovi)
+  end
+
+  def test_ovi_viewport
+    result = Geocoder.search("Madison Square Garden, New York, NY").first
+    assert_equal [40.7493451, -73.9948616, 40.7515934, -73.9918938],
+      result.viewport
+  end
+
+end

--- a/test/unit/lookups/yahoo_test.rb
+++ b/test/unit/lookups/yahoo_test.rb
@@ -24,6 +24,12 @@ class YahooTest < GeocoderTestCase
     assert_equal "Madison Square Garden, New York, NY 10001, United States", result.address
   end
 
+  def test_result_viewport
+    result = Geocoder.search("Madison Square Garden, New York, NY").first
+    assert_equal [40.749931, -73.994591, 40.750832, -73.993393],
+      result.viewport
+  end
+
   def test_raises_exception_when_over_query_limit
     Geocoder.configure(:always_raise => [Geocoder::OverQueryLimitError])
     l = Geocoder::Lookup.get(:yahoo)

--- a/test/unit/lookups/yandex_test.rb
+++ b/test/unit/lookups/yandex_test.rb
@@ -1,0 +1,17 @@
+# encoding: utf-8
+$: << File.join(File.dirname(__FILE__), "..", "..")
+require 'test_helper'
+
+class YandexTest < GeocoderTestCase
+
+  def setup
+    Geocoder.configure(lookup: :yandex)
+  end
+
+  def test_yandex_viewport
+    result = Geocoder.search('Кремль, Moscow, Russia').first
+    assert_equal [55.733361, 37.584182, 55.770517, 37.650064],
+      result.viewport
+  end
+
+end


### PR DESCRIPTION
Several providers return bounding box coordinates for the recommended area to display on a map for a particular query. It thought would be useful to expose this in the same format as bounding boxes are usually passed around in Geocoder.

Feedback would be welcome on naming and format. I see both `[[sw_lat, sw_lon], [ne_lat, ne_lon]]` and `[sw_lat, sw_lon, ne_lat, ne_lon]` being used, but I thought the former might be more clear.

The same method could probably be added to a lot of other providers as well. If you think this is a good idea, I could skim through the fixture data and add the ones I can verify by myself. :)