### PR TITLE
freegeoip now redirects http to https

### DIFF
--- a/lib/geocoder/lookups/freegeoip.rb
+++ b/lib/geocoder/lookups/freegeoip.rb
@@ -7,9 +7,9 @@ module Geocoder::Lookup
     def name
       "FreeGeoIP"
     end
-    
+
     def supported_protocols
-      [:http]
+      [:https]
     end
 
     def query_url(query)


### PR DESCRIPTION
I noticed I was getting 301 responses for ip geocoding, it looks like freegeoip.io
redirects plain http requests to https now.

```
$ curl -I -X GET  http://freegeoip.io/json/github.com
HTTP/1.1 301 Moved Permanently
Server: nginx/1.11.8
Date: Tue, 16 May 2017 09:20:58 GMT
Content-Type: text/html
Content-Length: 185
Connection: keep-alive
Location: https://freegeoip.io/json/github.com
```

I'm not sure if this is just this specific hosted instance of freegeoip
or if people hosting their own might want to disable https, so maybe we
could make it configurable.