### PR TITLE
Bug no method action dispatch request.include

### DIFF
--- a/lib/geocoder/request.rb
+++ b/lib/geocoder/request.rb
@@ -79,7 +79,7 @@ module Geocoder
 end
 
 if defined?(ActionDispatch::Request)
-  ActionDispatch::Request.include Geocoder::Request
+  ActionDispatch::Request.__send__(:include, Geocoder::Request)
 elsif defined?(Rack::Request)
   Rack::Request.include Geocoder::Request
 end

--- a/lib/geocoder/request.rb
+++ b/lib/geocoder/request.rb
@@ -81,5 +81,5 @@ end
 if defined?(ActionDispatch::Request)
   ActionDispatch::Request.__send__(:include, Geocoder::Request)
 elsif defined?(Rack::Request)
-  Rack::Request.include Geocoder::Request
+  Rack::Request.__send__(:include, Geocoder::Request)
 end


### PR DESCRIPTION
Maintains Ruby 2.0 compatibility in `Geocoder::Request` where `Module#include` is a private method.
Once pulled in this should fix #1066 

Thanks.