### PR TITLE
initial draft of batch geocoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -949,6 +949,19 @@ You can use Geocoder outside of Rails by calling the `Geocoder.search` method:
 This returns an array of `Geocoder::Result` objects with all data provided by the geocoding service.
 
 
+Batch Geocoding Outside of Rails
+--------------------------------
+
+For providers which have a batch geocoding API, you can use the `Geocoder.batch` method to pass in multiple addresses and get back a list of corresponding geocoded results. This will make a single API request to the provider, which will result in a significantly faster response when geocoding a large number of items.
+
+    results = Geocoder.batch([
+      {input: "309 SW 6th, Portland, OR", id: 2042},
+      {input: "220 NW 8th Ave, Portland, OR", id: 3029}
+    ])
+
+This returns an array of `Geocoder::Result` objects. If you provide an `id` for each input, the result object will have a matching id. Otherwise, the id will be automatically assigned.
+
+
 Testing Apps that Use Geocoder
 ------------------------------
 

--- a/lib/geocoder.rb
+++ b/lib/geocoder.rb
@@ -2,6 +2,7 @@ require "geocoder/configuration"
 require "geocoder/logger"
 require "geocoder/kernel_logger"
 require "geocoder/query"
+require "geocoder/batch"
 require "geocoder/calculations"
 require "geocoder/exceptions"
 require "geocoder/cache"
@@ -20,6 +21,11 @@ module Geocoder
   def self.search(query, options = {})
     query = Geocoder::Query.new(query, options) unless query.is_a?(Geocoder::Query)
     query.blank? ? [] : query.execute
+  end
+
+  def self.batch(batch, options = {})
+    batch = Geocoder::Batch.new(batch, options) unless batch.is_a?(Geocoder::Batch)
+    batch.blank? ? [] : batch.execute
   end
 
   ##

--- a/lib/geocoder/batch.rb
+++ b/lib/geocoder/batch.rb
@@ -1,0 +1,40 @@
+module Geocoder
+  class Batch
+    attr_accessor :items, :options
+
+    def initialize(items, options = {})
+      self.items = items
+      self.options = options
+    end
+
+    def execute
+      lookup.batch(items, options)
+    end
+
+    def to_s
+      items.map{|item| item.to_s}
+    end
+
+    ##
+    # Get a Lookup object (which communicates with the remote geocoding API)
+    # appropriate to the Query text.
+    #
+    def lookup
+      if !options[:street_address] and options[:ip_address]
+        name = options[:ip_lookup] || Configuration.ip_lookup || Geocoder::Lookup.ip_services.first
+      else
+        name = options[:lookup] || Configuration.lookup || Geocoder::Lookup.street_services.first
+      end
+      Lookup.get(name)
+    end
+
+    def blank?
+      items.length == 0
+    end
+
+    def reverse_geocode?
+      false
+    end
+    
+  end
+end

--- a/lib/geocoder/configuration.rb
+++ b/lib/geocoder/configuration.rb
@@ -48,6 +48,7 @@ module Geocoder
       :language,
       :http_headers,
       :use_https,
+      :use_post,
       :http_proxy,
       :https_proxy,
       :api_key,
@@ -94,6 +95,7 @@ module Geocoder
       @data[:language]     = :en         # ISO-639 language code
       @data[:http_headers] = {}          # HTTP headers for lookup
       @data[:use_https]    = false       # use HTTPS for lookup requests? (if supported)
+      @data[:use_post]     = false       # send POST request instead of GET
       @data[:http_proxy]   = nil         # HTTP proxy server (user:pass@host:port)
       @data[:https_proxy]  = nil         # HTTPS proxy server (user:pass@host:port)
       @data[:api_key]      = nil         # API key for geocoding service

--- a/lib/geocoder/lookups/base.rb
+++ b/lib/geocoder/lookups/base.rb
@@ -283,7 +283,7 @@ module Geocoder
         Geocoder.log(:debug, "Geocoder: HTTP request being made for #{uri.to_s}")
         http_client.start(uri.host, uri.port, use_ssl: use_ssl?, open_timeout: configuration.timeout, read_timeout: configuration.timeout) do |client|
           configure_ssl!(client) if use_ssl?
