### PR TITLE
Update Geocodio to v1.3

### DIFF
--- a/lib/geocoder/lookups/geocodio.rb
+++ b/lib/geocoder/lookups/geocodio.rb
@@ -10,7 +10,7 @@ module Geocoder::Lookup
 
     def query_url(query)
       path = query.reverse_geocode? ? "reverse" : "geocode"
-      "#{protocol}://api.geocod.io/v1.2/#{path}?#{url_query_string(query)}"
+      "#{protocol}://api.geocod.io/v1.3/#{path}?#{url_query_string(query)}"
     end
 
     def results(query)
@@ -35,7 +35,8 @@ module Geocoder::Lookup
     def query_url_params(query)
       {
         :api_key => configuration.api_key,
-        :q => query.sanitized_text
+        :q => query.sanitized_text,
+        :fields => "timezone"
       }.merge(super)
     end
   end

--- a/lib/geocoder/lookups/geocodio.rb
+++ b/lib/geocoder/lookups/geocodio.rb
@@ -35,8 +35,7 @@ module Geocoder::Lookup
     def query_url_params(query)
       {
         :api_key => configuration.api_key,
-        :q => query.sanitized_text,
-        :fields => "timezone"
+        :q => query.sanitized_text
       }.merge(super)
     end
   end


### PR DESCRIPTION
Update to Geocodio API v1.3 (https://geocod.io/docs/#v1-3-released-on-march-12th-2018).
Always request additional `timezone` information (open to other ways to accomplish this, but see https://github.com/alexreisner/geocoder/issues/1273).