### PR TITLE
always add geocoder to Rack::Request if defined

### DIFF
--- a/lib/geocoder/request.rb
+++ b/lib/geocoder/request.rb
@@ -78,8 +78,5 @@ module Geocoder
   end
 end
 
-if defined?(ActionDispatch::Request)
-  ActionDispatch::Request.__send__(:include, Geocoder::Request)
-elsif defined?(Rack::Request)
-  Rack::Request.__send__(:include, Geocoder::Request)
-end
+ActionDispatch::Request.__send__(:include, Geocoder::Request) if defined?(ActionDispatch::Request)
+Rack::Request.__send__(:include, Geocoder::Request) if defined?(Rack::Request)


### PR DESCRIPTION
Ever since the code change in #1061, if a Rack application loads both Rails and Sinatra simultaneously (e.g., both are included in the same middleware stack for handling different routes), then only `ActionDispatch::Request` will be enhanced with geocoder methods and not `Rack::Request`, causing `request#location` to be undefined in the Sinatra route. (My use-case is currently Rails 4.2, but presumably affects Rails 5 as well.)

The fix in this PR changes the `if ... elsif` conditional to instead use two separate conditionals.