### PR TITLE
Update smarty streets search results coordinates method to return nil 

### DIFF
--- a/lib/geocoder/results/smarty_streets.rb
+++ b/lib/geocoder/results/smarty_streets.rb
@@ -3,8 +3,14 @@ require 'geocoder/lookups/base'
 module Geocoder::Result
   class SmartyStreets < Base
     def coordinates
-      %w(latitude longitude).map do |i|
+      result = %w(latitude longitude).map do |i|
         zipcode_endpoint? ? zipcodes.first[i] : metadata[i]
+      end
+
+      if result.compact.empty?
+        nil
+      else
+        result
       end
     end
 

--- a/test/fixtures/smarty_streets_96628
+++ b/test/fixtures/smarty_streets_96628
@@ -1,0 +1,1 @@
+[{"input_index":0,"city_states":[{"city":"FPO","state_abbreviation":"AP","state":"ArmedForcesPacific","mailable_city":true}],"zipcodes":[{"zipcode":"96628","zipcode_type":"M","default_city":"Fpo","county_fips":"00000","county_name":"None","state_abbreviation":"AP","state":"ArmedForcesPacific","precision":"None"}]}]

--- a/test/unit/lookups/smarty_streets_test.rb
+++ b/test/unit/lookups/smarty_streets_test.rb
@@ -47,6 +47,11 @@ class SmartyStreetsTest < GeocoderTestCase
     assert result.zipcode_endpoint?
   end
 
+  def test_smarty_streets_when_longitude_latitude_does_not_exist
+    result = Geocoder.search("96628").first
+    assert_equal nil, result.coordinates
+  end
+
   def test_no_results
     results = Geocoder.search("no results")
     assert_equal 0, results.length


### PR DESCRIPTION
Currently when running a search via `Geocoder.coordinates("a zip code")` for certain zip codes (eg 96628) that exist, but for some reason doesn't exist in the Smarty Streets database, the coordinates method returns `[nil,nil]` which is not very useful. What would be more useful is if the method returns an actual nil value. These changes enable that.