### PR TITLE
Explain that 20 is default radius for near()

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,10 +156,10 @@ Please use MongoDB's [geospatial query language](https://docs.mongodb.org/manual
 
 To find objects by location, use the following scopes:
 
-    Venue.near('Omaha, NE, US', 20)    # venues within 20 miles of Omaha
-    Venue.near([40.71, -100.23], 20)    # venues within 20 miles of a point
-    Venue.near([40.71, -100.23], 20, :units => :km)
-                                       # venues within 20 kilometres of a point
+    Venue.near('Omaha, NE, US')        # venues within 20 (default) miles of Omaha
+    Venue.near([40.71, -100.23], 50)   # venues within 40 miles of a point
+    Venue.near([40.71, -100.23], 50, :units => :km)
+                                       # venues within 40 kilometres of a point
     Venue.geocoded                     # venues with coordinates
     Venue.not_geocoded                 # venues without coordinates
 

--- a/README.md
+++ b/README.md
@@ -157,9 +157,9 @@ Please use MongoDB's [geospatial query language](https://docs.mongodb.org/manual
 To find objects by location, use the following scopes:
 
     Venue.near('Omaha, NE, US')        # venues within 20 (default) miles of Omaha
-    Venue.near([40.71, -100.23], 50)   # venues within 40 miles of a point
+    Venue.near([40.71, -100.23], 50)   # venues within 50 miles of a point
     Venue.near([40.71, -100.23], 50, :units => :km)
-                                       # venues within 40 kilometres of a point
+                                       # venues within 50 kilometres of a point
     Venue.geocoded                     # venues with coordinates
     Venue.not_geocoded                 # venues without coordinates
 


### PR DESCRIPTION
20 was used as an example radius value in the README for near(), but it isn't explicitly mentioned that it's the default. I had to look through the code to find out, and found it here:
https://github.com/alexreisner/geocoder/blob/bab2e367880b02505dea077951bfada987e2c93d/lib/geocoder/stores/active_record.rb#L117

It would be nice if the README was clearer.