### PR TITLE
Fix mapbox results

### DIFF
--- a/lib/geocoder/results/mapbox.rb
+++ b/lib/geocoder/results/mapbox.rb
@@ -16,27 +16,27 @@ module Geocoder::Result
     end
 
     def city
-      context.map { |c| c['text'] if c['id'] =~ /place/ }.compact.first
+      context_part('place')
     end
 
     def state
-      context.map { |c| c['text'] if c['id'] =~ /region/ }.compact.first
+      context_part('region')
     end
 
     alias_method :state_code, :state
 
     def postal_code
-      context.map { |c| c['text'] if c['id'] =~ /postcode/ }.compact.first
+      context_part('postcode')
     end
 
     def country
-      context.map { |c| c['text'] if c['id'] =~ /country/ }.compact.first
+      context_part('country')
     end
 
     alias_method :country_code, :country
 
     def neighborhood
-      context.map { |c| c['text'] if c['id'] =~ /neighborhood/ }.compact.first
+      context_part('neighborhood')
     end
 
     def address
@@ -44,6 +44,10 @@ module Geocoder::Result
     end
 
     private
+
+    def context_part(name)
+      context.map { |c| c['text'] if c['id'] =~ Regexp.new(name) }.compact.first
+    end
 
     def context
       Array(data['context'])

--- a/lib/geocoder/results/mapbox.rb
+++ b/lib/geocoder/results/mapbox.rb
@@ -4,15 +4,15 @@ module Geocoder::Result
   class Mapbox < Base
 
     def coordinates
-      @data["geometry"]["coordinates"].reverse.map(&:to_f)
+      data["geometry"]["coordinates"].reverse.map(&:to_f)
     end
 
     def place_name
-      @data['text']
+      data['text']
     end
 
     def street
-      @data['properties']['address']
+      data['properties']['address']
     end
 
     def city

--- a/lib/geocoder/results/mapbox.rb
+++ b/lib/geocoder/results/mapbox.rb
@@ -16,31 +16,37 @@ module Geocoder::Result
     end
 
     def city
-      @data['context'].map { |c| c['text'] if c['id'] =~ /place/ }.compact.first
+      context.map { |c| c['text'] if c['id'] =~ /place/ }.compact.first
     end
 
     def state
-      @data['context'].map { |c| c['text'] if c['id'] =~ /region/ }.compact.first
+      context.map { |c| c['text'] if c['id'] =~ /region/ }.compact.first
     end
 
     alias_method :state_code, :state
 
     def postal_code
-      @data['context'].map { |c| c['text'] if c['id'] =~ /postcode/ }.compact.first
+      context.map { |c| c['text'] if c['id'] =~ /postcode/ }.compact.first
     end
 
     def country
-      @data['context'].map { |c| c['text'] if c['id'] =~ /country/ }.compact.first
+      context.map { |c| c['text'] if c['id'] =~ /country/ }.compact.first
     end
 
     alias_method :country_code, :country
 
     def neighborhood
-      @data['context'].map { |c| c['text'] if c['id'] =~ /neighborhood/ }.compact.first
+      context.map { |c| c['text'] if c['id'] =~ /neighborhood/ }.compact.first
     end
 
     def address
       [place_name, street, city, state, postal_code, country].compact.join(", ")
+    end
+
+    private
+
+    def context
+      @data['context']
     end
   end
 end

--- a/lib/geocoder/results/mapbox.rb
+++ b/lib/geocoder/results/mapbox.rb
@@ -4,7 +4,7 @@ module Geocoder::Result
   class Mapbox < Base
 
     def coordinates
-      data["geometry"]["coordinates"].reverse.map(&:to_f)
+      data['geometry']['coordinates'].reverse.map(&:to_f)
     end
 
     def place_name
@@ -40,7 +40,7 @@ module Geocoder::Result
     end
 
     def address
-      [place_name, street, city, state, postal_code, country].compact.join(", ")
+      [place_name, street, city, state, postal_code, country].compact.join(', ')
     end
 
     private

--- a/lib/geocoder/results/mapbox.rb
+++ b/lib/geocoder/results/mapbox.rb
@@ -46,7 +46,7 @@ module Geocoder::Result
     private
 
     def context
-      @data['context']
+      Array(data['context'])
     end
   end
 end

