### PR TITLE
OSMNames Lookup

### DIFF
--- a/lib/geocoder/lookup.rb
+++ b/lib/geocoder/lookup.rb
@@ -52,7 +52,8 @@ module Geocoder
         :ban_data_gouv_fr,
         :test,
         :latlon,
-        :amap
+        :amap,
+        :osmnames
       ]
     end
 

--- a/lib/geocoder/results/osmnames.rb
+++ b/lib/geocoder/results/osmnames.rb
@@ -1,0 +1,56 @@
+require 'geocoder/results/base'
+
+module Geocoder::Result
+  class Osmnames < Base
+    def address
+      @data['display_name']
+    end
+
+    def coordinates
+      [@data['lat'].to_f, @data['lon'].to_f]
+    end
+
+    def viewport
+      west, south, east, north = @data['boundingbox'].map(&:to_f)
+      [south, west, north, east]
+    end
+
+    def state
+      @data['state']
+    end
+    alias_method :state_code, :state
+
+    def place_class
+      @data['class']
+    end
+
+    def place_type
+      @data['type']
+    end
+
+    def postal_code
+      ''
+    end
+
+    def country_code
+      @data['country_code']
+    end
+
+    def country
+      @data['country']
+    end
+
+    def self.response_attributes
+      %w[house_number street city name osm_id osm_type boundingbox place_rank
+      importance county rank name_suffix]
+    end
+
+    response_attributes.each do |a|
+      unless method_defined?(a)
+        define_method a do
+          @data[a]
+        end
+      end
+    end
+  end
+end

--- a/test/fixtures/osmnames_invalid_request
+++ b/test/fixtures/osmnames_invalid_request
@@ -1,0 +1,7 @@
+{
+  "count": 20,
+    "startIndex": 0,
+    "message": "Invalid attribute value.",
+    "totalResults": 0,
+    "results": []
+}

--- a/test/fixtures/osmnames_madison_square_garden
+++ b/test/fixtures/osmnames_madison_square_garden
@@ -1,0 +1,40 @@
+{
+  "count": 20,
+  "nextIndex": 20,
+  "startIndex": 0,
+  "totalResults": 8000,
+  "results": [
+    {
+      "wikipedia": "en:New York City",
+      "rank": 628616.9375,
+      "county": "",
+      "street": "",
+      "wikidata": "Q60",
+      "country_code": "us",
+      "osm_id": "175905",
+      "housenumbers": "",
+      "id": 64,
+      "city": "New York City",
+      "display_name": "New York City, New York, United States of America",
+      "lon": -73.878418,
+      "state": "New York",
+      "boundingbox": [
+        -74.259087,
+        40.477398,
+        -73.70018,
+        40.91618
+      ],
+      "type": "city",
+      "importance": 0.782928,
+      "lat": 40.693073,
+      "class": "place",
+      "name": "New York City",
+      "country": "United States of America",
+      "name_suffix": "New York, US",
+      "osm_type": "relation",
+      "place_rank": 16,
+      "alternative_names": "New York,Nova York,Nueva York,NYC"
+    }
+
+  ]
+}

--- a/test/fixtures/osmnames_no_results
+++ b/test/fixtures/osmnames_no_results
@@ -1,0 +1,6 @@
+{
+  "count": 20,
+  "startIndex": 0,
+  "totalResults": 0,
+  "results": []
+}

--- a/test/unit/lookups/osmnames_test.rb
+++ b/test/unit/lookups/osmnames_test.rb
@@ -1,0 +1,63 @@
+# encoding: utf-8
+require 'test_helper'
+
+class OsmnamesTest < GeocoderTestCase
+  def setup
+    Geocoder.configure(lookup: :osmnames)
+    set_api_key!(:osmnames)
+  end
+
+  def test_url_contains_api_key
+    Geocoder.configure(osmnames: {api_key: 'abc123'})
+    query = Geocoder::Query.new('test')
+    assert_includes query.url, 'key=abc123'
+  end
+
+  def test_url_contains_query_base
+    query = Geocoder::Query.new("Madison Square Garden, New York, NY")
+    assert_includes query.url, 'https://geocoder.tilehosting.com/q/Madison%20Square%20Garden,%20New%20York,%20NY.js'
+  end
+
+  def test_url_contains_country_code
+    query = Geocoder::Query.new("test", country_code: 'US')
+    assert_includes query.url, 'https://geocoder.tilehosting.com/us/q/'
+  end
+
+  def test_result_components
+    result = Geocoder.search('Madison Square Garden, New York, NY').first
+    assert_equal [40.693073, -73.878418], result.coordinates
+    assert_equal 'New York City, New York, United States of America', result.address
+    assert_equal 'New York', result.state
+    assert_equal 'New York City', result.city
+    assert_equal 'us', result.country_code
+  end
+
+  def test_result_for_reverse_geocode
+    result = Geocoder.search('-73.878418, 40.693073').first
+    assert_equal 'New York City, New York, United States of America', result.address
+    assert_equal 'New York', result.state
+    assert_equal 'New York City', result.city
+    assert_equal 'us', result.country_code
+  end
+
+  def test_url_for_reverse_geocode
+    query = Geocoder::Query.new("-73.878418, 40.693073")
+    assert_includes query.url, 'https://geocoder.tilehosting.com/r/-73.878418/40.693073.js'
+  end
+
+  def test_result_viewport
+    result = Geocoder.search("Madison Square Garden, New York, NY").first
+    assert_equal [40.477398, -74.259087, 40.91618, -73.70018], result.viewport
+  end
+
+  def test_no_results
+    assert_equal [], Geocoder.search("no results")
+  end
+
+  def test_raises_exception_when_return_message_error
+    Geocoder.configure(always_raise: [Geocoder::InvalidRequest])
+    assert_raises Geocoder::InvalidRequest.new("Invalid attribute value.") do
+      Geocoder.search("invalid request")
+    end
+  end
+end


### PR DESCRIPTION
This adds a lookup for OSMNames (http://osmnames.org/api/)

This service is hosted by https://www.tilehosting.com/ but can be found as an open-source project here: https://github.com/klokantech/osmnames-sphinxsearch