### PR TITLE
return state_code instead of alias state

### DIFF
--- a/lib/geocoder/results/opencagedata.rb
+++ b/lib/geocoder/results/opencagedata.rb
@@ -36,12 +36,13 @@ module Geocoder::Result
       @data['components']['village']
     end
 
-
     def state
       @data['components']['state']
     end
 
-    alias_method :state_code, :state
+    def state_code
+      @data['components']['state_code']
+    end
 
     def postal_code
       @data['components']['postcode'].to_s

--- a/test/fixtures/opencagedata_madison_square_garden
+++ b/test/fixtures/opencagedata_madison_square_garden
@@ -49,6 +49,7 @@
             "city": "New York City",
             "stadium" : "Madison Square Garden",
             "state" : "New York",
+            "state_code" : "NY",
             "state_district" : "New York City"
          },
          "confidence" : 10,


### PR DESCRIPTION
Return the state_code instead of using state for state_code.

NOTE: OpenCage Data only supports state codes for certain countries, at the moment. See the list [here](https://github.com/OpenCageData/address-formatting/blob/master/conf/state_codes.yaml).