### PR TITLE
fix passing forStorage=true for esri geocoder when using api key

### DIFF
--- a/lib/geocoder/lookups/esri.rb
+++ b/lib/geocoder/lookups/esri.rb
@@ -52,7 +52,14 @@ module Geocoder::Lookup
         configuration[:token].to_s
       elsif configuration.api_key # generate a new token if we have credentials
         token_instance = Geocoder::EsriToken.generate_token(*configuration.api_key)
-        Geocoder.configure(:esri => {:token => token_instance})
+
+        esri_config = {:token => token_instance}
+        if configuration[:for_storage]
+          esri_config[:for_storage] = configuration[:for_storage]
+        end
+        # replaces the entire :esri config section with the new object
+        Geocoder.configure(:esri => esri_config)
+
         token_instance.to_s
       end
     end

--- a/lib/geocoder/lookups/esri.rb
+++ b/lib/geocoder/lookups/esri.rb
@@ -53,12 +53,7 @@ module Geocoder::Lookup
       elsif configuration.api_key # generate a new token if we have credentials
         token_instance = Geocoder::EsriToken.generate_token(*configuration.api_key)
 
-        esri_config = {:token => token_instance}
-        if configuration[:for_storage]
-          esri_config[:for_storage] = configuration[:for_storage]
-        end
-        # replaces the entire :esri config section with the new object
-        Geocoder.configure(:esri => esri_config)
+        Geocoder.configure(:esri => Geocoder.config[:esri].merge({:token => token_instance}))
 
         token_instance.to_s
       end

--- a/test/unit/lookups/esri_test.rb
+++ b/test/unit/lookups/esri_test.rb
@@ -2,12 +2,26 @@
 require 'test_helper'
 require 'geocoder/esri_token'
 
+class Geocoder::EsriToken
+  class << self
+
+    alias_method :old_generate_token, :generate_token; 
+
+    # Stub the generate_token method when called with a specific client_id and client_secret
+    def generate_token(client_id, client_secret, expires=1440)
+      if client_id == "id" and client_secret == "secret"
+        "xxxxx"
+      else
+        self.old_generate_token client_id, client_secret, expires
+      end
+    end
+  end
+end
+
 class EsriTest < GeocoderTestCase
 
   def setup
     Geocoder.configure(lookup: :esri)
-    require 'webmock/test_unit'
-    WebMock.enable!
   end
 
   def test_query_for_geocode
@@ -19,7 +33,7 @@ class EsriTest < GeocoderTestCase
   end
 
   def test_query_for_geocode_with_token_for_storage
-    token = Geocoder::EsriToken.new('xxxxx', Time.now + 1.day)
+    token = Geocoder::EsriToken.new('xxxxx', Time.now + 86400)
     Geocoder.configure(esri: {token: token, for_storage: true})
     query = Geocoder::Query.new("Bluffton, SC")
     lookup = Geocoder::Lookup.get(:esri)
@@ -29,18 +43,11 @@ class EsriTest < GeocoderTestCase
   end
 
   def test_query_for_geocode_with_client_credentials_for_storage
-    token_data = {
-      access_token: "xxxxx",
-      expires_in: 7200
-    }
-    stub_request(:post, "https://www.arcgis.com/sharing/rest/oauth2/token").to_return(:body => token_data.to_json)
-    # in ruby 1.9.3, WebMock generates this URL instead of a URL with the https protocol
-    stub_request(:post, "http://www.arcgis.com:443/sharing/rest/oauth2/token").to_return(:body => token_data.to_json)
-
     Geocoder.configure(esri: {api_key: ['id','secret'], for_storage: true})
     query = Geocoder::Query.new("Bluffton, SC")
     lookup = Geocoder::Lookup.get(:esri)
     res = lookup.query_url(query)
+
     assert_equal "http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/find?f=pjson&forStorage=true&outFields=%2A&text=Bluffton%2C+SC&token=xxxxx",
       res
   end
@@ -51,6 +58,28 @@ class EsriTest < GeocoderTestCase
     res = lookup.query_url(query)
     assert_equal "http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode?f=pjson&location=-75.676333%2C45.423733&outFields=%2A",
       res
+  end
+
+  def test_token_generation
+    require 'webmock/test_unit'
+    WebMock.enable!
+
+    token_data = {
+      access_token: "xxxxx",
+      expires_in: 7200
+    }
+
+    stub_request(:post, "https://www.arcgis.com/sharing/rest/oauth2/token").to_return(:body => token_data.to_json)
+    # in ruby 1.9.3, WebMock generates this URL instead of a URL with the https protocol
+    stub_request(:post, "http://www.arcgis.com:443/sharing/rest/oauth2/token").to_return(:body => token_data.to_json)
+
+    Geocoder.configure(esri: {api_key: ['id','secret'], for_storage: true})
+    lookup = Geocoder::Lookup.get(:esri)
+
+    assert_equal token_data[:access_token], lookup.send(:token)
+
+    WebMock.reset!
+    WebMock.disable!
   end
 
   def test_results_component
@@ -123,7 +152,5 @@ class EsriTest < GeocoderTestCase
 
   def teardown
     Geocoder.configure(esri: {token: nil, for_storage: nil})
-    WebMock.reset!
-    WebMock.disable!
   end
 end

--- a/test/unit/lookups/esri_test.rb
+++ b/test/unit/lookups/esri_test.rb
@@ -33,8 +33,9 @@ class EsriTest < GeocoderTestCase
       access_token: "xxxxx",
       expires_in: 7200
     }
-    stub_request(:post, "https://www.arcgis.com/sharing/rest/oauth2/token").
-      to_return(:body => token_data.to_json)
+    stub_request(:post, "https://www.arcgis.com/sharing/rest/oauth2/token").to_return(:body => token_data.to_json)
+    # in ruby 1.9.3, WebMock generates this URL instead of a URL with the https protocol
+    stub_request(:post, "http://www.arcgis.com:443/sharing/rest/oauth2/token").to_return(:body => token_data.to_json)
 
     Geocoder.configure(esri: {api_key: ['id','secret'], for_storage: true})
     query = Geocoder::Query.new("Bluffton, SC")


### PR DESCRIPTION
Previously, the esri config object was being replaced when setting the token so the `for_storage` option was cleared out. This meant that anyone using the `api_key` (client credentials) method of authenticating as well as trying to set the `for_storage` option was unable to actually pass the parameter to the Esri geocoder, breaking their TOS.