### PR TITLE
Add store#keys to Caching object requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -883,8 +883,8 @@ This example uses Redis, but the cache store can be any object that supports the
 
 * `store#[](key)` or `#get` or `#read` - retrieves a value
 * `store#[]=(key, value)` or `#set` or `#write` - stores a value
-* `store#keys` - retrieves array of existing keys
 * `store#del(url)` - deletes a value
+* `store#keys` - (Optional) Returns array of keys. Used if you wish to expire the entire cache (see below).
 
 Even a plain Ruby hash will work, though it's not a great choice (cleared out when app is restarted, not shared between app instances, etc).
 

--- a/README.md
+++ b/README.md
@@ -883,6 +883,7 @@ This example uses Redis, but the cache store can be any object that supports the
 
 * `store#[](key)` or `#get` or `#read` - retrieves a value
 * `store#[]=(key, value)` or `#set` or `#write` - stores a value
+* `store#keys` - retrieves array of existing keys
 * `store#del(url)` - deletes a value
 
 Even a plain Ruby hash will work, though it's not a great choice (cleared out when app is restarted, not shared between app instances, etc).

--- a/lib/geocoder/cache.rb
+++ b/lib/geocoder/cache.rb
@@ -40,6 +40,7 @@ module Geocoder
     #
     def expire(url)
       if url == :all
+        raise(NoMethodError, "The cache store must implement `#keys` when using `:all`") unless store.respond_to?(:keys)
         urls.each{ |u| expire(u) }
       else
         expire_single_url(url)

--- a/lib/geocoder/cache.rb
+++ b/lib/geocoder/cache.rb
@@ -40,8 +40,11 @@ module Geocoder
     #
     def expire(url)
       if url == :all
-        raise(NoMethodError, "The cache store must implement `#keys` when using `:all`") unless store.respond_to?(:keys)
-        urls.each{ |u| expire(u) }
+        if store.respond_to?(:keys)
+          urls.each{ |u| expire(u) }
+        else
+          raise(NoMethodError, "The Geocoder cache store must implement `#keys` for `expire(:all)` to work")
+        end
       else
         expire_single_url(url)
       end


### PR DESCRIPTION
A `NoMethodError` exception was raised when I tried expiring the cache while using a PORO Cache <-> DB adapter that did not implement `#keys`.

As an aside, sorry if it was inappropriate to submit the PR without creating an issue first, but it seemed unnecessary to create an issue for such a small change solely to documentation. I'm interested if you feel the same way, as I'm relatively new to contributing in the wild.