### PR TITLE
fix merging esri config when generating a token

### DIFF
--- a/lib/geocoder/lookups/esri.rb
+++ b/lib/geocoder/lookups/esri.rb
@@ -58,7 +58,7 @@ module Geocoder::Lookup
 
     def fetch_and_save_token!
       token_instance = Geocoder::EsriToken.generate_token(*configuration.api_key)
-      Geocoder.configure(:esri => {:token => token_instance})
+      Geocoder.configure(:esri => Geocoder.config[:esri].merge({:token => token_instance}))
     end
   end
 end


### PR DESCRIPTION
This fixes the test added in #1053 by merging the new token with the old esri config.