### PR TITLE
add mapbox_params to mapbox lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,7 +518,7 @@ The [Google Places Details API](https://developers.google.com/places/documentati
 #### Mapbox (`:mapbox`)
 
 * **API key**: required
-* **Dataset**: Uses `mapbox.places` dataset by default.  Specific the `mapbox.places-permanent` dataset by setting: `Geocoder.configure(:mapbox => {:dataset => "mapbox.places-permanent"})`
+* **Dataset**: Uses `mapbox.places` dataset by default.  Specific the `mapbox.places-permanent` dataset by setting: `Geocoder.configure(:mapbox => {:dataset => "mapbox.places-permanent", :mapbox_params => {:proximity => '0,0'}})`
 * **Key signup**: https://www.mapbox.com/pricing/
 * **Quota**: depends on plan
 * **Region**: complete coverage of US and Canada, partial coverage elsewhere (see for details: https://www.mapbox.com/developers/api/geocoding/#coverage)

--- a/lib/geocoder/lookups/mapbox.rb
+++ b/lib/geocoder/lookups/mapbox.rb
@@ -9,7 +9,7 @@ module Geocoder::Lookup
     end
 
     def query_url(query)
-      "#{protocol}://api.mapbox.com/geocoding/v5/#{dataset}/#{url_query_string(query)}.json?access_token=#{configuration.api_key}"
+      "#{protocol}://api.mapbox.com/geocoding/v5/#{dataset}/#{url_query_string(query)}.json?access_token=#{configuration.api_key}&#{mapbox_params_query}"
     end
 
     private # ---------------------------------------------------------------
@@ -48,6 +48,14 @@ module Geocoder::Lookup
       features.sort_by do |feature|
         [feature["relevance"],-features.index(feature)]
       end.reverse
+    end
+
+    def mapbox_params
+      configuration[:mapbox_params] || {}
+    end
+
+    def mapbox_params_query
+      hash_to_query(mapbox_params)
     end
   end
 end

--- a/test/unit/lookups/mapbox_test.rb
+++ b/test/unit/lookups/mapbox_test.rb
@@ -9,9 +9,9 @@ class MapboxTest < GeocoderTestCase
   end
 
   def test_url_contains_api_key
-    Geocoder.configure(mapbox: {api_key: "abc123"})
+    Geocoder.configure(mapbox: {api_key: "abc123", mapbox_params: {proximity: '0,0'}})
     query = Geocoder::Query.new("Leadville, CO")
-    assert_equal "https://api.mapbox.com/geocoding/v5/mapbox.places/Leadville%2C+CO.json?access_token=abc123", query.url
+    assert_equal "https://api.mapbox.com/geocoding/v5/mapbox.places/Leadville%2C+CO.json?access_token=abc123&proximity=0%2C0", query.url
   end
 
   def test_result_components


### PR DESCRIPTION
mapbox expects to get  parameters separately from query (example: https://www.mapbox.com/developers/api/geocoding/#country). Сurrently it is impossible to pass some filtering params to query_url .
