### PR TITLE
add connreset to network errors

### DIFF
--- a/lib/geocoder/lookups/base.rb
+++ b/lib/geocoder/lookups/base.rb
@@ -286,7 +286,7 @@ module Geocoder
         end
       rescue Timeout::Error
         raise Geocoder::LookupTimeout
-      rescue Errno::EHOSTUNREACH, Errno::ETIMEDOUT, Errno::ENETUNREACH
+      rescue Errno::EHOSTUNREACH, Errno::ETIMEDOUT, Errno::ENETUNREACH, Errno::ECONNRESET
         raise Geocoder::NetworkError
       end
 


### PR DESCRIPTION
if you're behind a firewall, you'll get
Errno::ECONNRESET (Connection reset by peer - SSL_connect)