### PR TITLE
adds test for esri token generation

### DIFF
--- a/test/unit/lookups/esri_test.rb
+++ b/test/unit/lookups/esri_test.rb
@@ -2,6 +2,22 @@
 require 'test_helper'
 require 'geocoder/esri_token'
 
+class Geocoder::EsriToken
+  class << self
+
+    alias_method :old_generate_token, :generate_token; 
+
+    # Stub the generate_token method when called with a specific client_id and client_secret
+    def generate_token(client_id, client_secret, expires=1440)
+      if client_id == "id" and client_secret == "secret"
+        "xxxxx"
+      else
+        self.old_generate_token client_id, client_secret, expires
+      end
+    end
+  end
+end
+
 class EsriTest < GeocoderTestCase
 
   def setup
@@ -22,6 +38,16 @@ class EsriTest < GeocoderTestCase
     query = Geocoder::Query.new("Bluffton, SC")
     lookup = Geocoder::Lookup.get(:esri)
     url = lookup.query_url(query)
+    assert_match /forStorage=true/, url
+    assert_match /token=xxxxx/, url
+  end
+
+  def test_query_for_geocode_with_client_credentials_for_storage
+    Geocoder.configure(esri: {api_key: ['id','secret'], for_storage: true})
+    query = Geocoder::Query.new("Bluffton, SC")
+    lookup = Geocoder::Lookup.get(:esri)
+    url = lookup.query_url(query)
+
     assert_match /forStorage=true/, url
     assert_match /token=xxxxx/, url
   end


### PR DESCRIPTION
there was previously no test of configuring the Esri geocoder with a client ID and secret. this adds a test for that, with a stub `generate_token` method to prevent the test from making an HTTP request to Esri.

Note that the test fails right now because of the bug in #1047 and re-introduced by https://github.com/alexreisner/geocoder/commit/1309ea63e9f9de56679f7c07027b487f92259a4d#diff-69b726dcd427393154984fe539912caeR61