### PR TITLE
Add support for query params in mapbox lookup.

### DIFF
--- a/lib/geocoder/lookups/mapbox.rb
+++ b/lib/geocoder/lookups/mapbox.rb
@@ -9,7 +9,8 @@ module Geocoder::Lookup
     end
 
     def query_url(query)
-      "#{protocol}://api.mapbox.com/geocoding/v5/#{dataset}/#{url_query_string(query)}.json?access_token=#{configuration.api_key}"
+      path = "#{mapbox_search_term(query)}.json?#{url_query_string(query)}"
+      "#{protocol}://api.mapbox.com/geocoding/v5/#{dataset}/#{path}"
     end
 
     private # ---------------------------------------------------------------
@@ -25,7 +26,11 @@ module Geocoder::Lookup
       end
     end
 
-    def url_query_string(query)
+    def query_url_params(query)
+      {access_token: configuration.api_key}.merge(super(query))
+    end
+
+    def mapbox_search_term(query)
       require 'cgi' unless defined?(CGI) && defined?(CGI.escape)
       if query.reverse_geocode?
         lat,lon = query.coordinates

--- a/test/unit/lookups/mapbox_test.rb
+++ b/test/unit/lookups/mapbox_test.rb
@@ -14,6 +14,12 @@ class MapboxTest < GeocoderTestCase
     assert_equal "https://api.mapbox.com/geocoding/v5/mapbox.places/Leadville%2C+CO.json?access_token=abc123", query.url
   end
 
+  def test_url_contains_params
+    Geocoder.configure(mapbox: {api_key: "abc123"})
+    query = Geocoder::Query.new("Leadville, CO", {params: {country: 'CN'}})
+    assert_equal "https://api.mapbox.com/geocoding/v5/mapbox.places/Leadville%2C+CO.json?access_token=abc123&country=CN", query.url
+  end
+
   def test_result_components
     result = Geocoder.search("Madison Square Garden, New York, NY").first
     assert_equal [40.749688, -73.991566], result.coordinates


### PR DESCRIPTION
The Mapbox  geocoding api supports additional parameters such as country. This PR enables geocoder to set these parameters for Mapbox lookups per query.