--- a/test/fixtures/mapbox_Shanghai,_China
+++ b/test/fixtures/mapbox_Shanghai,_China
@@ -1,0 +1,224 @@
+{
+    "type": "FeatureCollection",
+        "query": [
+            "shanghai",
+        "china"
+        ],
+        "features": [
+        {
+            "id": "country.6702069377157440",
+            "type": "Feature",
+            "text": "China",
+            "place_name": "China",
+            "relevance": 0.49,
+            "properties": {
+                "wikidata": "Q148",
+                "short_code": "cn"
+            },
+            "bbox": [
+                73.499857014,
+            15.6816898058459,
+            134.772810006,
+            53.560710919
+            ],
+            "center": [
+                101.901875,
+            35.486703
+            ],
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    101.901875,
+                35.486703
+                ]
+            }
+        },
+        {
+            "id": "neighborhood.8146618069770140",
+            "type": "Feature",
+            "text": "Chinatown",
+            "place_name": "Chinatown, Washington, 20001, District of Columbia, United States",
+            "relevance": 0.49,
+            "properties": {
+
+            },
+            "bbox": [
+                -77.0265197753999,
+            38.8958426648877,
+            -77.0178665827466,
+            38.9031438069192
+            ],
+            "center": [
+                -77.021,
+            38.8998
+            ],
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -77.021,
+                38.8998
+                ]
+            },
+            "context": [
+            {
+                "id": "place.12334081418246050",
+                "text": "Washington",
+                "wikidata": "Q61"
+            },
+            {
+                "id": "postcode.3526019892841050",
+                "text": "20001"
+            },
+            {
+                "id": "region.6884744206035790",
+                "text": "District of Columbia",
+                "short_code": "US-DC",
+                "wikidata": "Q61"
+            },
+            {
+                "id": "country.12862386939497690",
+                "text": "United States",
+                "short_code": "us",
+                "wikidata": "Q30"
+            }
+            ]
+        },
+        {
+            "id": "neighborhood.8687109740770140",
+            "type": "Feature",
+            "text": "Chinatown",
+            "place_name": "Chinatown, San Francisco, 94108, California, United States",
+            "relevance": 0.49,
+            "properties": {
+
+            },
+            "bbox": [
+                -122.411564112065,
+            37.7895769681609,
+            -122.404174805,
+            37.7985673428131
+            ],
+            "center": [
+                -122.4071,
+            37.7943
+            ],
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -122.4071,
+                37.7943
+                ]
+            },
+            "context": [
+            {
+                "id": "place.17925508508361910",
+                "text": "San Francisco",
+                "wikidata": "Q62"
+            },
+            {
+                "id": "postcode.1814482917195520",
+                "text": "94108"
+            },
+            {
+                "id": "region.6020809690311220",
+                "text": "California",
+                "short_code": "US-CA",
+                "wikidata": "Q99"
+            },
+            {
+                "id": "country.12862386939497690",
+                "text": "United States",
+                "short_code": "us",
+                "wikidata": "Q30"
+            }
+            ]
+        },
+        {
+            "id": "region.7004037305164860",
+            "type": "Feature",
+            "text": "Chinandega",
+            "place_name": "Chinandega, Nicaragua",
+            "relevance": 0.49,
+            "properties": {
+                "short_code": "NI-CI",
+                "wikidata": "Q644024"
+            },
+            "bbox": [
+                -87.785656816,
+            12.423387369,
+            -86.654601813223,
+            13.293349936
+            ],
+            "center": [
+                -87.210612,
+            12.857407
+            ],
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -87.210612,
+                12.857407
+                ]
+            },
+            "context": [
+            {
+                "id": "country.11224608483080220",
+                "text": "Nicaragua",
+                "short_code": "ni",
+                "wikidata": "Q811"
+            }
+            ]
+        },
+        {
+            "id": "neighborhood.5866411034770140",
+            "type": "Feature",
+            "text": "Chinatown",
+            "place_name": "Chinatown, Portland, 97209, Oregon, United States",
+            "relevance": 0.49,
+            "properties": {
+
+            },
+            "bbox": [
+                -122.679673745277,
+            45.522452158706,
+            -122.664221513386,
+            45.530089952328
+            ],
+            "center": [
+                -122.673,
+            45.5257
+            ],
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -122.673,
+                45.5257
+                ]
+            },
+            "context": [
+            {
+                "id": "place.10101300842326360",
+                "text": "Portland",
+                "wikidata": "Q6106"
+            },
+            {
+                "id": "postcode.16394767032837600",
+                "text": "97209"
+            },
+            {
+                "id": "region.14077928225490090",
+                "text": "Oregon",
+                "short_code": "US-OR",
+                "wikidata": "Q824"
+            },
+            {
+                "id": "country.12862386939497690",
+                "text": "United States",
+                "short_code": "us",
+                "wikidata": "Q30"
+            }
+            ]
+        }
+        ],
+        "attribution": "© 2016 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service. (https://www.mapbox.com/about/maps/)"
+}

--- a/test/unit/result_test.rb
+++ b/test/unit/result_test.rb
@@ -82,6 +82,16 @@ class ResultTest < GeocoderTestCase
     end
   end
 
+  def test_mapbox_result_without_context
+    assert_nothing_raised do
+      Geocoder.configure(:lookup => :mapbox)
+      set_api_key!(:mapbox)
+      result = Geocoder.search("Shanghai, China")[0]
+      puts result.inspect
+      assert_equal nil, result.city
+    end
+  end
+
   private # ------------------------------------------------------------------
 
   def assert_result_has_required_attributes(result)


### PR DESCRIPTION
Some mapbox results come back without context. The mapbox result class was assuming that this context is always present. This patch changes that assumption.

Also, extract a couple of methods.