### PR TITLE
Disable SSL v2 and v3 if ssl enabled

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ end
 
 group :test do
   gem 'sqlite3', :platform => [:ruby, :mswin, :mingw]
+  gem 'webmock'
 
   platforms :ruby do
     gem 'pg'

--- a/gemfiles/Gemfile.rails3.2
+++ b/gemfiles/Gemfile.rails3.2
@@ -24,6 +24,7 @@ end
 
 group :test do
   gem 'sqlite3', :platform => [:ruby, :mswin, :mingw]
+  gem 'webmock'
 
   platforms :ruby do
     gem 'pg'

--- a/gemfiles/Gemfile.rails4.1
+++ b/gemfiles/Gemfile.rails4.1
@@ -24,6 +24,7 @@ end
 
 group :test do
   gem 'sqlite3', :platform => [:ruby, :mswin, :mingw]
+  gem 'webmock'
 
   platforms :ruby do
     gem 'pg'

--- a/gemfiles/Gemfile.ruby1.9.3
+++ b/gemfiles/Gemfile.ruby1.9.3
@@ -16,6 +16,7 @@ group :development, :test do
   gem 'test-unit' # install newer version with omit() method
 
   gem 'debugger'
+  gem 'webmock'
 
   platforms :jruby do
     gem 'jruby-openssl'

--- a/lib/geocoder/lookups/base.rb
+++ b/lib/geocoder/lookups/base.rb
@@ -274,6 +274,7 @@ module Geocoder
         uri = URI.parse(query_url(query))
         Geocoder.log(:debug, "Geocoder: HTTP request being made for #{uri.to_s}")
         http_client.start(uri.host, uri.port, use_ssl: use_ssl?, open_timeout: configuration.timeout, read_timeout: configuration.timeout) do |client|
+          configure_ssl!(client) if use_ssl?
           req = Net::HTTP::Get.new(uri.request_uri, configuration.http_headers)
           if configuration.basic_auth[:user] and configuration.basic_auth[:password]
             req.basic_auth(
@@ -296,6 +297,8 @@ module Geocoder
           configuration.use_https
         end
       end
+
+      def configure_ssl!(client); end
 
       def check_api_key_configuration!(query)
         key_parts = query.lookup.required_api_key_parts

--- a/lib/geocoder/lookups/google.rb
+++ b/lib/geocoder/lookups/google.rb
@@ -30,7 +30,11 @@ module Geocoder::Lookup
     def configure_ssl!(client)
       client.instance_eval {
         @ssl_context = OpenSSL::SSL::SSLContext.new
-        @ssl_context.set_params({:options=> OpenSSL::SSL::OP_NO_SSLv2 | OpenSSL::SSL::OP_NO_SSLv3 | OpenSSL::SSL::OP_NO_COMPRESSION})
+        options = OpenSSL::SSL::OP_NO_SSLv2 | OpenSSL::SSL::OP_NO_SSLv3
+        if OpenSSL::SSL.const_defined?('OP_NO_COMPRESSION')
+          options |= OpenSSL::SSL::OP_NO_COMPRESSION
+        end
+        @ssl_context.set_params({options: options})
       }
     end
 

--- a/lib/geocoder/lookups/google.rb
+++ b/lib/geocoder/lookups/google.rb
@@ -27,6 +27,13 @@ module Geocoder::Lookup
 
     private # ---------------------------------------------------------------
 
+    def configure_ssl!(client)
+      client.instance_eval {
+        @ssl_context = OpenSSL::SSL::SSLContext.new
+        @ssl_context.set_params({:options=> OpenSSL::SSL::OP_NO_SSLv2 | OpenSSL::SSL::OP_NO_SSLv3 | OpenSSL::SSL::OP_NO_COMPRESSION})
+      }
+    end
+
     def valid_response?(response)
       json = parse_json(response.body)
       status = json["status"] if json

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -120,7 +120,9 @@ module Geocoder
         fixture_exists?(filename) ? filename : default_fixture_filename
       end
 
-      alias_method :make_api_http_request, :make_api_request
+      # This alias allows us to use this method in further tests
+      # to actually test http requests
+      alias_method :actual_make_api_request, :make_api_request
       remove_method(:make_api_request)
 
       def make_api_request(query)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -120,6 +120,7 @@ module Geocoder
         fixture_exists?(filename) ? filename : default_fixture_filename
       end
 
+      alias_method :make_api_http_request, :make_api_request
       remove_method(:make_api_request)
 
       def make_api_request(query)

--- a/test/unit/lookup_test.rb
+++ b/test/unit/lookup_test.rb
@@ -160,4 +160,19 @@ class LookupTest < GeocoderTestCase
     assert_equal :google, Geocoder::Lookup::Google.new.handle
     assert_equal :geocoder_ca, Geocoder::Lookup::GeocoderCa.new.handle
   end
+
+  def test_http_request
+    Geocoder.configure(use_https: true)
+
+    require 'webmock/test_unit'
+    WebMock.enable!
+    stub_all = WebMock.stub_request(:any, /.*/).to_return(status: 200)
+
+    g = Geocoder::Lookup::Google.new
+    g.send(:make_api_http_request, Geocoder::Query.new('test location'))
+    assert_requested(stub_all)
+
+    WebMock.reset!
+    WebMock.disable!
+  end
 end

--- a/test/unit/lookup_test.rb
+++ b/test/unit/lookup_test.rb
@@ -160,19 +160,4 @@ class LookupTest < GeocoderTestCase
     assert_equal :google, Geocoder::Lookup::Google.new.handle
     assert_equal :geocoder_ca, Geocoder::Lookup::GeocoderCa.new.handle
   end
-
-  def test_http_request
-    Geocoder.configure(use_https: true)
-
-    require 'webmock/test_unit'
-    WebMock.enable!
-    stub_all = WebMock.stub_request(:any, /.*/).to_return(status: 200)
-
-    g = Geocoder::Lookup::Google.new
-    g.send(:make_api_http_request, Geocoder::Query.new('test location'))
-    assert_requested(stub_all)
-
-    WebMock.reset!
-    WebMock.disable!
-  end
 end

--- a/test/unit/lookups/google_test.rb
+++ b/test/unit/lookups/google_test.rb
@@ -111,4 +111,19 @@ class GoogleTest < GeocoderTestCase
     query = Geocoder::Query.new("Madison Square Garden, New York, NY")
     assert_match(/^https:/, query.url)
   end
+
+  def test_actual_make_api_request_with_https
+    Geocoder.configure(use_https: true, lookup: :google)
+
+    require 'webmock/test_unit'
+    WebMock.enable!
+    stub_all = WebMock.stub_request(:any, /.*/).to_return(status: 200)
+
+    g = Geocoder::Lookup::Google.new
+    g.send(:actual_make_api_request, Geocoder::Query.new('test location'))
+    assert_requested(stub_all)
+
+    WebMock.reset!
+    WebMock.disable!
+  end
 end


### PR DESCRIPTION
Fixes #1034 

About the test, I didn't feel comfortable changing such a crucial piece of the code without at least making a test that passes :) . Basically what I did is rename the `:make_api_request` to `:make_http_api_request`, and then verify the behavior of the latter.