### PR TITLE
Use new /location endpoint for Telize

### DIFF
--- a/lib/geocoder/lookups/telize.rb
+++ b/lib/geocoder/lookups/telize.rb
@@ -14,9 +14,9 @@ module Geocoder::Lookup
 
     def query_url(query)
       if configuration[:host]
-        "#{protocol}://#{configuration[:host]}/geoip/#{query.sanitized_text}"
+        "#{protocol}://#{configuration[:host]}/location/#{query.sanitized_text}"
       else
-        "#{protocol}://telize-v1.p.mashape.com/geoip/#{query.sanitized_text}?mashape-key=#{api_key}"
+        "#{protocol}://telize-v1.p.mashape.com/location/#{query.sanitized_text}?mashape-key=#{api_key}"
       end
     end
 
@@ -50,6 +50,6 @@ module Geocoder::Lookup
     def api_key
       configuration.api_key
     end
-    
+
   end
 end

--- a/test/fixtures/telize_74_200_247_59
+++ b/test/fixtures/telize_74_200_247_59
@@ -1,1 +1,17 @@
-{"timezone":"America\/Chicago","isp":"Layered Technologies, Inc.","region_code":"TX","country":"United States","dma_code":"0","area_code":"0","region":"Texas","ip":"74.200.247.59","asn":"AS22576","continent_code":"NA","city":"Plano","postal_code":"75093","longitude":-96.8134,"latitude":33.0347,"country_code":"US","country_code3":"USA"}
+{
+  "longitude": -74.0468,
+  "city": "Jersey City",
+  "timezone": "America/New_York",
+  "latitude": 40.7209,
+  "asn": 22576,
+  "region": "New Jersey",
+  "offset": -14400,
+  "organization": "DataPipe, Inc.",
+  "country_code": "US",
+  "ip": "74.200.247.59",
+  "country_code3": "USA",
+  "postal_code": "07302",
+  "continent_code": "NA",
+  "country": "United States",
+  "region_code": "NJ"
+}

--- a/test/unit/lookups/telize_test.rb
+++ b/test/unit/lookups/telize_test.rb
@@ -4,7 +4,41 @@ require 'test_helper'
 class TelizeTest < GeocoderTestCase
 
   def setup
-    Geocoder.configure(ip_lookup: :telize)
+    Geocoder.configure(ip_lookup: :telize, telize: {host: nil})
+  end
+
+  def test_query_url
+    lookup = Geocoder::Lookup::Telize.new
+    query = Geocoder::Query.new("74.200.247.59")
+    assert_match %r{^https://telize-v1\.p\.mashape\.com/location/74\.200\.247\.59}, lookup.query_url(query)
+  end
+
+  def test_includes_api_key_when_set
+    Geocoder.configure(api_key: "api_key")
+    lookup = Geocoder::Lookup::Telize.new
+    query = Geocoder::Query.new("74.200.247.59")
+    assert_match %r{/location/74\.200\.247\.59\?mashape-key=api_key}, lookup.query_url(query)
+  end
+
+  def test_uses_custom_host_when_set
+    Geocoder.configure(telize: {host: "example.com"})
+    lookup = Geocoder::Lookup::Telize.new
+    query = Geocoder::Query.new("74.200.247.59")
+    assert_match %r{^http://example\.com/location/74\.200\.247\.59$}, lookup.query_url(query)
+  end
+
+  def test_allows_https_when_custom_host
+    Geocoder.configure(use_https: true, telize: {host: "example.com"})
+    lookup = Geocoder::Lookup::Telize.new
+    query = Geocoder::Query.new("74.200.247.59")
+    assert_match %r{^https://example\.com}, lookup.query_url(query)
+  end
+
+  def test_requires_https_when_not_custom_host
+    Geocoder.configure(use_https: false)
+    lookup = Geocoder::Lookup::Telize.new
+    query = Geocoder::Query.new("74.200.247.59")
+    assert_match %r{^https://telize-v1\.p\.mashape\.com}, lookup.query_url(query)
   end
 
   def test_result_on_ip_address_search
@@ -15,6 +49,8 @@ class TelizeTest < GeocoderTestCase
   def test_result_components
     result = Geocoder.search("74.200.247.59").first
     assert_equal "Jersey City, NJ 07302, United States", result.address
+    assert_equal "US", result.country_code
+    assert_equal [40.7209, -74.0468], result.coordinates
   end
 
   def test_no_results

--- a/test/unit/lookups/telize_test.rb
+++ b/test/unit/lookups/telize_test.rb
@@ -14,7 +14,7 @@ class TelizeTest < GeocoderTestCase
 
   def test_result_components
     result = Geocoder.search("74.200.247.59").first
-    assert_equal "Plano, TX 75093, United States", result.address
+    assert_equal "Jersey City, NJ 07302, United States", result.address
   end
 
   def test_no_results


### PR DESCRIPTION
Telize is moving from their current "/geoip" endpoint to a new "/location" endpoint. [See the announcement here.](https://market.mashape.com/fcambus/telize/announcements/2)

The /geoip endpoint will stop receiving database updates as of May 1st, and will stop responding to queries as of June 1st, so it is important to get this updated quickly for all Telize users.

The new endpoint does return data in a slightly different format, as detailed here: https://www.telize.com/telize-2.0.0-has-been-released/