### PR TITLE
Provide ipdata.co as a lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -856,6 +856,18 @@ This uses the PostcodeAnywhere UK Geocode service, this will geocode any string 
 * **Documentation**: https://db-ip.com/api/doc.php
 * **Terms of Service**: https://db-ip.com/tos.php
 
+#### Ipdata.co (`:ipdata_co`)
+
+* **API key**: optional, see: https://ipdata.co/pricing.html
+* **Quota**: 1500/day (up to 600k with paid API keys)
+* **Region**: world
+* **SSL support**: yes
+* **Languages**: English
+* **Documentation**: https://ipdata.co/docs.html
+* **Terms of Service**: https://ipdata.co/terms.html
+* **Limitations**: ?
+
+
 ### IP Address Local Database Services
 
 #### MaxMind Local (`:maxmind_local`) - EXPERIMENTAL

--- a/lib/geocoder/lookup.rb
+++ b/lib/geocoder/lookup.rb
@@ -71,6 +71,7 @@ module Geocoder
         :maxmind_geoip2,
         :ipinfo_io,
         :ipapi_com,
+        :ipdata_co,
         :db_ip_com
       ]
     end

--- a/lib/geocoder/lookups/ipdata_co.rb
+++ b/lib/geocoder/lookups/ipdata_co.rb
@@ -43,5 +43,14 @@ module Geocoder::Lookup
     def host
       "api.ipdata.co"
     end
+
+    def check_response_for_errors!(response)
+      if response.code.to_i == 403
+        raise_error(Geocoder::RequestDenied) ||
+          Geocoder.log(:warn, "Geocoding API error: 403 API key does not exist")
+      else
+        super(response)
+      end
+    end
   end
 end

--- a/lib/geocoder/lookups/ipdata_co.rb
+++ b/lib/geocoder/lookups/ipdata_co.rb
@@ -19,7 +19,7 @@ module Geocoder::Lookup
     private # ---------------------------------------------------------------
 
     def results(query)
-      Geocoder.configure(:http_headers => { "api-key" => configuration.api_key }) if configuration.api_key
+      Geocoder.configure(:ipdata_co => {:http_headers => { "api-key" => configuration.api_key }}) if configuration.api_key
       # don't look up a loopback address, just return the stored result
       return [reserved_result(query.text)] if query.loopback_ip_address?
       # note: Ipdata.co returns plain text on bad request

--- a/lib/geocoder/lookups/ipdata_co.rb
+++ b/lib/geocoder/lookups/ipdata_co.rb
@@ -1,0 +1,51 @@
+require 'geocoder/lookups/base'
+require 'geocoder/results/ipdata_co'
+
+module Geocoder::Lookup
+  class IpdataCo < Base
+
+    def name
+      "ipdata.co"
+    end
+
+    def supported_protocols
+      [:https]
+    end
+
+    def query_url(query)
+      "#{protocol}://#{host}/#{query.sanitized_text}"
+    end
+
+    private # ---------------------------------------------------------------
+
+    def parse_raw_data(raw_data)
+      raw_data.match(/^<html><title>404/) ? nil : super(raw_data)
+    end
+
+    def results(query)
+      # don't look up a loopback address, just return the stored result
+      return [reserved_result(query.text)] if query.loopback_ip_address?
+      # note: Ipdata.co returns plain text on bad request
+      (doc = fetch_data(query)) ? [doc] : []
+    end
+
+    def reserved_result(ip)
+      {
+        "ip"           => ip,
+        "city"         => "",
+        "region_code"  => "",
+        "region_name"  => "",
+        "metrocode"    => "",
+        "zipcode"      => "",
+        "latitude"     => "0",
+        "longitude"    => "0",
+        "country_name" => "Reserved",
+        "country_code" => "RD"
+      }
+    end
+
+    def host
+      "api.ipdata.co"
+    end
+  end
+end

--- a/lib/geocoder/lookups/ipdata_co.rb
+++ b/lib/geocoder/lookups/ipdata_co.rb
@@ -18,10 +18,6 @@ module Geocoder::Lookup
 
     private # ---------------------------------------------------------------
 
-    def parse_raw_data(raw_data)
-      raw_data.match(/^<html><title>404/) ? nil : super(raw_data)
-    end
-
     def results(query)
       # don't look up a loopback address, just return the stored result
       return [reserved_result(query.text)] if query.loopback_ip_address?

--- a/lib/geocoder/lookups/ipdata_co.rb
+++ b/lib/geocoder/lookups/ipdata_co.rb
@@ -19,6 +19,7 @@ module Geocoder::Lookup
     private # ---------------------------------------------------------------
 
     def results(query)
+      Geocoder.configure(:http_headers => { "api-key" => configuration.api_key }) if configuration.api_key
       # don't look up a loopback address, just return the stored result
       return [reserved_result(query.text)] if query.loopback_ip_address?
       # note: Ipdata.co returns plain text on bad request

