### PR TITLE
Add .ruby-version to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ pkg/*
 rdoc/*
 *.gem
 .bundle
+.ruby-version
 Gemfile.lock
 api_keys.yml
 test/geocoder_test.sqlite


### PR DESCRIPTION
…so I can use a .ruby-version file to control what version of Ruby I use to work on the project without risking accidentally committing the .ruby-version file.