### PR TITLE
Compress cache values larger than 1 Kilobyte

### DIFF
--- a/README.md
+++ b/README.md
@@ -943,6 +943,12 @@ You can also set a custom prefix to be used for cache keys:
 
 By default the prefix is `geocoder:`
 
+In some situations it helps a lot to **compress the cache values**. Geocoder will do that for values larger than 1 Kilobyte, provided that you enable cache compression inside your configuration:
+
+```ruby
+Geocoder.configure(:cache_compress => true)
+```
+
 If you need to expire cached content:
 
     Geocoder::Lookup.get(Geocoder.config[:lookup]).cache.expire(:all)  # expire cached results for current Lookup

--- a/lib/geocoder/configuration.rb
+++ b/lib/geocoder/configuration.rb
@@ -61,6 +61,7 @@ module Geocoder
       :api_key,
       :cache,
       :cache_prefix,
+      :cache_compress,
       :always_raise,
       :units,
       :distances,
@@ -96,20 +97,37 @@ module Geocoder
     def set_defaults
 
       # geocoding options
-      @data[:timeout]      = 3           # geocoding service timeout (secs)
-      @data[:lookup]       = :google     # name of street address geocoding service (symbol)
-      @data[:ip_lookup]    = :freegeoip  # name of IP address geocoding service (symbol)
-      @data[:language]     = :en         # ISO-639 language code
-      @data[:http_headers] = {}          # HTTP headers for lookup
-      @data[:use_https]    = false       # use HTTPS for lookup requests? (if supported)
-      @data[:http_proxy]   = nil         # HTTP proxy server (user:pass@host:port)
-      @data[:https_proxy]  = nil         # HTTPS proxy server (user:pass@host:port)
-      @data[:api_key]      = nil         # API key for geocoding service
-      @data[:cache]        = nil         # cache object (must respond to #[], #[]=, and #keys)
-      @data[:cache_prefix] = "geocoder:" # prefix (string) to use for all cache keys
-      @data[:basic_auth]   = {}          # user and password for basic auth ({:user => "user", :password => "password"})
-      @data[:logger]       = :kernel     # :kernel or Logger instance
-      @data[:kernel_logger_level] = ::Logger::WARN # log level, if kernel logger is used
+
+      # geocoding service timeout (secs)
+      @data[:timeout] = 3
+      # name of street address geocoding service (symbol)
+      @data[:lookup] = :google
+      # name of IP address geocoding service (symbol)
+      @data[:ip_lookup] = :freegeoip
+      # ISO-639 language code
+      @data[:language] = :en
+      # HTTP headers for lookup
+      @data[:http_headers] = {}
+      # use HTTPS for lookup requests? (if supported)
+      @data[:use_https] = false
+      # HTTP proxy server (user:pass@host:port)
+      @data[:http_proxy] = nil
+      # HTTPS proxy server (user:pass@host:port)
+      @data[:https_proxy] = nil
+      # API key for geocoding service
+      @data[:api_key] = nil
+      # cache object (must respond to #[], #[]=, and #keys)
+      @data[:cache] = nil
+      # prefix (string) to use for all cache keys
+      @data[:cache_prefix] = "geocoder:"
+      # compress cache values larger than 1KB
+      @data[:cache_compress] = false
+      # user and password for basic auth ({:user => "user", :password => "password"})
+      @data[:basic_auth] = {}
+      # :kernel or Logger instance
+      @data[:logger] = :kernel
+      # log level, if kernel logger is used
+      @data[:kernel_logger_level] = ::Logger::WARN
 
       # exceptions that should not be rescued by default
       # (if you want to implement custom error handling);

--- a/lib/geocoder/lookups/base.rb
+++ b/lib/geocoder/lookups/base.rb
@@ -81,7 +81,7 @@ module Geocoder
       #
       def cache
         if @cache.nil? and store = configuration.cache
-          @cache = Cache.new(store, configuration.cache_prefix)
+          @cache = Cache.new(store, configuration.cache_prefix, compress: configuration.cache_compress)
         end
         @cache
       end

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -70,4 +70,30 @@ class ConfigurationTest < GeocoderTestCase
     Geocoder.merge_into_lookup_config(:google, new)
     assert_equal merged, Geocoder.config[:google]
   end
+
+  def test_enable_cache_compression
+    # Lookups are static so we need to remove the cache before this test
+    Geocoder::Lookup.get(:google).instance_variable_set(:@cache, nil)
+
+    store = {}
+    Geocoder.configure(:cache => store, :cache_compress => true, :lookup => :google)
+    value = "a" * 1024
+
+    Geocoder::Lookup.get(:google).cache["key"] = value
+
+    assert_equal "geocoder/compressed;#{Zlib::Deflate.deflate(value)}", store["geocoder:key"]
+  end
+
+  def test_disable_cache_compression
+    # Lookups are static so we need to remove the cache before this test
+    Geocoder::Lookup.get(:google).instance_variable_set(:@cache, nil)
+
+    store = {}
+    Geocoder.configure(:cache => store, :cache_compress => false, :lookup => :google)
+    value = "a" * 1024
+
+    Geocoder::Lookup.get(:google).cache["key"] = value
+
+    assert_equal value, store["geocoder:key"]
+  end
 end


### PR DESCRIPTION
We've been struggling with containing our geocoder cache under decent limits as some of the lookup responses tend to be very verbose. I recently discovered that Rails is actually [compressing cache values](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/cache.rb#L739) beyond a certain size and has been doing so for quite some time (they've recently lowered the threshold from 16Kb to 1Kb).

So I thought that this would be a great improvement to geocoder. Compression is fairly cheap nowadays, especially because we're not dealing with huge documents here. And the fact that most (all?) of the lookups are delivering JSON helps quite a lot.

My implementation is inspired by the Rails implementation, with some simplifications:

- I'm not *marhsaling* anything because we're only dealing with Strings here.
- The problem of figuring out if a value was compressed or not: Rails solves this by wrapping the cached value inside an object (`Entry`) which they *marshal* again, but I've decided to just prepend compressed values with that *marker* thingy. I've done so for simplicity (it's also faster and easier to read when looking inside your cache store), but it comes with the downside of this bit more rigid structure.

I left the option *disabled* by default.

I'd love to see this a part of geocoder. Let me know what you think :)