### PR TITLE
add `source_country` parameter for esri geocoder

### DIFF
--- a/lib/geocoder/lookups/esri.rb
+++ b/lib/geocoder/lookups/esri.rb
@@ -44,6 +44,7 @@ module Geocoder::Lookup
       end
       params[:token] = token
       params[:forStorage] = configuration[:for_storage] if configuration[:for_storage]
+      params[:sourceCountry] = configuration[:source_country] if configuration[:source_country]
       params.merge(super)
     end
 

--- a/test/unit/lookups/esri_test.rb
+++ b/test/unit/lookups/esri_test.rb
@@ -16,6 +16,14 @@ class EsriTest < GeocoderTestCase
       res
   end
 
+  def test_query_for_geocode_with_source_country
+    Geocoder.configure(esri: {source_country: 'USA'})
+    query = Geocoder::Query.new("Bluffton, SC")
+    lookup = Geocoder::Lookup.get(:esri)
+    url = lookup.query_url(query)
+    assert_match /sourceCountry=USA/, url
+  end
+
   def test_query_for_geocode_with_token_and_for_storage
     token = Geocoder::EsriToken.new('xxxxx', Time.now + 1.day)
     Geocoder.configure(esri: {token: token, for_storage: true})


### PR DESCRIPTION
The Esri geocoder also takes a `sourceCountry` parameter which forces the geocoding requests to use a particular country's geocoder.

I originally thought about making a more significant change that would allow arbitrary parameters to be passed through to the request, but in reviewing the Esri [API docs](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-find.htm) there's really only this `sourceCountry` and the `forStorage` ones that make sense to set globally. The others would be better off being able to set per request, so I'll leave that for another time.