-          req = Net::HTTP::Get.new(uri.request_uri, configuration.http_headers)
+          req = create_http_request uri.request_uri, query
           if configuration.basic_auth[:user] and configuration.basic_auth[:password]
             req.basic_auth(
               configuration.basic_auth[:user],
@@ -294,6 +294,16 @@ module Geocoder
         end
       rescue Timeout::Error
         raise Geocoder::LookupTimeout
+      end
+
+      def create_http_request(request_uri, query)
+        if configuration.use_post
+          req = Net::HTTP::Post.new(request_uri, configuration.http_headers)
+          req.body = url_query_string(query)
+        else
+          req = Net::HTTP::Get.new(request_uri, configuration.http_headers)
+        end
+        req
       end
 
       def use_ssl?

--- a/lib/geocoder/lookups/base.rb
+++ b/lib/geocoder/lookups/base.rb
@@ -51,6 +51,14 @@ module Geocoder
         }
       end
 
+      # Takes an array of search strings and returns an array of <tt>Geocoder::Result</tt>
+      def batch(items, options = {})
+        items = Geocoder::Batch.new(items, options) unless items.is_a?(Geocoder::Batch)
+        results(items).map{ |r|
+          result = result_class.new(r)
+        }
+      end
+
       ##
       # Return the URL for a map of the given coordinates.
       #

--- a/lib/geocoder/lookups/esri.rb
+++ b/lib/geocoder/lookups/esri.rb
@@ -16,8 +16,13 @@ module Geocoder::Lookup
         search_keyword = query.reverse_geocode? ? "reverseGeocode" : "find"
       end
 
-      "#{protocol}://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/#{search_keyword}?" +
-        url_query_string(query)
+      base_url = "#{protocol}://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/#{search_keyword}"
+
+      if configuration.use_post
+        base_url
+      else
+        "#{base_url}?#{url_query_string(query)}"
+      end
     end
 
     private # ---------------------------------------------------------------
@@ -68,8 +73,9 @@ module Geocoder::Lookup
         else
           params[:text] = query.sanitized_text
         end
-        params[:forStorage] = configuration[:for_storage] if configuration[:for_storage]
       end
+
+      params[:forStorage] = configuration[:for_storage] if configuration[:for_storage]
 
       params[:token] = token
       params.merge(super)

--- a/lib/geocoder/lookups/esri.rb
+++ b/lib/geocoder/lookups/esri.rb
@@ -76,6 +76,7 @@ module Geocoder::Lookup
       end
 
       params[:forStorage] = configuration[:for_storage] if configuration[:for_storage]
+      params[:sourceCountry] = configuration[:source_country] if configuration[:source_country]
 
       params[:token] = token
       params.merge(super)

--- a/lib/geocoder/results/base.rb
+++ b/lib/geocoder/results/base.rb
@@ -17,6 +17,11 @@ module Geocoder
         @cache_hit = nil
       end
 
+      # batch geocoding results will have this id set to the id that was given in the input
+      def id
+        fail
+      end
+
       ##
       # A string in the given format.
       #

--- a/test/unit/lookup_test.rb
+++ b/test/unit/lookup_test.rb
@@ -160,4 +160,27 @@ class LookupTest < GeocoderTestCase
     assert_equal :google, Geocoder::Lookup::Google.new.handle
     assert_equal :geocoder_ca, Geocoder::Lookup::GeocoderCa.new.handle
   end
+
+  def test_get_request
+    token = Geocoder::EsriToken.new('xxxxx', Time.now + 86400)
+    Geocoder.configure(:token => token)
+    lookup = Geocoder::Lookup::Esri.new
+
+    query = Geocoder::Query.new('test location')
+    uri = URI.parse(lookup.query_url(query))
+    request = lookup.send(:create_http_request, uri.request_uri, query)
+    assert_equal "GET", request.method
+  end
+
+  def test_post_request
+    token = Geocoder::EsriToken.new('xxxxx', Time.now + 86400)
+    Geocoder.configure(:token => token, :use_post => true)
+    lookup = Geocoder::Lookup::Esri.new
+
+    query = Geocoder::Query.new('test location')
+    uri = URI.parse(lookup.query_url(query))
+    request = lookup.send(:create_http_request, uri.request_uri, query)
+    assert_equal "POST", request.method
+  end
+
 end

--- a/test/unit/lookups/esri_test.rb
+++ b/test/unit/lookups/esri_test.rb
@@ -17,7 +17,7 @@ class EsriTest < GeocoderTestCase
   end
 
   def test_query_for_geocode_with_token_for_storage
-    token = Geocoder::EsriToken.new('xxxxx', Time.now + 1.day)
+    token = Geocoder::EsriToken.new('xxxxx', Time.now + 86400)
     Geocoder.configure(esri: {token: token, for_storage: true})
     query = Geocoder::Query.new("Bluffton, SC")
     lookup = Geocoder::Lookup.get(:esri)


### PR DESCRIPTION
- Adds new `Geocoder.batch` method which takes an array of input text and uses the provider's batch API to make a single HTTP request to geocode all the inputs.
- Updates readme with a usage example.
