### PR TITLE
Removing ruby versions that are not supported anymore from our travis…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 sudo: false
 env:
-  global: 
+  global:
     - JRUBY_OPTS=--2.0
   matrix:
     - DB=
@@ -10,8 +10,6 @@ env:
     - DB=postgres
     - DB=mysql
 rvm:
-  - 1.9.3
-  - 2.0.0
   - 2.1.2
   - 2.2.2
   - 2.3.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ env:
     - DB=postgres
     - DB=mysql
 rvm:
-  - 2.1.2
   - 2.2.2
   - 2.3.0
   - jruby-19mode


### PR DESCRIPTION
… matrix

```
WARNING: Please be aware that you just installed a ruby that is no longer maintained (2014-02-23), for a list of maintained rubies visit:

    http://bugs.ruby-lang.org/projects/ruby/wiki/ReleaseEngineering

Please consider upgrading to ruby-2.2.1 which will have all of the latest security patches.
```