### PR TITLE
Fixed typo in google API Signup URL

### DIFF
--- a/gemfiles/Gemfile.ruby1.9.3
+++ b/gemfiles/Gemfile.ruby1.9.3
@@ -9,7 +9,7 @@ group :development, :test do
   gem 'rails'
   gem 'sqlite3'
   gem 'sqlite_ext', '~> 1.5.0'
-  gem 'pg'
+  gem 'pg', '0.18.4'
   gem 'mysql2', '~> 0.3.11'
   gem 'public_suffix', '1.4.6'
 


### PR DESCRIPTION
the URL had an extra slash in it in the readme