### PR TITLE
Add Method for Merging Lookup Configuration

### DIFF
--- a/lib/geocoder/configuration.rb
+++ b/lib/geocoder/configuration.rb
@@ -38,6 +38,14 @@ module Geocoder
     data
   end
 
+  ##
+  # Merge the given hash into a lookup's existing configuration.
+  #
+  def self.merge_into_lookup_config(lookup_name, options)
+    base = Geocoder.config[lookup_name]
+    Geocoder.configure(lookup_name => base.merge(options))
+  end
+
   class Configuration
     include Singleton
 

--- a/lib/geocoder/lookups/esri.rb
+++ b/lib/geocoder/lookups/esri.rb
@@ -65,7 +65,7 @@ module Geocoder::Lookup
     end
 
     def save_token!(token_instance)
-      Geocoder.configure(:esri => Geocoder.config[:esri].merge({:token => token_instance}))
+      Geocoder.merge_into_lookup_config(:esri, token: token_instance)
     end
   end
 end

--- a/lib/geocoder/lookups/esri.rb
+++ b/lib/geocoder/lookups/esri.rb
@@ -48,7 +48,7 @@ module Geocoder::Lookup
     end
 
     def token
-      fetch_and_save_token! if !valid_token_configured? and configuration.api_key
+      create_and_save_token! if !valid_token_configured? and configuration.api_key
       configuration[:token].to_s unless configuration[:token].nil?
     end
 
@@ -56,8 +56,15 @@ module Geocoder::Lookup
       !configuration[:token].nil? and configuration[:token].active?
     end
 
-    def fetch_and_save_token!
-      token_instance = Geocoder::EsriToken.generate_token(*configuration.api_key)
+    def create_and_save_token!
+      save_token!(create_token)
+    end
+
+    def create_token
+      Geocoder::EsriToken.generate_token(*configuration.api_key)
+    end
+
+    def save_token!(token_instance)
       Geocoder.configure(:esri => Geocoder.config[:esri].merge({:token => token_instance}))
     end
   end

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -51,4 +51,23 @@ class ConfigurationTest < GeocoderTestCase
     # method option > per-model configuration
     assert_equal 111, v.distance_to([0,1], :km).round
   end
+
+  def test_merge_into_lookup_config
+    base = {
+      timeout: 5,
+      api_key: "xxx"
+    }
+    new = {
+      timeout: 10,
+      units: :km,
+    }
+    merged = {
+      timeout: 10, # overwritten
+      units: :km, # added
+      api_key: "xxx" # preserved
+    }
+    Geocoder.configure(google: base)
+    Geocoder.merge_into_lookup_config(:google, new)
+    assert_equal merged, Geocoder.config[:google]
+  end
 end


### PR DESCRIPTION
This functionality is currently implemented by the ESRI lookup but is potentially useful to other lookups as well.