### PR TITLE
Add source code and changelog links to gemspec

### DIFF
--- a/geocoder.gemspec
+++ b/geocoder.gemspec
@@ -18,4 +18,9 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.executables = ["geocode"]
   s.license     = 'MIT'
+
+  s.metadata = {
+    'source_code_uri' => 'https://github.com/alexreisner/geocoder',
+    'changelog_uri'   => 'https://github.com/alexreisner/geocoder/blob/master/CHANGELOG.md'
+  }
 end


### PR DESCRIPTION
Makes it easy to programatically find the source code and changelog for `geocoder`, using the rubygems API. More details on the direction of travel for gemspecs is [here](https://github.com/rubygems/rubygems.org/issues/1127) and [here](https://github.com/rubygems/rubygems.org/pull/1234), and the current state is [here](https://github.com/rubygems/rubygems/blob/master/lib/rubygems/specification.rb).

(My interest in this is so that [Dependabot](https://dependabot.com) can find a link to the `geocoder` source code when it creates PRs. Without that link, we generate PRs like [this one](https://github.com/greysteil/onebody/pull/8), rather than PRs like [this one](https://github.com/greysteil/onebody/pull/12).)