### PR TITLE
add md5 cache key option to prevent too long cache key

### DIFF
--- a/lib/generators/geocoder/config/templates/initializer.rb
+++ b/lib/generators/geocoder/config/templates/initializer.rb
@@ -9,6 +9,7 @@ Geocoder.configure(
   # api_key: nil,               # API key for geocoding service
   # cache: nil,                 # cache object (must respond to #[], #[]=, and #keys)
   # cache_prefix: 'geocoder:',  # prefix (string) to use for all cache keys
+  # cache_md5_name: false,      # use MD5 cache name for url? (prevents file name too long error)
 
   # Exceptions that should not be rescued by default
   # (if you want to implement custom error handling);

--- a/lib/geocoder/configuration.rb
+++ b/lib/geocoder/configuration.rb
@@ -53,6 +53,7 @@ module Geocoder
       :api_key,
       :cache,
       :cache_prefix,
+      :cache_md5_name,
       :always_raise,
       :units,
       :distances,
@@ -99,6 +100,7 @@ module Geocoder
       @data[:api_key]      = nil         # API key for geocoding service
       @data[:cache]        = nil         # cache object (must respond to #[], #[]=, and #keys)
       @data[:cache_prefix] = "geocoder:" # prefix (string) to use for all cache keys
+      @data[:cache_md5_name] = false     # use MD5 cache name for url? (prevents file name too long error)
       @data[:basic_auth]   = {}          # user and password for basic auth ({:user => "user", :password => "password"})
       @data[:logger]       = :kernel     # :kernel or Logger instance
       @data[:kernel_logger_level] = ::Logger::WARN # log level, if kernel logger is used

--- a/lib/geocoder/lookups/base.rb
+++ b/lib/geocoder/lookups/base.rb
@@ -218,7 +218,11 @@ module Geocoder
       # The result might or might not be cached.
       #
       def fetch_raw_data(query)
-        key = cache_key(query)
+        if configuration.cache_md5_name
+          key = Digest::MD5.hexdigest(cache_key(query))
+        else
+          key = cache_key(query)
+        end
         if cache and body = cache[key]
           @cache_hit = true
         else


### PR DESCRIPTION
Similar work was done back in August 2014 but never merged. If you set cache_md5_name: true in the configuration, the md5 value of the URL key will be generated to prevent the file name too long error. 

What do you think?