### PR TITLE
Add i18n integration for geoip2 results

### DIFF
--- a/lib/geocoder/results/geoip2.rb
+++ b/lib/geocoder/results/geoip2.rb
@@ -61,7 +61,7 @@ module Geocoder
       end
 
       def locale
-        @locale ||= Geocoder.config[:language].to_s
+        defined?(I18n) ? I18n.locale.to_s : Geocoder.config[:language].to_s
       end
     end
   end

--- a/test/unit/lookups/geoip2_test.rb
+++ b/test/unit/lookups/geoip2_test.rb
@@ -4,10 +4,12 @@ require 'test_helper'
 class Geoip2Test < GeocoderTestCase
   def setup
     Geocoder.configure(ip_lookup: :geoip2, file: 'test_file')
+    I18n.available_locales = [:en, :ru]
   end
 
   def teardown
     Geocoder::Configuration.language = :en
+    I18n.locale = :en
   end
 
   def test_result_attributes
@@ -29,10 +31,10 @@ class Geoip2Test < GeocoderTestCase
     assert_equal [], results
   end
 
-  def test_localization
+  def test_i18n_localization
     result = Geocoder.search('8.8.8.8').first
 
-    Geocoder::Configuration.language = :ru
+    I18n.locale = :ru
     assert_equal 'Маунтин-Вью', result.city
   end
 end


### PR DESCRIPTION
Hi! I added I18n integration for geoip2 results.

I have a rails app and I want to detect user's city. The output depends on the locale: when user locale is RU I want to show "Москва". But if Geocoder.config[:language] = :en, I get "Moscow". Geocoder's language is set in the initializers once and forever.

But during adding tests for this feature, I faced a problem testing the case when I18n is not defined. Now I18n exists in the test environment. So, the obvious method is undefining I18n using `Object.send(:remove_const, :I18n)` and after the test defining it back again, but this is a terrible way:
1. `remove_const` is a private method
2. I get the exception 'dynamic constant assignment' when caching I18n to TempI18n:

```
  def test_default_localization
    Geocoder::Configuration.language = :ru
    TempI18n = I18n
    Object.send(:remove_const, :I18n)

    result = Geocoder.search('8.8.8.8').first

    assert_equal 'Маунтин-Вью', result.city
    I18n = TempI18n
    Object.send(:remove_const, :TempI18n)
  end
```

And just undefining the I18n constant is very bad, because the environment will not rollback to a known state after the test.

So, if you have any ideas how to test the default behavior when i18n is not defined, please let me know. Thank you!
