### PR TITLE
adds test for esri token generation from client credentials

### DIFF
--- a/test/unit/lookups/esri_test.rb
+++ b/test/unit/lookups/esri_test.rb
@@ -29,18 +29,16 @@ class EsriTest < GeocoderTestCase
   def test_query_for_geocode_with_client_credentials_and_for_storage
     Geocoder.configure(esri: {api_key: ['id','secret'], for_storage: true})
 
-    Geocoder::EsriToken.instance_eval do
-      def generate_token(client_id, client_secret, expires=1440)
-        if client_id == "id" and client_secret == "secret"
-          "xxxxx"
-        else
-          nil
-        end
+    query = Geocoder::Query.new("Bluffton, SC")
+    lookup = Geocoder::Lookup.get(:esri)
+
+    lookup.instance_eval do
+      # redefine `create_token` to return a manually-created token
+      def create_token
+        "xxxxx"
       end
     end
 
-    query = Geocoder::Query.new("Bluffton, SC")
-    lookup = Geocoder::Lookup.get(:esri)
     url = lookup.query_url(query)
 
     assert_match /forStorage=true/, url

--- a/test/unit/lookups/esri_test.rb
+++ b/test/unit/lookups/esri_test.rb
@@ -26,7 +26,7 @@ class EsriTest < GeocoderTestCase
     assert_match /token=xxxxx/, url
   end
 
-  def test_query_for_geocode_with_client_credentials_and_for_storage
+  def test_token_generation_doesnt_overwrite_existing_config
     Geocoder.configure(esri: {api_key: ['id','secret'], for_storage: true})
 
     query = Geocoder::Query.new("Bluffton, SC")

--- a/test/unit/lookups/esri_test.rb
+++ b/test/unit/lookups/esri_test.rb
@@ -26,6 +26,27 @@ class EsriTest < GeocoderTestCase
     assert_match /token=xxxxx/, url
   end
 
+  def test_query_for_geocode_with_client_credentials_and_for_storage
+    Geocoder.configure(esri: {api_key: ['id','secret'], for_storage: true})
+
+    Geocoder::EsriToken.instance_eval do
+      def generate_token(client_id, client_secret, expires=1440)
+        if client_id == "id" and client_secret == "secret"
+          "xxxxx"
+        else
+          nil
+        end
+      end
+    end
+
+    query = Geocoder::Query.new("Bluffton, SC")
+    lookup = Geocoder::Lookup.get(:esri)
+    url = lookup.query_url(query)
+
+    assert_match /forStorage=true/, url
+    assert_match /token=xxxxx/, url
+  end
+
   def test_query_for_reverse_geocode
     query = Geocoder::Query.new([45.423733, -75.676333])
     lookup = Geocoder::Lookup.get(:esri)


### PR DESCRIPTION
This stubs the `generate_token` method only within this test. This brings the test coverage of `Geocoder::Lookup::Esri` closer to 100%.