### PR TITLE
Remove chance of nil return in Calculations.extract_coordinates

### DIFF
--- a/lib/geocoder/calculations.rb
+++ b/lib/geocoder/calculations.rb
@@ -416,7 +416,8 @@ module Geocoder
           end
         end
       when String
-        point = Geocoder.coordinates(point) and return point
+        point = Geocoder.coordinates(point)
+        return point ? point : [ NAN, NAN ]
       else
         if point.respond_to?(:to_coordinates)
           if Array === array = point.to_coordinates


### PR DESCRIPTION
This is one place in this method that may return `nil` in `Geocoder::Calculations.extract_coordinates`.

```ruby
Geocoder.coordinates("")
# => nil
```