### PR TITLE
Add supported_protocols to Freegeoip.rb lookup

### DIFF
--- a/lib/geocoder/lookups/freegeoip.rb
+++ b/lib/geocoder/lookups/freegeoip.rb
@@ -7,6 +7,10 @@ module Geocoder::Lookup
     def name
       "FreeGeoIP"
     end
+    
+    def supported_protocols
+      [:http]
+    end
 
     def query_url(query)
       "#{protocol}://#{host}/json/#{query.sanitized_text}"


### PR DESCRIPTION
I uncovered a small issue when switching from Yahoo BOSS to Google (with API, which requires enabling :use_https).  Because the Freegeoip.rb file is missing a supported_protocols method, it attempts to do an https lookup for IP lookups when enabling :use_https.

I already tested this on my setup and it appears to resolve the issue, with lookups/base.rb detecting that https is not supported for Freegeoip