### PR TITLE
Warn that the Yahoo BOSS Placefinder API is being discontinued.

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,7 @@ The [Google Places Details API](https://developers.google.com/places/documentati
 * **Limitations**: "If your application displays Places API data on a page or view that does not also display a Google Map, you must show a "Powered by Google" logo with that data."
 
 #### Yahoo BOSS (`:yahoo`)
+**Warning - [this API will be discontinued on March 31.](https://developer.yahoo.com/boss/placefinder/)**
 
 * **API key**: requires OAuth consumer key and secret (set `Geocoder.configure(:api_key => [key, secret])`)
 * **Key signup**: http://developer.yahoo.com/boss/geo/

--- a/lib/geocoder/configuration.rb
+++ b/lib/geocoder/configuration.rb
@@ -17,6 +17,10 @@ module Geocoder
     if !options.nil?
       Configuration.instance.configure(options)
     end
+
+    if config.lookup == :yahoo
+      Geocoder.log(:warn, "Yahoo BOSS Placefinder API will be discontinued March 31, 2016.")
+    end
   end
 
   ##

--- a/lib/geocoder/lookups/yahoo.rb
+++ b/lib/geocoder/lookups/yahoo.rb
@@ -28,6 +28,7 @@ module Geocoder::Lookup
     private # ---------------------------------------------------------------
 
     def results(query)
+      Geocoder.log(:warn, "Yahoo BOSS Placefinder API will be discontinued March 31, 2016.")
       return [] unless doc = fetch_data(query)
       doc = doc['bossresponse']
       if doc['responsecode'].to_i == 200


### PR DESCRIPTION
https://developer.yahoo.com/boss/placefinder/

the Yahoo lookup will be fully removed via:
https://github.com/alexreisner/geocoder/pull/985

@alexreisner - I'm not sure whether a warning in `Lookup.get` or in `Lookup::Yahoo.results` makes more sense. Let me know what you think & I will remove one of the warnings. 