### PR TITLE
Make #near_scope_options public for Rails 5.2

### DIFF
--- a/lib/geocoder/stores/active_record.rb
+++ b/lib/geocoder/stores/active_record.rb
@@ -87,8 +87,6 @@ module Geocoder::Store
         end
       end
 
-      private # ----------------------------------------------------------------
-
       ##
       # Get options hash suitable for passing to ActiveRecord.find to get
       # records within a radius (in kilometers) of the given point.
@@ -167,6 +165,8 @@ module Geocoder::Store
           :order => options.include?(:order) ? options[:order] : "#{distance_column} ASC"
         }
       end
+
+      private # ----------------------------------------------------------------
 
       ##
       # SQL for calculating distance based on the current database's


### PR DESCRIPTION
Rails 5.2 changed the receiver within a scope from `klass` to `relation`. With that, we no longer have private access to `Geocoder::Store::ActiveRecord#near_scope_options`, and so must make it public.

see: https://github.com/rails/rails/pull/29301

Closes: #1247