### PR TITLE
Allows radius to be a symbol representing a column in DB

### DIFF
--- a/test/db/migrate/001_create_test_schema.rb
+++ b/test/db/migrate/001_create_test_schema.rb
@@ -10,6 +10,7 @@ class CreateTestSchema < ActiveRecord::Migration
         t.column :address, :string
         t.column :latitude, :decimal, :precision => 16, :scale => 6
         t.column :longitude, :decimal, :precision => 16, :scale => 6
+        t.column :radius_column, :decimal, :precision => 16, :scale => 6
       end
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -75,6 +75,10 @@ else
         def primary_key
           :id
         end
+
+        def maximum(_field)
+          1.0
+        end
       end
     end
   end

--- a/test/unit/near_test.rb
+++ b/test/unit/near_test.rb
@@ -18,6 +18,13 @@ class NearTest < GeocoderTestCase
     assert_match(/BETWEEN \? AND \?$/, result[:conditions][0])
   end
 
+  def test_near_scope_options_includes_radius_column_max_radius
+    omit("Not applicable to unextended SQLite") if using_unextended_sqlite?
+
+    result = Place.send(:near_scope_options, 1.0, 2.0, :radius_column)
+    assert_match(/BETWEEN \? AND radius_column$/, result[:conditions][0])
+  end
+
   def test_near_scope_options_includes_radius_default_min_radius
     omit("Not applicable to unextended SQLite") if using_unextended_sqlite?
 


### PR DESCRIPTION
Related to #334 (Near search using column for radius) and #449 (Allow symbol to mean radius comes from a db column)

I decided to not change `.bounding_box` based on the reasons discussed on #449, but instead build the bounding box based on the maximum radius and simply "filter" the results based on the distance between the min_radius (defaults to 0.0) and whatever is stored in _radius_column_. The performance hit is dependent on how variable the radiuses stored in the DB are. 

Other concern discussed previously: **Security**. I haven't handled this one. But what I had in mind, was to compare the given `radius_column` to the model's column_names array: `Place.column_names.column_names.include?  radius_column.to_s`, but decided not to implement it until we discussed it further. 

I wasn't sure how to stub `.maximum` for ActiveRecord::Base. Don't hesitate correcting me on that one and pointing me in other directions for me to fix.

Finally, I didn't like how repeated the code look on the `if`/`else` and wrote this alternative implenetation instead, except it sacrificed readability. I decided to go with the original implementation instead:

``` ruby
conditions = [bounding_box_conditions + " AND (#{distance}) BETWEEN ? AND "]
if radius_column
  conditions[0] += radius_column.to_s
  conditions << min_radius
else
  conditions[0] += '?'
  conditions += [min_radius, radius]
end
```
