### PR TITLE
adequation to neighborhood method of Results::Google object

### DIFF
--- a/lib/geocoder/results/google.rb
+++ b/lib/geocoder/results/google.rb
@@ -12,7 +12,7 @@ module Geocoder::Result
     end
 
     def neighborhood
-      if neighborhood = address_components_of_type(:neighborhood).first
+      if neighborhood = address_components_of_type(:sublocality).first
         neighborhood['long_name']
       end
     end
@@ -120,14 +120,14 @@ module Geocoder::Result
     def precision
       geometry['location_type'] if geometry
     end
-    
+
     def partial_match
       @data['partial_match']
     end
-    
+
     def place_id
       @data['place_id']
-    end  
+    end
 
     def viewport
       viewport = geometry['viewport'] || fail

--- a/lib/geocoder/results/google.rb
+++ b/lib/geocoder/results/google.rb
@@ -1,5 +1,6 @@
 require 'geocoder/results/base'
 
+
 module Geocoder::Result
   class Google < Base
 
@@ -71,9 +72,9 @@ module Geocoder::Result
       end
     end
 
-    def route
+    def route key = :long_name
       if route = address_components_of_type(:route).first
-        route['long_name']
+        route[key.to_s]
       end
     end
 


### PR DESCRIPTION
The ```types``` key doesn't more contains ```neighborhood``` symbol, then the method always returns ```nil``` value, now contains ```sublocality``` and ```sublocality_level_1```.

The ```types``` key doesn't more contains ```neighborhood``` symbol, but now contains ```sublocality``` and ```sublocality_level_1```, for that the ```neighborhood``` method always returns nil value.