### PR TITLE
more status codes from Google Maps API

### DIFF
--- a/lib/geocoder/exceptions.rb
+++ b/lib/geocoder/exceptions.rb
@@ -25,6 +25,12 @@ module Geocoder
   class InvalidRequest < Error
   end
 
+  class ZeroResults < Error
+  end
+
+  class UnknownError < Error
+  end
+
   class InvalidApiKey < Error
   end
 

--- a/lib/geocoder/lookups/google.rb
+++ b/lib/geocoder/lookups/google.rb
@@ -57,6 +57,12 @@ module Geocoder::Lookup
       when "INVALID_REQUEST"
         raise_error(Geocoder::InvalidRequest) ||
           Geocoder.log(:warn, "Google Geocoding API error: invalid request.")
+      when "ZERO_RESULTS"
+        raise_error(Geocoder::ZeroResults) ||
+          Geocoder.log(:warn, "Google Geocoding API error: zero results.")
+      when "UNKNOWN_ERROR"
+        raise_error(Geocoder::UnknownError) ||
+          Geocoder.log(:warn, "Google Geocoding API error: unknown error.")
       end
       return []
     end


### PR DESCRIPTION
This adds more status codes as shown in the Google Maps API Documentation (see status codes [here](https://developers.google.com/maps/documentation/geocoding/intro#StatusCodes)):

- `ZERO_RESULTS` indicates that the geocode was successful but returned no results. This may occur if the geocoder was passed a non-existent address.
- `UNKNOWN_ERROR` indicates that the request could not be processed due to a server error. The request may succeed if you try again.

Hope you can check! :)