### PR TITLE
Fix result of ipinfo.io for loopback address (127.0.0.1)

### DIFF
--- a/lib/geocoder/lookups/ipinfo_io.rb
+++ b/lib/geocoder/lookups/ipinfo_io.rb
@@ -42,7 +42,14 @@ module Geocoder::Lookup
     end
 
     def reserved_result(ip)
-      {"message" => "Input string is not a valid IP address", "code" => 401}
+      {
+        "ip"           => ip,
+        "city"         => "",
+        "region"       => "",
+        "country"      => "",
+        "loc"          => "0,0",
+        "postal"       => ""
+      }
     end
 
     def query_url_params(query)

--- a/lib/geocoder/results/ipinfo_io.rb
+++ b/lib/geocoder/results/ipinfo_io.rb
@@ -8,7 +8,7 @@ module Geocoder::Result
     end
 
     def coordinates
-      @data['loc'].split(",").map(&:to_f)
+      @data['loc'].to_s.split(",").map(&:to_f)
     end
 
     def city
@@ -36,7 +36,7 @@ module Geocoder::Result
     end
 
     def self.response_attributes
-      %w['ip', 'region', 'postal']
+      %w(ip region postal)
     end
 
     response_attributes.each do |a|

--- a/test/unit/lookups/ipinfo_io_test.rb
+++ b/test/unit/lookups/ipinfo_io_test.rb
@@ -22,4 +22,12 @@ class IpinfoIoTest < GeocoderTestCase
     assert_equal 0.0, result.latitude
     assert_equal "127.0.0.1", result.ip
   end
+
+  def test_ipinfo_io_extra_attributes
+    Geocoder.configure(:ip_lookup => :ipinfo_io, :use_https => true)
+    result = Geocoder.search("8.8.8.8").first
+    assert_equal "8.8.8.8", result.ip
+    assert_equal "California", result.region
+    assert_equal "94040", result.postal
+  end
 end

--- a/test/unit/lookups/ipinfo_io_test.rb
+++ b/test/unit/lookups/ipinfo_io_test.rb
@@ -14,4 +14,12 @@ class IpinfoIoTest < GeocoderTestCase
     query = Geocoder::Query.new("8.8.8.8")
     assert_match(/^https:/, query.url)
   end
+
+  def test_ipinfo_io_lookup_loopback_address
+    Geocoder.configure(:ip_lookup => :ipinfo_io, :use_https => true)
+    result = Geocoder.search("127.0.0.1").first
+    assert_equal 0.0, result.longitude
+    assert_equal 0.0, result.latitude
+    assert_equal "127.0.0.1", result.ip
+  end
 end


### PR DESCRIPTION
Patch https://github.com/alexreisner/geocoder/pull/997

When query loopback address using ipinfo.io,
```
Geocoder.search("127.0.0.1")
```

This error is raised because an invalid result is returned:

```
undefined method `split' for nil:NilClass
geocoder (1.3.7) lib/geocoder/results/ipinfo_io.rb, line 11
```

Changes:
- Returns a valid result when query loopback address in ipinfo.io
- Fix incorrect method definition for extra result attributes i.e. `result.ip`, `result.region`, `result.postal`