--- a/lib/geocoder/results/ipdata_co.rb
+++ b/lib/geocoder/results/ipdata_co.rb
@@ -1,0 +1,45 @@
+require 'geocoder/results/base'
+
+module Geocoder::Result
+  class IpdataCo < Base
+
+    def address(format = :full)
+      s = state_code.to_s == "" ? "" : ", #{state_code}"
+      "#{city}#{s} #{postal_code}, #{country}".sub(/^[ ,]*/, "")
+    end
+
+    def city
+      @data['city']
+    end
+
+    def state
+      @data['region']
+    end
+
+    def state_code
+      @data['region_code']
+    end
+
+    def country
+      @data['country_name']
+    end
+
+    def country_code
+      @data['country_code']
+    end
+
+    def postal_code
+      @data['postal']
+    end
+
+    def self.response_attributes
+      %w[ip asn organisation currency currency_symbol calling_code flag time_zone is_eu]
+    end
+
+    response_attributes.each do |a|
+      define_method a do
+        @data[a]
+      end
+    end
+  end
+end

--- a/test/fixtures/ipdata_co_74_200_247_59
+++ b/test/fixtures/ipdata_co_74_200_247_59
@@ -1,0 +1,24 @@
+{
+    "ip": "74.200.247.59",
+    "city": "Jersey City",
+    "region": "New Jersey",
+    "region_code": "NJ",
+    "country_name": "United States",
+    "country_code": "US",
+    "continent_name": "North America",
+    "continent_code": "NA",
+    "latitude": 40.7209,
+    "longitude": -74.0468,
+    "asn": "AS22576",
+    "organisation": "DataPipe, Inc.",
+    "postal": "07302",
+    "currency": "USD",
+    "currency_symbol": "$",
+    "calling_code": "1",
+    "flag": "https://ipdata.co/flags/us.png",
+    "time_zone": "America/New_York",
+    "is_eu": false,
+    "suspicious_factors": {
+        "is_tor": false
+    }
+}

--- a/test/fixtures/ipdata_co_8_8_8
+++ b/test/fixtures/ipdata_co_8_8_8
@@ -1,0 +1,1 @@
+8.8.8 does not appear to be an IPv4 or IPv6 address

--- a/test/fixtures/ipdata_co_no_results
+++ b/test/fixtures/ipdata_co_no_results
@@ -1,0 +1,1 @@
+0.0.0 does not appear to be an IPv4 or IPv6 address

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -373,6 +373,14 @@ module Geocoder
       end
     end
 
+    require 'geocoder/lookups/ipdata_co'
+    class IpdataCo
+      private
+      def default_fixture_filename
+        "ipdata_co_74_200_247_59"
+      end
+    end
+
     require 'geocoder/lookups/ban_data_gouv_fr'
     class BanDataGouvFr
       private

--- a/test/unit/error_handling_test.rb
+++ b/test/unit/error_handling_test.rb
@@ -19,7 +19,7 @@ class ErrorHandlingTest < GeocoderTestCase
 
   def test_always_raise_response_parse_error
     Geocoder.configure(:always_raise => [Geocoder::ResponseParseError])
-    [:freegeoip, :google, :okf].each do |l|
+    [:freegeoip, :google, :ipdata_co, :okf].each do |l|
       lookup = Geocoder::Lookup.get(l)
       set_api_key!(l)
       assert_raises Geocoder::ResponseParseError do
@@ -29,7 +29,7 @@ class ErrorHandlingTest < GeocoderTestCase
   end
 
   def test_never_raise_response_parse_error
-    [:freegeoip, :google, :okf].each do |l|
+    [:freegeoip, :google, :ipdata_co, :okf].each do |l|
       lookup = Geocoder::Lookup.get(l)
       set_api_key!(l)
       silence_warnings do

--- a/test/unit/lookup_test.rb
+++ b/test/unit/lookup_test.rb
@@ -24,7 +24,7 @@ class LookupTest < GeocoderTestCase
 
   def test_query_url_contains_values_in_params_hash
     Geocoder::Lookup.all_services_except_test.each do |l|
