### PR TITLE
933 remove port from geocoder_spoofable_ip

### DIFF
--- a/lib/geocoder/request.rb
+++ b/lib/geocoder/request.rb
@@ -1,3 +1,5 @@
+require 'ipaddr'
+
 module Geocoder
   module Request
 
@@ -83,13 +85,16 @@ module Geocoder
     end
 
     def geocoder_reject_non_ipv4_addresses(ip_addresses)
-      reg = Regexp.new("^([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.([01]?\\d\\d?|2[0-4]\\d|25[0-5])$")
-      matched = []
+      ips = []
       for ip in ip_addresses
-        match = reg.match(ip)
-        matched << match.to_s if match
+        begin
+          valid_ip = IPAddr.new(ip)
+        rescue
+          valid_ip = false
+        end
+        ips << valid_ip.to_s if valid_ip
       end
-      return matched.any? ? matched : ip_addresses
+      return ips.any? ? ips : ip_addresses
     end
   end
 end

--- a/test/unit/request_test.rb
+++ b/test/unit/request_test.rb
@@ -66,4 +66,16 @@ class RequestTest < GeocoderTestCase
     assert_equal 'RD', req.safe_location.country_code
     assert_equal 'US', req.location.country_code
   end
+  def test_geocoder_remove_port_from_addresses
+    expected_ips = ['127.0.0.1', '127.0.0.2', '127.0.0.3']
+    ips = ['127.0.0.1:3000', '127.0.0.2:8080', '127.0.0.3:9292']
+    req = MockRequest.new()
+    assert_equal expected_ips, req.send(:geocoder_remove_port_from_addresses, ips)
+  end
+  def test_geocoder_reject_non_ipv4_addresses
+    expected_ips = ['127.0.0.1']
+    ips = ['127.0.0', '127.0.0.1', '127.0.0.2.0']
+    req = MockRequest.new()
+    assert_equal expected_ips, req.send(:geocoder_reject_non_ipv4_addresses, ips)
+  end
 end

--- a/test/unit/request_test.rb
+++ b/test/unit/request_test.rb
@@ -66,13 +66,25 @@ class RequestTest < GeocoderTestCase
     assert_equal 'RD', req.safe_location.country_code
     assert_equal 'US', req.location.country_code
   end
-  def test_geocoder_remove_port_from_addresses
+  def test_geocoder_remove_port_from_addresses_with_port
     expected_ips = ['127.0.0.1', '127.0.0.2', '127.0.0.3']
     ips = ['127.0.0.1:3000', '127.0.0.2:8080', '127.0.0.3:9292']
     req = MockRequest.new()
     assert_equal expected_ips, req.send(:geocoder_remove_port_from_addresses, ips)
   end
-  def test_geocoder_reject_non_ipv4_addresses
+  def test_geocoder_remove_port_from_addresses_without_port
+    expected_ips = ['127.0.0.1', '127.0.0.2', '127.0.0.3']
+    ips = ['127.0.0.1', '127.0.0.2', '127.0.0.3']
+    req = MockRequest.new()
+    assert_equal expected_ips, req.send(:geocoder_remove_port_from_addresses, ips)
+  end
+  def test_geocoder_reject_non_ipv4_addresses_with_good_ips
+    expected_ips = ['127.0.0.1', '127.0.0.2', '127.0.0.3']
+    ips = ['127.0.0.1', '127.0.0.2', '127.0.0.3']
+    req = MockRequest.new()
+    assert_equal expected_ips, req.send(:geocoder_reject_non_ipv4_addresses, ips)
+  end
+  def test_geocoder_reject_non_ipv4_addresses_with_bad_ips
     expected_ips = ['127.0.0.1']
     ips = ['127.0.0', '127.0.0.1', '127.0.0.2.0']
     req = MockRequest.new()


### PR DESCRIPTION
Hello. This PR is about the issue #933. 
I created `geocoder_remove_port_from_addresses(ip_addresses)` and `geocoder_reject_non_ipv4_addresses(ip_addresses)` to insure that the `ip_addresses` contains the valid ip address without port number. Then these two method are called in `geocoder_spoofable_ip` method.
I added tests for the cases when the `ip_addresses` includes port numbers and invalid ip addresses.