### PR TITLE
Add warning for redis cache clearing

### DIFF
--- a/README.md
+++ b/README.md
@@ -868,6 +868,8 @@ By default the prefix is `geocoder:`
 
 If you need to expire cached content:
 
+_Warning: If you are using redis for caching, this method of caching uses .keys to select URLs to expire, with regex processing in ruby to filter geocoder URLs/keys to delete. This in a large production environment can cause Redis to lock, and will most likely cause memory issues._
+
     Geocoder::Lookup.get(Geocoder.config[:lookup]).cache.expire(:all)  # expire cached results for current Lookup
     Geocoder::Lookup.get(:google).cache.expire("http://...")           # expire cached result for a specific URL
     Geocoder::Lookup.get(:google).cache.expire(:all)                   # expire cached results for Google Lookup


### PR DESCRIPTION
.keys in a Production environment is pretty dangerous, particularly when it's being manipulated in ruby as an array afterwards.

This should probably be reworked to use something like scan_each, eg:

``` ruby
store.scan_each(:match => "geocoder:*") { |key|
  store.del(key)
end
```
