### PR TITLE
Add time_zone to Opencagedata result

### DIFF
--- a/lib/geocoder/results/opencagedata.rb
+++ b/lib/geocoder/results/opencagedata.rb
@@ -75,6 +75,15 @@ module Geocoder::Result
       [south, west, north, east]
     end
 
+    def time_zone
+      # The OpenCage API documentation states that `annotations` is available
+      # "when possible" https://geocoder.opencagedata.com/api#annotations
+      @data
+        .fetch('annotations', {})
+        .fetch('timezone', {})
+        .fetch('name', nil)
+    end
+
     def self.response_attributes
       %w[boundingbox license 
         formatted stadium]

--- a/test/unit/lookups/opencagedata_test.rb
+++ b/test/unit/lookups/opencagedata_test.rb
@@ -60,7 +60,10 @@ class OpencagedataTest < GeocoderTestCase
     assert_match(/\bq=45.423733%2C-75.676333\b/, query.url)
   end
 
-
+  def test_opencagedata_time_zone
+    result = Geocoder.search("Madison Square Garden, New York, NY").first
+    assert_equal "America/New_York", result.time_zone
+  end
 
   def test_raises_exception_when_invalid_request
     Geocoder.configure(always_raise: [Geocoder::InvalidRequest])


### PR DESCRIPTION
The OpenCage API [may include a time zone in the response](https://geocoder.opencagedata.com/api#annotations). This PR adds `#time_zone` to the `Opencagedata` result so it can be accessed when it's available.

`Geocoder::Result#time_zone` has been previously implemented in  [`Maxmind`](https://github.com/alexreisner/geocoder/blob/6589b9b2cd6d1cdda06bd1f598fe9ad070d8e5a9/lib/geocoder/results/maxmind.rb#L49) and [`Pointpin`](https://github.com/alexreisner/geocoder/blob/6589b9b2cd6d1cdda06bd1f598fe9ad070d8e5a9/lib/geocoder/results/pointpin.rb#L31) so hopefully it makes sense to add it to `Opencagedata` too.
