### PR TITLE
Use https for freegeoip

### DIFF
--- a/README.md
+++ b/README.md
@@ -737,7 +737,7 @@ This uses the PostcodeAnywhere UK Geocode service, this will geocode any string 
 * **Documentation**: http://github.com/fiorix/freegeoip/blob/master/README.md
 * **Terms of Service**: ?
 * **Limitations**: ?
-* **Notes**: If you are [running your own local instance of the FreeGeoIP service](https://github.com/fiorix/freegeoip) you can configure the host like this: `Geocoder.configure(freegeoip: {host: "..."})`.
+* **Notes**: If you are [running your own local instance of the FreeGeoIP service](https://github.com/fiorix/freegeoip) you can configure the host like this: `Geocoder.configure(freegeoip: {host: "...", use_https: false})`.
 
 #### Pointpin (`:pointpin`)
 

--- a/lib/geocoder/lookups/freegeoip.rb
+++ b/lib/geocoder/lookups/freegeoip.rb
@@ -10,7 +10,7 @@ module Geocoder::Lookup
     
     def supported_protocols
       if configuration[:host]
-        configuration[:use_https] ? [:https] : [:http]
+        [:http, :https]
       else
         # use https for default host
         [:https]

--- a/lib/geocoder/lookups/freegeoip.rb
+++ b/lib/geocoder/lookups/freegeoip.rb
@@ -9,7 +9,12 @@ module Geocoder::Lookup
     end
     
     def supported_protocols
-      [:http]
+      if configuration[:host]
+        configuration[:use_https] ? [:https] : [:http]
+      else
+        # use https for default host
+        [:https]
+      end
     end
 
     def query_url(query)


### PR DESCRIPTION
Requests to freegeoip.io now works only with https. So changed protocol for default :host, while continuing to use http for custom :host and allowing to set protocol with :use_https for custom :host