### PR TITLE
Replace TimeoutError with Timeout::Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1033,7 +1033,7 @@ Error Handling
 
 By default Geocoder will rescue any exceptions raised by calls to a geocoding service and return an empty array. You can override this on a per-exception basis, and also have Geocoder raise its own exceptions for certain events (eg: API quota exceeded) by using the `:always_raise` option:
 
-    Geocoder.configure(:always_raise => [SocketError, TimeoutError])
+    Geocoder.configure(:always_raise => [SocketError, Timeout::Error])
 
 You can also do this to raise all exceptions:
 
@@ -1042,14 +1042,14 @@ You can also do this to raise all exceptions:
 The raise-able exceptions are:
 
     SocketError
-    TimeoutError
+    Timeout::Error
     Geocoder::OverQueryLimitError
     Geocoder::RequestDenied
     Geocoder::InvalidRequest
     Geocoder::InvalidApiKey
     Geocoder::ServiceUnavailable
 
-Note that only a few of the above exceptions are raised by any given lookup, so there's no guarantee if you configure Geocoder to raise `ServiceUnavailable` that it will actually be raised under those conditions (because most APIs don't return 503 when they should; you may get a `TimeoutError` instead). Please see the source code for your particular lookup for details.
+Note that only a few of the above exceptions are raised by any given lookup, so there's no guarantee if you configure Geocoder to raise `ServiceUnavailable` that it will actually be raised under those conditions (because most APIs don't return 503 when they should; you may get a `Timeout::Error` instead). Please see the source code for your particular lookup for details.
 
 
 Troubleshooting

--- a/examples/reverse_geocode_job.rb
+++ b/examples/reverse_geocode_job.rb
@@ -35,6 +35,6 @@ class ReverseGeocodeJob < ActiveJob::Base
   end
 
   def retryable?(exception)
-    exception.is_a?(TimeoutError) || exception.is_a?(SocketError)
+    exception.is_a?(Timeout::Error) || exception.is_a?(SocketError)
   end
 end

--- a/lib/generators/geocoder/config/templates/initializer.rb
+++ b/lib/generators/geocoder/config/templates/initializer.rb
@@ -12,7 +12,7 @@ Geocoder.configure(
 
   # Exceptions that should not be rescued by default
   # (if you want to implement custom error handling);
-  # supports SocketError and TimeoutError
+  # supports SocketError and Timeout::Error
   # always_raise: [],
 
   # Calculation options

--- a/lib/geocoder/configuration.rb
+++ b/lib/geocoder/configuration.rb
@@ -109,7 +109,7 @@ module Geocoder
 
       # exceptions that should not be rescued by default
       # (if you want to implement custom error handling);
-      # supports SocketError and TimeoutError
+      # supports SocketError and Timeout::Error
       @data[:always_raise] = []
 
       # calculation options

--- a/lib/geocoder/lookups/base.rb
+++ b/lib/geocoder/lookups/base.rb
@@ -179,7 +179,7 @@ module Geocoder
         raise_error(err) or Geocoder.log(:warn, "Geocoding API connection cannot be established.")
       rescue Errno::ECONNREFUSED => err
         raise_error(err) or Geocoder.log(:warn, "Geocoding API connection refused.")
-      rescue TimeoutError => err
+      rescue Timeout::Error => err
         raise_error(err) or Geocoder.log(:warn, "Geocoding API not responding fast enough " +
           "(use Geocoder.configure(:timeout => ...) to set limit).")
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -123,7 +123,7 @@ module Geocoder
       remove_method(:make_api_request)
 
       def make_api_request(query)
-        raise TimeoutError if query.text == "timeout"
+        raise Timeout::Error if query.text == "timeout"
         raise SocketError if query.text == "socket_error"
         raise Errno::ECONNREFUSED if query.text == "connection_refused"
         if query.text == "invalid_json"

--- a/test/unit/error_handling_test.rb
+++ b/test/unit/error_handling_test.rb
@@ -41,12 +41,12 @@ class ErrorHandlingTest < GeocoderTestCase
   end
 
   def test_always_raise_timeout_error
-    Geocoder.configure(:always_raise => [TimeoutError])
+    Geocoder.configure(:always_raise => [Timeout::Error])
     Geocoder::Lookup.all_services_except_test.each do |l|
       next if l == :maxmind_local || l == :geoip2 # local, does not use cache
       lookup = Geocoder::Lookup.get(l)
       set_api_key!(l)
-      assert_raises TimeoutError do
+      assert_raises Timeout::Error do
         lookup.send(:results, Geocoder::Query.new("timeout"))
       end
     end


### PR DESCRIPTION
`TimeoutError` is deprecated in Ruby 2.3.0, causing some of the warnings seen in #976.

It has been an alias for `Timeout::Error` starting in Ruby 1.8.0, and should be safe to replace. Here's the original commit from 2003: https://github.com/ruby/ruby/commit/9d22a06ea06e9bec5030fd6e2c8481958fcd30d9