### PR TITLE
change freegeoip lookup's host from freegeoip.net to freegeoip.io

### DIFF
--- a/lib/geocoder/lookups/freegeoip.rb
+++ b/lib/geocoder/lookups/freegeoip.rb
@@ -45,7 +45,7 @@ module Geocoder::Lookup
     end
 
     def host
-      configuration[:host] || "freegeoip.net"
+      configuration[:host] || "freegeoip.io"
     end
   end
 end

--- a/lib/geocoder/results/freegeoip.rb
+++ b/lib/geocoder/results/freegeoip.rb
@@ -33,7 +33,7 @@ module Geocoder::Result
     end
 
     def self.response_attributes
-      %w[metrocode ip]
+      %w[metro_code ip]
     end
 
     response_attributes.each do |a|


### PR DESCRIPTION
Given 'freegeoip.net' is down for the foreseeable future ([ref here](https://twitter.com/fiorix_/status/715892818758221825)) and a clone has been established at 'freegeoip.net' I propose updating the default IP lookup to the latter. This is also somewhat in response to issue [#1009](https://github.com/alexreisner/geocoder/issues/1009)