### PR TITLE
Add the possibility to set a method as a query option

### DIFF
--- a/lib/geocoder/stores/base.rb
+++ b/lib/geocoder/stores/base.rb
@@ -92,7 +92,11 @@ module Geocoder
 
         query_options = [:lookup, :ip_lookup, :language, :params].inject({}) do |hash, key|
           if options.has_key?(key)
-            val = options[key]
+            val = if (options[key].is_a? Symbol) && (self.class.method_defined? options[key])
+                    send(options[key])
+                  else
+                    options[key]
+                  end
             hash[key] = val.respond_to?(:call) ? val.call(self) : val
           end
           hash


### PR DESCRIPTION
I had a problem with validating addresses because sometime random numbers will actually find an address some where.
My initial idea was to narrow the scope of the search to the country. but that was impossible to change with each search since the params are loaded on the server startup.

Options should be dynamic and can be changed with each search request.