### PR TITLE
Change SmartyStreets Zipcode API

### DIFF
--- a/lib/geocoder/lookups/smarty_streets.rb
+++ b/lib/geocoder/lookups/smarty_streets.rb
@@ -12,8 +12,11 @@ module Geocoder::Lookup
     end
 
     def query_url(query)
-      path = zipcode_only?(query) ? "zipcode" : "street-address"
-      "#{protocol}://api.smartystreets.com/#{path}?#{url_query_string(query)}"
+      if zipcode_only?(query)
+        "#{protocol}://us-zipcode.api.smartystreets.com/lookup?#{url_query_string(query)}"
+      else
+        "#{protocol}://api.smartystreets.com/street-address?#{url_query_string(query)}"
+      end
     end
 
     # required by API as of 26 March 2015

--- a/test/unit/lookups/smarty_streets_test.rb
+++ b/test/unit/lookups/smarty_streets_test.rb
@@ -21,12 +21,12 @@ class SmartyStreetsTest < GeocoderTestCase
 
   def test_query_for_zipcode_geocode
     query = Geocoder::Query.new("22204")
-    assert_match(/api\.smartystreets\.com\/zipcode\?/, query.url)
+    assert_match(/us-zipcode\.api\.smartystreets\.com\/lookup\?/, query.url)
   end
 
   def test_query_for_zipfour_geocode
     query = Geocoder::Query.new("22204-1603")
-    assert_match(/api\.smartystreets\.com\/zipcode\?/, query.url)
+    assert_match(/us-zipcode\.api\.smartystreets\.com\/lookup\?/, query.url)
   end
 
   def test_smarty_streets_result_components


### PR DESCRIPTION
SmartyStreets is permanently changing their ZIP Code API endpoint by
**June 22 at 9am Mountain Time**.  The legacy API endpoint is available
until the 22nd.  http://status.smartystreets.com/incidents/4hjpfqh9q2k7

This change basically changes the API endpoint and updated the tests to
reflect the change.