### PR TITLE
add configuration parameter to send a POST request

### DIFF
--- a/lib/geocoder/configuration.rb
+++ b/lib/geocoder/configuration.rb
@@ -56,6 +56,7 @@ module Geocoder
       :language,
       :http_headers,
       :use_https,
+      :use_post,
       :http_proxy,
       :https_proxy,
       :api_key,
@@ -102,6 +103,7 @@ module Geocoder
       @data[:language]     = :en         # ISO-639 language code
       @data[:http_headers] = {}          # HTTP headers for lookup
       @data[:use_https]    = false       # use HTTPS for lookup requests? (if supported)
+      @data[:use_post]     = false       # send POST request instead of GET
       @data[:http_proxy]   = nil         # HTTP proxy server (user:pass@host:port)
       @data[:https_proxy]  = nil         # HTTPS proxy server (user:pass@host:port)
       @data[:api_key]      = nil         # API key for geocoding service

--- a/lib/geocoder/lookups/base.rb
+++ b/lib/geocoder/lookups/base.rb
@@ -275,7 +275,7 @@ module Geocoder
         Geocoder.log(:debug, "Geocoder: HTTP request being made for #{uri.to_s}")
         http_client.start(uri.host, uri.port, use_ssl: use_ssl?, open_timeout: configuration.timeout, read_timeout: configuration.timeout) do |client|
           configure_ssl!(client) if use_ssl?
-          req = Net::HTTP::Get.new(uri.request_uri, configuration.http_headers)
+          req = create_http_request uri.request_uri, query
           if configuration.basic_auth[:user] and configuration.basic_auth[:password]
             req.basic_auth(
               configuration.basic_auth[:user],
@@ -288,6 +288,16 @@ module Geocoder
         raise Geocoder::LookupTimeout
       end
 
+      def create_http_request(request_uri, query)
+        if configuration.use_post
+          req = Net::HTTP::Post.new(request_uri, configuration.http_headers)
+          req.body = url_query_string(query)
+        else
+          req = Net::HTTP::Get.new(request_uri, configuration.http_headers)
+        end
+        req
+      end
+      
       def use_ssl?
         if supported_protocols == [:https]
           true

--- a/test/unit/lookup_test.rb
+++ b/test/unit/lookup_test.rb
@@ -160,4 +160,26 @@ class LookupTest < GeocoderTestCase
     assert_equal :google, Geocoder::Lookup::Google.new.handle
     assert_equal :geocoder_ca, Geocoder::Lookup::GeocoderCa.new.handle
   end
+
+  def test_get_request
+    token = Geocoder::EsriToken.new('xxxxx', Time.now + 86400)
+    Geocoder.configure(:token => token)
+    lookup = Geocoder::Lookup::Esri.new
+
+    query = Geocoder::Query.new('test location')
+    uri = URI.parse(lookup.query_url(query))
+    request = lookup.send(:create_http_request, uri.request_uri, query)
+    assert_equal "GET", request.method
+  end
+
+  def test_post_request
+    token = Geocoder::EsriToken.new('xxxxx', Time.now + 86400)
+    Geocoder.configure(:token => token, :use_post => true)
+    lookup = Geocoder::Lookup::Esri.new
+
+    query = Geocoder::Query.new('test location')
+    uri = URI.parse(lookup.query_url(query))
+    request = lookup.send(:create_http_request, uri.request_uri, query)
+    assert_equal "POST", request.method
+  end  
 end


### PR DESCRIPTION
since the Esri batch geocoder can generate requests that are potentially very large, it's better to set the request method to POST for those. this adds a configuration option so GET/POST can be used on any provider.