### PR TITLE
Added scope :near! for strict results

### DIFF
--- a/lib/geocoder/exceptions.rb
+++ b/lib/geocoder/exceptions.rb
@@ -25,6 +25,9 @@ module Geocoder
   class InvalidRequest < Error
   end
 
+  class InvalidLocation < Error
+  end
+
   class InvalidApiKey < Error
   end
 

--- a/lib/geocoder/stores/active_record.rb
+++ b/lib/geocoder/stores/active_record.rb
@@ -55,6 +55,20 @@ module Geocoder::Store
         }
 
         ##
+        # Strict version of scope :near
+        #
+        scope :near!, lambda{ |location, *args|
+          point = Geocoder::Calculations.extract_coordinates(location)
+          raise Geocoder::InvalidLocation, "The provided location didn't return as valid" \
+            and return if [[Geocoder::Calculations::NAN,Geocoder::Calculations::NAN], nil].
+            include? point
+
+          options = near_scope_options(*Array(point), *args)
+          select(options[:select]).where(options[:conditions]).
+            order(options[:order])
+        }
+
+        ##
         # Find all objects within the area of a given bounding box.
         # Bounds must be an array of locations specifying the southwest
         # corner followed by the northeast corner of the box


### PR DESCRIPTION
Provide strict scope :near! for ActiveRecord::Base instance methods

**Current method implementation with invalid location input.**
```ruby
Address.near("New York, VA").to_sql
# => "SELECT addresses.*, NULL::text AS distance, NULL::text AS bearing FROM \"addresses\"  WHERE (false)" 
```
**New method with invalid location input.**
```ruby
Address.near!("New York, VA").to_sql
#Geocoder::InvalidLocation: The provided location didn't return as valid

```