### PR TITLE
Update base.rb

### DIFF
--- a/lib/geocoder/lookups/base.rb
+++ b/lib/geocoder/lookups/base.rb
@@ -304,7 +304,7 @@ module Geocoder
 
       def check_api_key_configuration!(query)
         key_parts = query.lookup.required_api_key_parts
-        if key_parts.size > Array(configuration.api_key).size
+        if key_parts.any? { |key_part| key_part.blank? } || key_parts.size > Array(configuration.api_key).size
           parts_string = key_parts.size == 1 ? key_parts.first : key_parts
           raise Geocoder::ConfigurationError,
             "The #{query.lookup.name} API requires a key to be configured: " +


### PR DESCRIPTION
If a key exists but is empty and key is required, the same error should be raised.

If this is a wrong assumption, it's also possible to change the array of required keys to a has that also has property "required" per key.

The reasoning here is that where the keys are secret (like Google Premier) you do not want them in the code but in env or secret file, and then if it's missing in production or any other env there's no way of knowing.

Alternatively, it should not crash if the key is missing (today GooglePremier#url_safe_base64_decode would crash if nil is passed in)