### PR TITLE
Prevent rake task crash when BATCH not specified

### DIFF
--- a/lib/tasks/geocoder.rake
+++ b/lib/tasks/geocoder.rake
@@ -7,7 +7,7 @@ namespace :geocode do
     reverse = ENV['REVERSE'] || ENV['reverse']
     raise "Please specify a CLASS (model)" unless class_name
     klass = class_from_string(class_name)
-    batch = batch.to_i unless batch.nil?
+    batch = (batch.to_i unless batch.nil?) || 1000
     reverse = false unless reverse.to_s.downcase == 'true'
 
     if reverse


### PR DESCRIPTION
In Rails 5, `rake geocode:all` crashes:

```
$ rake geocode:all CLASS=Whatzit
rake aborted!
ArgumentError: comparison of Fixnum with nil failed
/Users/paul/.rvm/gems/ruby-2.2.2/gems/activerecord-5.0.0/lib/active_record/relation/batches.rb:217:in `<'
/Users/paul/.rvm/gems/ruby-2.2.2/gems/activerecord-5.0.0/lib/active_record/relation/batches.rb:217:in `block in in_batches'
/Users/paul/.rvm/gems/ruby-2.2.2/gems/activerecord-5.0.0/lib/active_record/relation/batches.rb:198:in `loop'
/Users/paul/.rvm/gems/ruby-2.2.2/gems/activerecord-5.0.0/lib/active_record/relation/batches.rb:198:in `in_batches'
/Users/paul/.rvm/gems/ruby-2.2.2/gems/activerecord-5.0.0/lib/active_record/relation/batches.rb:120:in `find_in_batches'
/Users/paul/.rvm/gems/ruby-2.2.2/gems/activerecord-5.0.0/lib/active_record/relation/batches.rb:58:in `find_each'
/Users/paul/.rvm/gems/ruby-2.2.2/gems/geocoder-1.2.2/lib/tasks/geocoder.rake:11:in `block (2 levels) in <top (required)>'
/Users/paul/.rvm/gems/ruby-2.2.2/gems/rake-11.2.2/exe/rake:27:in `<top (required)>'
/Users/paul/.rvm/gems/ruby-2.2.2/bin/ruby_executable_hooks:15:in `eval'
/Users/paul/.rvm/gems/ruby-2.2.2/bin/ruby_executable_hooks:15:in `<main>'
Tasks: TOP => geocode:all
(See full trace by running task with --trace)
```

The problem seems to be that `find_each` used to default the `batch:` param when it was explicitly set to nil, but now passes an explicit nil on through.

This patch fixes the issue by defaulting the batch size in the rake task.