### PR TITLE
Add result_type as option for google lookup

### DIFF
--- a/lib/geocoder/lookups/google.rb
+++ b/lib/geocoder/lookups/google.rb
@@ -65,6 +65,9 @@ module Geocoder::Lookup
       unless (components = query.options[:components]).nil?
         params[:components] = components.is_a?(Array) ? components.join("|") : components
       end
+      unless (result_type = query.options[:result_type]).nil?
+        params[:result_type] = result_type.is_a?(Array) ? result_type.join("|") : result_type
+      end
       params
     end
 

--- a/test/unit/lookups/google_test.rb
+++ b/test/unit/lookups/google_test.rb
@@ -86,6 +86,26 @@ class GoogleTest < GeocoderTestCase
     assert url.include?(formatted), "Expected #{formatted} to be included in #{url}"
   end
 
+  def test_google_query_url_contains_result_type_when_given_as_string
+    lookup = Geocoder::Lookup::Google.new
+    url = lookup.query_url(Geocoder::Query.new(
+      "Some Intersection",
+      :result_type => "country"
+    ))
+    formatted = "result_type=" + CGI.escape("country")
+    assert url.include?(formatted), "Expected #{formatted} to be included in #{url}"
+  end
+
+  def test_google_query_url_contains_result_type_when_given_as_array
+    lookup = Geocoder::Lookup::Google.new
+    url = lookup.query_url(Geocoder::Query.new(
+      "Some Intersection",
+      :result_type => ["country", "postal_code"]
+    ))
+    formatted = "result_type=" + CGI.escape("country|postal_code")
+    assert url.include?(formatted), "Expected #{formatted} to be included in #{url}"
+  end
+
   def test_google_uses_https_when_api_key_is_set
     Geocoder.configure(api_key: "deadbeef")
     query = Geocoder::Query.new("Madison Square Garden, New York, NY")


### PR DESCRIPTION
Hey guys.

Just wondering if it would be possible have the option to return `result_type` from the google geocoder reverse lookup as seen here.
https://developers.google.com/maps/documentation/geocoding/intro#ReverseGeocoding