-      next if [:freegeoip, :maxmind_local, :telize, :pointpin, :geoip2, :maxmind_geoip2, :mapbox, :ipinfo_io, :ipapi_com].include? l # does not use query string
+      next if [:freegeoip, :maxmind_local, :telize, :pointpin, :geoip2, :maxmind_geoip2, :mapbox, :ipdata_co, :ipinfo_io, :ipapi_com].include? l # does not use query string
       set_api_key!(l)
       url = Geocoder::Lookup.get(l).query_url(Geocoder::Query.new(
         "test", :params => {:one_in_the_hand => "two in the bush"}

--- a/test/unit/lookups/ipdata_co_test.rb
+++ b/test/unit/lookups/ipdata_co_test.rb
@@ -32,4 +32,23 @@ class IpdataCoTest < GeocoderTestCase
         lookup.send(:check_response_for_errors!, response)
     end
   end
+
+  def test_api_key
+    Geocoder.configure(:api_key => 'XXXX')
+
+    # HACK: run the code once to add the api key to the HTTP request headers
+    Geocoder.search('8.8.8.8')
+    # It's really hard to 'un-monkey-patch' the base lookup class here
+
+    require 'webmock/test_unit'
+    WebMock.enable!
+    stubbed_request = WebMock.stub_request(:get, "https://api.ipdata.co/8.8.8.8").with(headers: {'api-key' => 'XXXX'}).to_return(status: 200)
+
+    g = Geocoder::Lookup::IpdataCo.new
+    g.send(:actual_make_api_request, Geocoder::Query.new('8.8.8.8'))
+    assert_requested(stubbed_request)
+
+    WebMock.reset!
+    WebMock.disable!
+  end
 end

--- a/test/unit/lookups/ipdata_co_test.rb
+++ b/test/unit/lookups/ipdata_co_test.rb
@@ -12,8 +12,16 @@ class IpdataCoTest < GeocoderTestCase
     assert result.is_a?(Geocoder::Result::IpdataCo)
   end
 
+  def test_invalid_json
+    Geocoder.configure(:always_raise => [Geocoder::ResponseParseError])
+    assert_raise Geocoder::ResponseParseError do
+      Geocoder.search("8.8.8", ip_address: true)
+    end
+  end
+
   def test_result_components
     result = Geocoder.search("74.200.247.59").first
     assert_equal "Jersey City, NJ 07302, United States", result.address
   end
+
 end

--- a/test/unit/lookups/ipdata_co_test.rb
+++ b/test/unit/lookups/ipdata_co_test.rb
@@ -32,23 +32,4 @@ class IpdataCoTest < GeocoderTestCase
         lookup.send(:check_response_for_errors!, response)
     end
   end
-
-  def test_api_key
-    Geocoder.configure(:api_key => 'XXXX')
-
-    # HACK: run the code once to add the api key to the HTTP request headers
-    Geocoder.search('8.8.8.8')
-    # It's really hard to 'un-monkey-patch' the base lookup class here
-
-    require 'webmock/test_unit'
-    WebMock.enable!
-    stubbed_request = WebMock.stub_request(:get, "https://api.ipdata.co/8.8.8.8").with(headers: {'api-key' => 'XXXX'}).to_return(status: 200)
-
-    g = Geocoder::Lookup::IpdataCo.new
-    g.send(:actual_make_api_request, Geocoder::Query.new('8.8.8.8'))
-    assert_requested(stubbed_request)
-
-    WebMock.reset!
-    WebMock.disable!
-  end
 end

--- a/test/unit/lookups/ipdata_co_test.rb
+++ b/test/unit/lookups/ipdata_co_test.rb
@@ -1,0 +1,19 @@
+# encoding: utf-8
+require 'test_helper'
+
+class IpdataCoTest < GeocoderTestCase
+
+  def setup
+    Geocoder.configure(ip_lookup: :ipdata_co)
+  end
+
+  def test_result_on_ip_address_search
+    result = Geocoder.search("74.200.247.59").first
+    assert result.is_a?(Geocoder::Result::IpdataCo)
+  end
+
+  def test_result_components
+    result = Geocoder.search("74.200.247.59").first
+    assert_equal "Jersey City, NJ 07302, United States", result.address
+  end
+end

--- a/test/unit/lookups/ipdata_co_test.rb
+++ b/test/unit/lookups/ipdata_co_test.rb
@@ -24,4 +24,12 @@ class IpdataCoTest < GeocoderTestCase
     assert_equal "Jersey City, NJ 07302, United States", result.address
   end
 
+  def test_not_authorized
+    Geocoder.configure(always_raise: [Geocoder::RequestDenied])
+    lookup = Geocoder::Lookup.get(:ipdata_co)
+      assert_raises Geocoder::RequestDenied do
+        response = MockHttpResponse.new(code: 403)
+        lookup.send(:check_response_for_errors!, response)
+    end
+  end
 end


### PR DESCRIPTION
Hello everybody!

Here's another ip->geolocation endpoint. Most of it is inspired ~copy&pasted~ by the freegeoip example.

Side notes:
1) I see a lot of deprecation warnings when in run `rake test`
2) There is a failing spec on the latest commit of the master branch: 
```
===============================================================================================================================================================================================
/home/robert/Development/Ruby/geocoder/test/unit/lookups/yandex_test.rb:29:in `test_yandex_query_url_contains_bbox'
     26:       "Some Intersection",
     27:       :bounds => [[40.0, -120.0], [39.0, -121.0]]
     28:     ))
  => 29:     assert_match(/bbox=40.0+%2C-120.0+%7E39.0+%2C-121.0+/, url)
     30:   end
     31: end
Failure: test_yandex_query_url_contains_bbox(YandexTest):
  </bbox=40.0+%2C-120.0+%7E39.0+%2C-121.0+/> was expected to be =~
  <"https://geocode-maps.yandex.ru/1.x/?bbox=40.000000%2C-120.000000~39.000000%2C-121.000000&format=json&geocode=Some+Intersection&key=%5B%22auti-id%22%2C+%22auth-token%22%5D&plng=en">.
==============================================================================================================================================================================================
```
when I replace `%7E` with `~` the test runs fine. I guess, it's because the API has changed since the last time the master was built?

