### PR TITLE
add maxmind_geoip2 setup to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -726,6 +726,18 @@ This uses the PostcodeAnywhere UK Geocode service, this will geocode any string 
 * **Limitations**: Only good for non-commercial use. For commercial usage please check http://developer.baidu.com/map/question.htm#qa0013
 * **Notes**: To use Baidu set `Geocoder.configure(:lookup => :baidu_ip, :api_key => "your_api_key")`.
 
+#### MaxMind GeoIP2 Precision Web Services (`:maxmind_geoip2`)
+
+* **API key**: required
+* **Quota**: Request Packs can be purchased
+* **Region**: world
+* **SSL support**: yes
+* **Languages**: English
+* **Documentation**: http://dev.maxmind.com/geoip/geoip2/web-services/
+* **Terms of Service**: ?
+* **Limitations**: ?
+* **Notes**: You must specify which MaxMind service you are using in your configuration, and also basic authentication. For example: `Geocoder.configure(:maxmind_geoip2 => {:service => :country, :basic_auth => {:user => '', :password => ''}})`.
+
 
 ### IP Address Local Database Services
 


### PR DESCRIPTION
Yesterday, I had to check out the library and search through code to find how to setup `:maxmind_geoip2` as an IP Address Service.

The main goal was _basic_auth_ params. So I think of can be helpful to have this information on the `README.md`.