### PR TITLE
add #city_district, #state_district, #neighbourhood to Nominatim response

### DIFF
--- a/lib/geocoder/results/nominatim.rb
+++ b/lib/geocoder/results/nominatim.rb
@@ -64,6 +64,18 @@ module Geocoder::Result
       @data['address']['suburb']
     end
 
+    def city_district
+      @data['address']['city_district']
+    end
+
+    def state_district
+      @data['address']['state_district']
+    end
+
+    def neighbourhood
+      @data['address']['neighbourhood']
+    end
+
     def coordinates
       [@data['lat'].to_f, @data['lon'].to_f]
     end

--- a/test/fixtures/nominatim_cologne_cathedral_cologne_germany
+++ b/test/fixtures/nominatim_cologne_cathedral_cologne_germany
@@ -1,0 +1,36 @@
+[
+  {
+    "place_id": "61478831",
+    "licence": "Data © OpenStreetMap contributors, ODbL 1.0. http://www.openstreetmap.org/copyright",
+    "osm_type": "way",
+    "osm_id": "4532022",
+    "boundingbox": [
+      "50.9409217",
+      "50.9417618",
+      "6.9570708",
+      "6.9591382"
+    ],
+    "lat": "50.94134445",
+    "lon": "6.95812085888689",
+    "display_name": "Cologne Cathedral, 4, Domkloster, Kunibertsviertel, Altstadt-Nord, Innenstadt, Cologne, Cologne Government Region, North Rhine-Westphalia, 50667, Germany",
+    "class": "amenity",
+    "type": "place_of_worship",
+    "importance": 0.70253720393793,
+    "icon": "http://nominatim.openstreetmap.org/images/mapicons/place_of_worship_unknown3.p.20.png",
+    "address": {
+      "place_of_worship": "Cologne Cathedral",
+      "house_number": "4",
+      "pedestrian": "Domkloster",
+      "neighbourhood": "Kunibertsviertel",
+      "suburb": "Altstadt-Nord",
+      "city_district": "Innenstadt",
+      "city": "Cologne",
+      "county": "Cologne",
+      "state_district": "Cologne Government Region",
+      "state": "North Rhine-Westphalia",
+      "postcode": "50667",
+      "country": "Germany",
+      "country_code": "de"
+    }
+  }
+]

--- a/test/unit/lookups/nominatim_test.rb
+++ b/test/unit/lookups/nominatim_test.rb
@@ -11,6 +11,9 @@ class NominatimTest < GeocoderTestCase
   def test_result_components
     result = Geocoder.search("Madison Square Garden, New York, NY").first
     assert_equal "10001", result.postal_code
+    assert_nil result.city_district
+    assert_nil result.state_district
+    assert_nil result.neighbourhood
     assert_equal "Madison Square Garden, West 31st Street, Long Island City, New York City, New York, 10001, United States of America", result.address
   end
 
@@ -18,6 +21,17 @@ class NominatimTest < GeocoderTestCase
     result = Geocoder.search("Madison Square Garden, New York, NY").first
     assert_equal [40.749828338623, -73.9943389892578, 40.7511596679688, -73.9926528930664],
       result.viewport
+  end
+
+  def test_city_state_district
+    result = Geocoder.search("cologne cathedral cologne germany").first
+    assert_equal "Innenstadt", result.city_district
+    assert_equal "Cologne Government Region", result.state_district
+  end
+
+  def test_neighbourhood
+    result = Geocoder.search("cologne cathedral cologne germany").first
+    assert_equal "Kunibertsviertel", result.neighbourhood
   end
 
   def test_host_configuration


### PR DESCRIPTION
First of all, thanks a lot for this gem!
I've been using it for a while and recently switched to Nominatim. I noticed a few address parts were missing, namely:
- state_district
- neighbourhood
- city_district

Those are often present in Nominatim responses but not always, so I added a fixture and specs.

Thanks for checking!