### PR TITLE
Allow to limit the objects that will be geocoded by rake task

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ Geocoder will print warnings if you exceed the rate limit for your geocoding ser
 
     rake geocode:all CLASS=YourModel SLEEP=0.25 BATCH=100
 
+To avoid per-day limit issues (for example if you are trying to geocode thousands of objects and don't want to reach the limit), you can add a `LIMIT` option. Warning: This will ignore the `BATCH` value if provided.
+
+    rake geocode:all CLASS=YourModel LIMIT=1000
+
 ### Avoiding Unnecessary API Requests
 
 Geocoding only needs to be performed under certain conditions. To avoid unnecessary work (and quota usage) you will probably want to geocode an object only when:

--- a/lib/tasks/geocoder.rake
+++ b/lib/tasks/geocoder.rake
@@ -1,4 +1,4 @@
-require "geocoder/models/mongoid" 
+require "geocoder/models/mongoid"
 
 namespace :geocode do
   desc "Geocode all objects without coordinates."
@@ -7,6 +7,7 @@ namespace :geocode do
     sleep_timer = ENV['SLEEP'] || ENV['sleep']
     batch = ENV['BATCH'] || ENV['batch']
     reverse = ENV['REVERSE'] || ENV['reverse']
+    limit = ENV['LIMIT'] || ENV['limit']
     raise "Please specify a CLASS (model)" unless class_name
     klass = class_from_string(class_name)
     batch = (batch.to_i unless batch.nil?) || 1000
@@ -20,13 +21,20 @@ namespace :geocode do
     }
 
     scope = reverse ? klass.not_reverse_geocoded : klass.not_geocoded
+    scope = scope.limit(limit) if limit
     if orm == 'mongoid'
       scope.each do |obj|
         geocode_record.call(obj)
       end
     elsif orm == 'active_record'
-      scope.find_each(batch_size: batch) do |obj|
-        geocode_record.call(obj)
+      if limit
+        scope.each do |obj|
+          geocode_record.call(obj)
+        end
+      else
+        scope.find_each(batch_size: batch) do |obj|
+          geocode_record.call(obj)
+        end
       end
     end
 


### PR DESCRIPTION
That's a proposal to limit the objects that will be geocoded by the rake task, using an environment variable (LIMIT).

It could be useful if you want to geocode thousands of objects and don't want to reach the per-day limits of the geocoding services (for example if you are running the rake task in production and you are using the service for other porpoises.

It won't use batches when LIMIT is used, because _limit_ and _find_each_ don't work together.

Comments and/or corrections are very welcome :)