### PR TITLE
Fix Travis CI build errors. Closes #1224

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ gemfile:
   - gemfiles/Gemfile.rails3.2
   - gemfiles/Gemfile.rails4.1
   - gemfiles/Gemfile.rails5.0
+before_install:
+  - which bundle >/dev/null 2>&1 || gem install bundler
 matrix:
   exclude:
     - rvm: 1.9.3

--- a/Gemfile
+++ b/Gemfile
@@ -31,14 +31,14 @@ group :test do
   gem 'webmock'
 
   platforms :ruby do
-    gem 'pg'
+    gem 'pg', '~> 0.11'
     gem 'mysql2', '~> 0.3.11'
   end
 
   platforms :jruby do
     gem 'jdbc-mysql'
     gem 'jdbc-sqlite3'
-    gem 'activerecord-jdbcpostgresql-adapter'
+    gem 'activerecord-jdbcpostgresql-adapter', '~> 1.3.0'
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -32,7 +32,7 @@ namespace :db do
 
     desc 'Drop the MySQL test databases'
     task :drop do
-      `mysqladmin --user=#{config['mysql']['username']} -f drop #{config['mysql']['database']}`
+      `mysql --user=#{config['mysql']['username']} -e "DROP DATABASE IF EXISTS #{config['mysql']['database']}"`
     end
   end
 
@@ -44,7 +44,7 @@ namespace :db do
 
     desc 'Drop the PostgreSQL test databases'
     task :drop do
-      `dropdb #{config['postgres']['database']}`
+      `dropdb --if-exists #{config['postgres']['database']}`
     end
   end
 

--- a/gemfiles/Gemfile.rails3.2
+++ b/gemfiles/Gemfile.rails3.2
@@ -31,13 +31,13 @@ group :test do
   gem 'webmock'
 
   platforms :ruby do
-    gem 'pg'
+    gem 'pg', '~> 0.11'
     gem 'mysql2', '~> 0.3.11'
   end
 
   platforms :jruby do
     gem 'jdbc-mysql'
     gem 'jdbc-sqlite3'
-    gem 'activerecord-jdbcpostgresql-adapter'
+    gem 'activerecord-jdbcpostgresql-adapter', '~> 1.3.0'
   end
 end

--- a/gemfiles/Gemfile.rails4.1
+++ b/gemfiles/Gemfile.rails4.1
@@ -31,13 +31,13 @@ group :test do
   gem 'webmock'
 
   platforms :ruby do
-    gem 'pg'
+    gem 'pg', '~> 0.11'
     gem 'mysql2', '~> 0.3.11'
   end
 
   platforms :jruby do
     gem 'jdbc-mysql'
     gem 'jdbc-sqlite3'
-    gem 'activerecord-jdbcpostgresql-adapter'
+    gem 'activerecord-jdbcpostgresql-adapter', '~> 1.3.0'
   end
 end

--- a/gemfiles/Gemfile.rails5.0
+++ b/gemfiles/Gemfile.rails5.0
@@ -31,7 +31,7 @@ group :test do
   gem 'webmock'
 
   platforms :ruby do
-    gem 'pg'
+    gem 'pg', '~> 0.18'
     gem 'mysql2', '~> 0.3.11'
   end
 


### PR DESCRIPTION
Closes #1224. There were a few main causes:

* bundler was missing on jruby-19mode in Travis CI's image so I slightly modified a suggested fix from here: https://github.com/travis-ci/travis-ci/issues/5578#issuecomment-180445244
* the `pg` gem released a new 1.0.0 version yesterday which caused issues with [Rails versions < 5 requiring `~> 0.11` at runtime](https://github.com/rails/rails/blob/0cad778c2605a5204a05a9f1dbd3344e39f248d8/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L13), and [Rails 5 requiring `~> 0.18`](https://github.com/rails/rails/blob/71f4758c50fca5220429365c23b014458e7341f6/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L2) (figuring this out was slightly complicated by ruby/rake#247)
* the `activerecord-jdbc-adapter` gem released version 50.0 semi-recently, which should only be used by Rails 5+

Also, I don't know whether the intention is for the Gemfile in the root of the project to run agains the latest version of Rails or not, but `mongoid` being pinned to 2.6.0 is forcing it to select Rails 3, which is why I had to apply the version restriction on `activerecord-jdbcpostgresql-adapter` there to get the tests to pass.