### PR TITLE
Deprecate Freegeoip and Implement Ipstack

### DIFF
--- a/README.md
+++ b/README.md
@@ -763,15 +763,17 @@ This uses the PostcodeAnywhere UK Geocode service, this will geocode any string 
 * **Documentation**: https://ipstack.com/documentation
 * **Terms of Service**: ?
 * **Limitations**: ?
-* **Notes**: To use Ipstack set `Geocoder.configure(:ip_lookup => :ipstack, :api_key => "your_ipstack_api_key")`. Support for the ipstack JSONP, batch lookup, and requester lookup features has not been implemented yet.  DSL options are as follows:
+* **Notes**: To use Ipstack set `Geocoder.configure(:ip_lookup => :ipstack, :api_key => "your_ipstack_api_key")`. Support for the ipstack JSONP, batch lookup, and requester lookup features has not been implemented yet.  This lookup does support the params shown below:
 * ```ruby
     # Search Options Examples
 
-    Geocoder.search('0.0.0.0', {
-        hostname: true, # enable hostname in response
-        security: true,
-        fields: ['fields','go','here'],
-        language: 'en',
+    Geocoder.search('0.0.0.0', { 
+        params: {
+            hostname: '1', 
+            security: '1', 
+            fields: 'country_code,location.capital,...', # see ipstack documentation
+            language: 'en'
+        }
     })
     ```
 

--- a/README.md
+++ b/README.md
@@ -753,7 +753,29 @@ This uses the PostcodeAnywhere UK Geocode service, this will geocode any string 
 
 ### IP Address Services
 
-#### FreeGeoIP (`:freegeoip`)
+#### Ipstack (`:ipstack`)
+
+* **API key**: required - see https://ipstack.com/product
+* **Quota**: 10,000 requests per month (with free API Key, 50,000/day and up for paid plans)
+* **Region**: world
+* **SSL support**: yes ( only with paid plan )
+* **Languages**: English, German, Spanish, French, Japanese, Portugues (Brazil), Russian, Chinese
+* **Documentation**: https://ipstack.com/documentation
+* **Terms of Service**: ?
+* **Limitations**: ?
+* **Notes**: To use Ipstack set `Geocoder.configure(:ip_lookup => :ipstack, :api_key => "your_ipstack_api_key")`. Support for the ipstack JSONP, batch lookup, and requester lookup features has not been implemented yet.  DSL options are as follows:
+* ```ruby
+    # Search Options Examples
+
+    Geocoder.search('0.0.0.0', {
+        hostname: true, # enable hostname in response
+        security: true,
+        fields: ['fields','go','here'],
+        language: 'en',
+    })
+    ```
+
+#### FreeGeoIP (`:freegeoip`) - DEPRECATED ( see [ upgrade instructions](https://github.com/alexreisner/geocoder/wiki/Freegeoip-Discontinuation-Upgrade-Instructions) )
 
 * **API key**: none
 * **Quota**: 15,000 requests per hour. After reaching the hourly quota, all of your requests will result in HTTP 403 (Forbidden) until it clears up on the next roll over.

--- a/README.md
+++ b/README.md
@@ -777,7 +777,7 @@ This uses the PostcodeAnywhere UK Geocode service, this will geocode any string 
     })
     ```
 
-#### FreeGeoIP (`:freegeoip`) - DEPRECATED ( see [ upgrade instructions](https://github.com/alexreisner/geocoder/wiki/Freegeoip-Discontinuation-Upgrade-Instructions) )
+#### FreeGeoIP (`:freegeoip`) - DEPRECATED ( [ more information](https://github.com/alexreisner/geocoder/wiki/Freegeoip-Discontinuation) )
 
 * **API key**: none
 * **Quota**: 15,000 requests per hour. After reaching the hourly quota, all of your requests will result in HTTP 403 (Forbidden) until it clears up on the next roll over.

--- a/geocoder.gemspec
+++ b/geocoder.gemspec
@@ -19,6 +19,17 @@ Gem::Specification.new do |s|
   s.executables = ["geocode"]
   s.license     = 'MIT'
 
+  s.post_install_message = %q{
+
+IMPORTANT: As of July 1st, 2018 the :freegeoip lookup api (formerly the default) will be
+discontinued.  Regardless of what version of geocoder you are using, if you have specified :freegeoip
+in your configuration, you must upgrade.
+
+Please follow the instructions here to upgrade:
+https://github.com/alexreisner/geocoder/wiki/Freegeoip-Discontinuation-Upgrade-Instructions
+
+}
+
   s.metadata = {
     'source_code_uri' => 'https://github.com/alexreisner/geocoder',
     'changelog_uri'   => 'https://github.com/alexreisner/geocoder/blob/master/CHANGELOG.md'

--- a/geocoder.gemspec
+++ b/geocoder.gemspec
@@ -21,12 +21,12 @@ Gem::Specification.new do |s|
 
   s.post_install_message = %q{
 
-IMPORTANT: As of July 1st, 2018 the :freegeoip lookup api (formerly the default) will be
-discontinued.  Regardless of what version of geocoder you are using, if you have specified :freegeoip
-in your configuration, you must upgrade.
+IMPORTANT: Geocoder has recently switched its default ip lookup.  If you have specified :freegeoip
+in your configuration, you must choose a different ip lookup by July 1, 2018, which is when
+the Freegeoip API will be discontinued.
 
-Please follow the instructions here to upgrade:
-https://github.com/alexreisner/geocoder/wiki/Freegeoip-Discontinuation-Upgrade-Instructions
+For more information visit:
+https://github.com/alexreisner/geocoder/wiki/Freegeoip-Discontinuation
 
 }
 

--- a/lib/generators/geocoder/config/templates/initializer.rb
+++ b/lib/generators/geocoder/config/templates/initializer.rb
@@ -2,7 +2,7 @@ Geocoder.configure(
   # Geocoding options
   # timeout: 3,                 # geocoding service timeout (secs)
   # lookup: :google,            # name of geocoding service (symbol)
-  # ip_lookup: :freegeoip,      # name of IP address geocoding service (symbol)
+  # ip_lookup: :ipinfo_io,      # name of IP address geocoding service (symbol)
   # language: :en,              # ISO-639 language code
   # use_https: false,           # use HTTPS for lookup requests? (if supported)
   # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)

--- a/lib/geocoder/lookup.rb
+++ b/lib/geocoder/lookup.rb
@@ -72,7 +72,8 @@ module Geocoder
         :ipinfo_io,
         :ipapi_com,
         :ipdata_co,
-        :db_ip_com
+        :db_ip_com,
+        :ipstack,
       ]
     end
 

--- a/lib/geocoder/lookups/ipstack.rb
+++ b/lib/geocoder/lookups/ipstack.rb
@@ -22,12 +22,9 @@ module Geocoder::Lookup
     end
 
     def query_url(query)
-      fields = (query.options[:fields] || []).join(',')
+      extra_params = url_query_string(query)
       url = "#{protocol}://#{host}/#{query.sanitized_text}?access_key=#{api_key}"
-      url << "&security=1" if query.options[:security]
-      url << "&hostname=1" if query.options[:hostname]
-      url << "&fields=#{fields}" unless fields.empty?
-      url << "&language=#{query.options[:language]}" if query.options[:language]
+      url << "&#{extra_params}" unless extra_params.empty?
       url
     end
 

--- a/lib/geocoder/lookups/ipstack.rb
+++ b/lib/geocoder/lookups/ipstack.rb
@@ -1,0 +1,67 @@
+require 'geocoder/lookups/base'
+require 'geocoder/results/ipstack'
+
+module Geocoder::Lookup
+  class Ipstack < Base
+
+    ERROR_CODES = {
+      404 => Geocoder::InvalidRequest,
+      101 => Geocoder::InvalidApiKey,
+      102 => Geocoder::Error,
+      103 => Geocoder::InvalidRequest,
+      104 => Geocoder::OverQueryLimitError,
+      105 => Geocoder::RequestDenied,
+      301 => Geocoder::InvalidRequest,
+      302 => Geocoder::InvalidRequest,
+      303 => Geocoder::RequestDenied,
+    }
+    ERROR_CODES.default = Geocoder::Error
+
+    def name
+      "Ipstack"
+    end
+
+    def query_url(query)
+      fields = (query.options[:fields] || []).join(',')
+      url = "#{protocol}://#{host}/#{query.sanitized_text}?access_key=#{api_key}"
+      url << "&security=1" if query.options[:security]
+      url << "&hostname=1" if query.options[:hostname]
+      url << "&fields=#{fields}" unless fields.empty?
+      url << "&language=#{query.options[:language]}" if query.options[:language]
+      url
+    end
+
+    private
+
+    def results(query)
+      # don't look up a loopback address, just return the stored result
+      return [reserved_result(query.text)] if query.loopback_ip_address?
+
+      return [] unless doc = fetch_data(query)
+
+      if error = doc['error']
+        code = error['code']
+        msg = error['info']
+        raise_error(ERROR_CODES[code], msg ) || Geocoder.log(:warn, "Ipstack Geocoding API error: #{msg}")
+        return []
+      end
+      [doc]
+    end
+
+    def reserved_result(ip)
+      {
+        "ip"           => ip,
+        "country_name" => "Reserved",
+        "country_code" => "RD"
+      }
+    end
+
+    def host
+      configuration[:host] || "api.ipstack.com"
+    end
+
+    def api_key
+      configuration.api_key
+    end
+  end
+end

--- a/lib/geocoder/results/ipstack.rb
+++ b/lib/geocoder/results/ipstack.rb
@@ -1,0 +1,73 @@
+require 'geocoder/results/base'
+
+module Geocoder::Result
+  class Ipstack < Base
+
+    def address(format = :full)
+      s = region_code.empty? ? "" : ", #{region_code}"
+      "#{city}#{s} #{zip}, #{country_name}".sub(/^[ ,]*/, "")
+    end
+
+    def self.response_attributes
+      [
+        ['ip', ''],
+        ['hostname', ''],
+        ['continent_code', ''],
+        ['continent_name', ''],
+        ['country_code', ''],
+        ['country_name', ''],
+        ['region_code', ''],
+        ['region_name', ''],
+        ['city', ''],
+        ['zip', ''],
+        ['latitude', 0],
+        ['longitude', 0],
+        ['location', {}],
+        ['time_zone', {}],
+        ['currency', {}],
+        ['connection', {}],
+        ['security', {}],
+      ]
+    end
+
+    response_attributes.each do |attr, default|
+      define_method attr do
+        @data[attr] || default
+      end
+    end
+
+    # These methods provide backwards compatibility for (now deprecated)
+    # freegeoip results.  Please update to use the api methods above
+
+    def state
+      log_using_deprecated_method('region_name', 'state')
+      @data['region_name']
+    end
+
+    def state_code
+      log_using_deprecated_method('region_code', 'state_code')
+      @data['region_code']
+    end
+
+    def country
+      log_using_deprecated_method('country_name', 'country')
+      @data['country_name']
+    end
+
+    def postal_code
+      log_using_deprecated_method('zip', 'postal_code')
+      @data['zip'] || @data['zipcode'] || @data['zip_code']
+    end
+
+    def metro_code
+      Geocoder.log(:warn, "Ipstack does not implement `metro_code` in api results.  Please discontinue use.")
+      0 # no longer implemented by ipstack
+    end
+
+    private
+
+    def log_using_deprecated_method(new_method, old_method)
+      Geocoder.log(:warn, "Ipstack does not implement `#{old_method}`. Please use `#{new_method}` instead.")
+    end
+  end
+end

--- a/lib/geocoder/results/ipstack.rb
+++ b/lib/geocoder/results/ipstack.rb
@@ -8,6 +8,22 @@ module Geocoder::Result
       "#{city}#{s} #{zip}, #{country_name}".sub(/^[ ,]*/, "")
     end
 
+    def state
+      @data['region_name']
+    end
+
+    def state_code
+      @data['region_code']
+    end
+
+    def country
+      @data['country_name']
+    end
+
+    def postal_code
+      @data['zip'] || @data['zipcode'] || @data['zip_code']
+    end
+
     def self.response_attributes
       [
         ['ip', ''],
@@ -36,38 +52,9 @@ module Geocoder::Result
       end
     end
 
-    # These methods provide backwards compatibility for (now deprecated)
-    # freegeoip results.  Please update to use the api methods above
-
-    def state
-      log_using_deprecated_method('region_name', 'state')
-      @data['region_name']
-    end
-
-    def state_code
-      log_using_deprecated_method('region_code', 'state_code')
-      @data['region_code']
-    end
-
-    def country
-      log_using_deprecated_method('country_name', 'country')
-      @data['country_name']
-    end
-
-    def postal_code
-      log_using_deprecated_method('zip', 'postal_code')
-      @data['zip'] || @data['zipcode'] || @data['zip_code']
-    end
-
     def metro_code
       Geocoder.log(:warn, "Ipstack does not implement `metro_code` in api results.  Please discontinue use.")
       0 # no longer implemented by ipstack
-    end
-
-    private
-
-    def log_using_deprecated_method(new_method, old_method)
-      Geocoder.log(:warn, "Ipstack does not implement `#{old_method}`. Please use `#{new_method}` instead.")
     end
   end
 end

--- a/test/fixtures/freegeoip_74_200_247_59
+++ b/test/fixtures/freegeoip_74_200_247_59
@@ -4,9 +4,9 @@
   "region_name": "Texas",
   "metro_code": "623",
   "zipcode": "75093",
-  "longitude": "-96.8134",
+  "longitude": -96.8134,
   "country_name": "United States",
   "country_code": "US",
   "ip": "74.200.247.59",
-  "latitude": "33.0347"
+  "latitude": 33.0347
 }

--- a/test/fixtures/ipstack_134_201_250_155
+++ b/test/fixtures/ipstack_134_201_250_155
@@ -1,0 +1,49 @@
+{
+  "ip": "134.201.250.155",
+  "hostname": "134.201.250.155",
+  "type": "ipv4",
+  "continent_code": "NA",
+  "continent_name": "North America",
+  "country_code": "US",
+  "country_name": "United States",
+  "region_code": "CA",
+  "region_name": "California",
+  "city": "Los Angeles",
+  "zip": "90013",
+  "latitude": 34.0453,
+  "longitude": -118.2413,
+  "location": {
+    "geoname_id": 5368361,
+    "capital": "Washington D.C.",
+    "languages": [
+        {
+          "code": "en",
+          "name": "English",
+          "native": "English"
+        }
+    ],
+    "country_flag": "https://assets.ipstack.com/images/assets/flags_svg/us.svg",
+    "country_flag_emoji": "🇺🇸",
+    "country_flag_emoji_unicode": "U+1F1FA U+1F1F8",
+    "calling_code": "1",
+    "is_eu": false
+  },
+  "time_zone": {
+    "id": "America/Los_Angeles",
+    "current_time": "2018-03-29T07:35:08-07:00",
+    "gmt_offset": -25200,
+    "code": "PDT",
+    "is_daylight_saving": true
+  },
+  "currency": {
+    "code": "USD",
+    "name": "US Dollar",
+    "plural": "US dollars",
+    "symbol": "$",
+    "symbol_native": "$"
+  },
+  "connection": {
+    "asn": 25876,
+    "isp": "Los Angeles Department of Water & Power"
+  }
+}

--- a/test/fixtures/ipstack_access_restricted
+++ b/test/fixtures/ipstack_access_restricted
@@ -1,0 +1,8 @@
+{
+  "success": false,
+  "error": {
+    "code": 105,
+    "type": "function_access_restricted",
+    "info": "The current subscription plan does not support this API endpoint."
+  }
+}

--- a/test/fixtures/ipstack_batch_not_supported
+++ b/test/fixtures/ipstack_batch_not_supported
@@ -1,0 +1,8 @@
+{
+  "success": false,
+  "error": {
+    "code": 303,
+    "type": "batch_not_supported_on_plan",
+    "info": "The Bulk Lookup Endpoint is not supported on the current subscription plan"
+  }
+}

--- a/test/fixtures/ipstack_inactive_user
+++ b/test/fixtures/ipstack_inactive_user
@@ -1,0 +1,8 @@
+{
+  "success": false,
+  "error": {
+    "code": 102,
+    "type": "inactive_user",
+    "info": "The current user account is not active. User will be prompted to get in touch with Customer Support."
+  }
+}

--- a/test/fixtures/ipstack_invalid_access_key
+++ b/test/fixtures/ipstack_invalid_access_key
@@ -1,0 +1,8 @@
+{
+  "success": false,
+  "error": {
+    "code": 101,
+    "type": "invalid_access_key",
+    "info": "No API Key was specified or an invalid API Key was specified."
+  }
+}

--- a/test/fixtures/ipstack_invalid_api_function
+++ b/test/fixtures/ipstack_invalid_api_function
@@ -1,0 +1,8 @@
+{
+  "success": false,
+  "error": {
+    "code": 103,
+    "type": "invalid_api_function",
+    "info": "The requested API endpoint does not exist."
+  }
+}

--- a/test/fixtures/ipstack_invalid_fields
+++ b/test/fixtures/ipstack_invalid_fields
@@ -1,0 +1,8 @@
+{
+  "success": false,
+  "error": {
+    "code": 301,
+    "type": "invalid_fields",
+    "info": "One or more invalid fields were specified using the fields parameter."
+  }
+}

--- a/test/fixtures/ipstack_missing_access_key
+++ b/test/fixtures/ipstack_missing_access_key
@@ -1,0 +1,8 @@
+{
+  "success": false,
+  "error": {
+    "code": 101,
+    "type": "missing_access_key",
+    "info": "No API Key was specified."
+  }
+}

--- a/test/fixtures/ipstack_not_found
+++ b/test/fixtures/ipstack_not_found
@@ -1,0 +1,8 @@
+{
+  "success": false,
+  "error": {
+    "code": 404,
+    "type": "404_not_found",
+    "info": "The requested resource does not exist."
+  }
+}

--- a/test/fixtures/ipstack_protocol_access_restricted
+++ b/test/fixtures/ipstack_protocol_access_restricted
@@ -1,0 +1,8 @@
+{
+  "success": false,
+  "error": {
+    "code": 105,
+    "type": "https_access_restricted",
+    "info": "The user's current subscription plan does not support HTTPS Encryption."
+  }
+}

--- a/test/fixtures/ipstack_too_many_ips
+++ b/test/fixtures/ipstack_too_many_ips
@@ -1,0 +1,8 @@
+{
+  "success": false,
+  "error": {
+    "code": 302,
+    "type": "too_many_ips",
+    "info": "Too many IPs have been specified for the Bulk Lookup Endpoint. (max. 50)"
+  }
+}

--- a/test/fixtures/ipstack_usage_limit
+++ b/test/fixtures/ipstack_usage_limit
@@ -1,0 +1,8 @@
+{
+  "success": false,
+  "error": {
+    "code": 104,
+    "type": "usage_limit_reached",
+    "info": "The maximum allowed amount of monthly API requests has been reached."
+  }
+}

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -217,6 +217,14 @@ module Geocoder
       end
     end
 
+    require 'geocoder/lookups/ipstack'
+    class Ipstack
+      private
+      def default_fixture_filename
+        "ipstack_134_201_250_155"
+      end
+    end
+
     require 'geocoder/lookups/geoip2'
     class Geoip2
       private

--- a/test/unit/lookup_test.rb
+++ b/test/unit/lookup_test.rb
@@ -24,7 +24,7 @@ class LookupTest < GeocoderTestCase
 
   def test_query_url_contains_values_in_params_hash
     Geocoder::Lookup.all_services_except_test.each do |l|
-      next if [:freegeoip, :maxmind_local, :telize, :pointpin, :geoip2, :maxmind_geoip2, :mapbox, :ipdata_co, :ipinfo_io, :ipapi_com].include? l # does not use query string
+      next if [:freegeoip, :maxmind_local, :telize, :pointpin, :geoip2, :maxmind_geoip2, :mapbox, :ipdata_co, :ipinfo_io, :ipapi_com, :ipstack].include? l # does not use query string
       set_api_key!(l)
       url = Geocoder::Lookup.get(l).query_url(Geocoder::Query.new(
         "test", :params => {:one_in_the_hand => "two in the bush"}

--- a/test/unit/lookups/ipstack_test.rb
+++ b/test/unit/lookups/ipstack_test.rb
@@ -1,0 +1,314 @@
+# encoding: utf-8
+require 'test_helper'
+
+class SpyLogger
+  def initialize
+    @log = []
+  end
+
+  def logged?(msg)
+    @log.include?(msg)
+  end
+
+  def add(level, msg)
+    @log << msg
+  end
+end
+
+class IpstackTest < GeocoderTestCase
+
+  def setup
+    @logger = SpyLogger.new
+    Geocoder::Configuration.instance.data.clear
+    Geocoder::Configuration.set_defaults
+    Geocoder.configure(
+      :api_key => '123',
+      :ip_lookup => :ipstack,
+      :always_raise => :all,
+      :logger => @logger
+    )
+  end
+
+  def test_result_on_ip_address_search
+    result = Geocoder.search("134.201.250.155").first
+    assert result.is_a?(Geocoder::Result::Ipstack)
+  end
+
+  def test_result_components
+    result = Geocoder.search("134.201.250.155").first
+    assert_equal "Los Angeles, CA 90013, United States", result.address
+  end
+
+  def test_all_top_level_api_fields
+    result = Geocoder.search("134.201.250.155").first
+    assert_equal "134.201.250.155", result.ip
+    assert_equal "134.201.250.155", result.hostname
+    assert_equal "NA",              result.continent_code
+    assert_equal "North America",   result.continent_name
+    assert_equal "US",              result.country_code
+    assert_equal "United States",   result.country_name
+    assert_equal "CA",              result.region_code
+    assert_equal "California",      result.region_name
+    assert_equal "Los Angeles",     result.city
+    assert_equal "90013",           result.zip
+    assert_equal 34.0453,           result.latitude
+    assert_equal (-118.2413),       result.longitude
+  end
+
+  def test_nested_api_fields
+    result = Geocoder.search("134.201.250.155").first
+
+    assert result.location.is_a?(Hash)
+    assert_equal 5368361, result.location['geoname_id']
+
+    assert result.time_zone.is_a?(Hash)
+    assert_equal "America/Los_Angeles", result.time_zone['id']
+
+    assert result.currency.is_a?(Hash)
+    assert_equal "USD", result.currency['code']
+
+    assert result.connection.is_a?(Hash)
+    assert_equal 25876, result.connection['asn']
+
+    assert result.security.is_a?(Hash)
+  end
+
+  def test_legacy_freegeoip_result_api_fields
+    Geocoder.configure(logger: SpyLogger.new)
+    result = Geocoder.search("134.201.250.155").first
+    assert_equal "California",      result.state
+    assert_equal "CA",              result.state_code
+    assert_equal "United States",   result.country
+    assert_equal "90013",           result.postal_code
+    assert_equal 0,                 result.metro_code
+  end
+
+  def test_logs_use_of_freegeoip_state_field
+    result = Geocoder.search("134.201.250.155").first
+    result.state
+
+    assert @logger.logged?("Ipstack does not implement `state`. Please use `region_name` instead.")
+  end
+
+  def test_logs_use_of_freegeoip_state_code_field
+    result = Geocoder.search("134.201.250.155").first
+    result.state_code
+
+    assert @logger.logged?("Ipstack does not implement `state_code`. Please use `region_code` instead.")
+  end
+
+  def test_logs_use_of_freegeoip_country_field
+    result = Geocoder.search("134.201.250.155").first
+    result.country
+
+    assert @logger.logged?("Ipstack does not implement `country`. Please use `country_name` instead.")
+  end
+
+  def test_logs_use_of_freegeoip_postal_code_field
+    result = Geocoder.search("134.201.250.155").first
+    result.postal_code
+
+    assert @logger.logged?("Ipstack does not implement `postal_code`. Please use `zip` instead.")
+  end
+
+  def test_logs_deprecation_of_metro_code_field
+    result = Geocoder.search("134.201.250.155").first
+    result.metro_code
+
+    assert @logger.logged?("Ipstack does not implement `metro_code` in api results.  Please discontinue use.")
+  end
+
+  def test_localhost_loopback
+    result = Geocoder.search("127.0.0.1").first
+    assert_equal "127.0.0.1", result.ip
+    assert_equal "RD",        result.country_code
+    assert_equal "Reserved",  result.country_name
+  end
+
+  def test_localhost_loopback_defaults
+    result = Geocoder.search("127.0.0.1").first
+    assert_equal "127.0.0.1", result.ip
+    assert_equal "",          result.hostname
+    assert_equal "",          result.continent_code
+    assert_equal "",          result.continent_name
+    assert_equal "RD",        result.country_code
+    assert_equal "Reserved",  result.country_name
+    assert_equal "",          result.region_code
+    assert_equal "",          result.region_name
+    assert_equal "",          result.city
+    assert_equal "",          result.zip
+    assert_equal 0,           result.latitude
+    assert_equal 0,           result.longitude
+    assert_equal({},          result.location)
+    assert_equal({},          result.time_zone)
+    assert_equal({},          result.currency)
+    assert_equal({},          result.connection)
+  end
+
+  def test_api_request_adds_access_key
+    lookup = Geocoder::Lookup.get(:ipstack)
+    assert_match 'http://api.ipstack.com/74.200.247.59?access_key=123', lookup.query_url(Geocoder::Query.new("74.200.247.59"))
+  end
+
+  def test_api_request_adds_security_when_specified
+    lookup = Geocoder::Lookup.get(:ipstack)
+
+    query_url = lookup.query_url(Geocoder::Query.new("74.200.247.59", security: true))
+
+    assert_match(/&security=1/, query_url)
+  end
+
+  def test_api_request_adds_hostname_when_specified
+    lookup = Geocoder::Lookup.get(:ipstack)
+
+    query_url = lookup.query_url(Geocoder::Query.new("74.200.247.59", hostname: true))
+
+    assert_match(/&hostname=1/, query_url)
+  end
+
+  def test_api_request_adds_language_when_specified
+    lookup = Geocoder::Lookup.get(:ipstack)
+
+    query_url = lookup.query_url(Geocoder::Query.new("74.200.247.59", language: 'es'))
+
+    assert_match(/&language=es/, query_url)
+  end
+
+  def test_api_request_adds_fields_when_specified
+    lookup = Geocoder::Lookup.get(:ipstack)
+
+    query_url = lookup.query_url(Geocoder::Query.new("74.200.247.59", fields: ['foo','bar']))
+
+    assert_match(/&fields=foo,bar/, query_url)
+  end
+
+  def test_logs_warning_when_errors_are_set_not_to_raise
+    Geocoder::Configuration.instance.data.clear
+    Geocoder::Configuration.set_defaults
+    Geocoder.configure(api_key: '123', ip_lookup: :ipstack, logger: @logger)
+
+    lookup = Geocoder::Lookup.get(:ipstack)
+
+    lookup.send(:results, Geocoder::Query.new("not_found"))
+
+    assert @logger.logged?("Ipstack Geocoding API error: The requested resource does not exist.")
+  end
+
+  def test_uses_lookup_specific_configuration
+    Geocoder::Configuration.instance.data.clear
+    Geocoder::Configuration.set_defaults
+    Geocoder.configure(api_key: '123', ip_lookup: :ipstack, logger: @logger, ipstack: { api_key: '345'})
+
+    lookup = Geocoder::Lookup.get(:ipstack)
+    assert_match 'http://api.ipstack.com/74.200.247.59?access_key=345', lookup.query_url(Geocoder::Query.new("74.200.247.59"))
+  end
+
+  def test_not_authorized   lookup = Geocoder::Lookup.get(:ipstack)
+
+    error = assert_raise Geocoder::InvalidRequest do
+      lookup.send(:results, Geocoder::Query.new("not_found"))
+    end
+
+    assert_equal error.message, "The requested resource does not exist."
+  end
+
+  def test_missing_access_key
+    lookup = Geocoder::Lookup.get(:ipstack)
+
+    error = assert_raise Geocoder::InvalidApiKey do
+      lookup.send(:results, Geocoder::Query.new("missing_access_key"))
+    end
+
+    assert_equal error.message, "No API Key was specified."
+  end
+
+  def test_invalid_access_key
+    lookup = Geocoder::Lookup.get(:ipstack)
+
+    error = assert_raise Geocoder::InvalidApiKey do
+      lookup.send(:results, Geocoder::Query.new("invalid_access_key"))
+    end
+
+    assert_equal error.message, "No API Key was specified or an invalid API Key was specified."
+  end
+
+  def test_inactive_user
+    lookup = Geocoder::Lookup.get(:ipstack)
+
+    error = assert_raise Geocoder::Error do
+      lookup.send(:results, Geocoder::Query.new("inactive_user"))
+    end
+
+    assert_equal error.message, "The current user account is not active. User will be prompted to get in touch with Customer Support."
+  end
+
+  def test_invalid_api_function
+    lookup = Geocoder::Lookup.get(:ipstack)
+
+    error = assert_raise Geocoder::InvalidRequest do
+      lookup.send(:results, Geocoder::Query.new("invalid_api_function"))
+    end
+
+    assert_equal error.message, "The requested API endpoint does not exist."
+  end
+
+  def test_usage_limit
+    lookup = Geocoder::Lookup.get(:ipstack)
+
+    error = assert_raise Geocoder::OverQueryLimitError do
+      lookup.send(:results, Geocoder::Query.new("usage_limit"))
+    end
+
+    assert_equal error.message, "The maximum allowed amount of monthly API requests has been reached."
+  end
+
+  def test_access_restricted
+    lookup = Geocoder::Lookup.get(:ipstack)
+
+    error = assert_raise Geocoder::RequestDenied do
+      lookup.send(:results, Geocoder::Query.new("access_restricted"))
+    end
+
+    assert_equal error.message, "The current subscription plan does not support this API endpoint."
+  end
+
+  def test_protocol_access_restricted
+    lookup = Geocoder::Lookup.get(:ipstack)
+
+    error = assert_raise Geocoder::RequestDenied do
+      lookup.send(:results, Geocoder::Query.new("protocol_access_restricted"))
+    end
+
+    assert_equal error.message, "The user's current subscription plan does not support HTTPS Encryption."
+  end
+
+  def test_invalid_fields
+    lookup = Geocoder::Lookup.get(:ipstack)
+
+    error = assert_raise Geocoder::InvalidRequest do
+      lookup.send(:results, Geocoder::Query.new("invalid_fields"))
+    end
+
+    assert_equal error.message, "One or more invalid fields were specified using the fields parameter."
+  end
+
+  def test_too_many_ips
+    lookup = Geocoder::Lookup.get(:ipstack)
+
+    error = assert_raise Geocoder::InvalidRequest do
+      lookup.send(:results, Geocoder::Query.new("too_many_ips"))
+    end
+
+    assert_equal error.message, "Too many IPs have been specified for the Bulk Lookup Endpoint. (max. 50)"
+  end
+
+  def test_batch_not_supported
+    lookup = Geocoder::Lookup.get(:ipstack)
+
+    error = assert_raise Geocoder::RequestDenied do
+      lookup.send(:results, Geocoder::Query.new("batch_not_supported"))
+    end
+
+    assert_equal error.message, "The Bulk Lookup Endpoint is not supported on the current subscription plan"
+  end
+end

--- a/test/unit/lookups/ipstack_test.rb
+++ b/test/unit/lookups/ipstack_test.rb
@@ -153,7 +153,7 @@ class IpstackTest < GeocoderTestCase
   def test_api_request_adds_security_when_specified
     lookup = Geocoder::Lookup.get(:ipstack)
 
-    query_url = lookup.query_url(Geocoder::Query.new("74.200.247.59", security: true))
+    query_url = lookup.query_url(Geocoder::Query.new("74.200.247.59", params: { security: '1' }))
 
     assert_match(/&security=1/, query_url)
   end
@@ -161,7 +161,7 @@ class IpstackTest < GeocoderTestCase
   def test_api_request_adds_hostname_when_specified
     lookup = Geocoder::Lookup.get(:ipstack)
 
-    query_url = lookup.query_url(Geocoder::Query.new("74.200.247.59", hostname: true))
+    query_url = lookup.query_url(Geocoder::Query.new("74.200.247.59", params: { hostname: '1' }))
 
     assert_match(/&hostname=1/, query_url)
   end
@@ -169,7 +169,7 @@ class IpstackTest < GeocoderTestCase
   def test_api_request_adds_language_when_specified
     lookup = Geocoder::Lookup.get(:ipstack)
 
-    query_url = lookup.query_url(Geocoder::Query.new("74.200.247.59", language: 'es'))
+    query_url = lookup.query_url(Geocoder::Query.new("74.200.247.59", params: { language: 'es' }))
 
     assert_match(/&language=es/, query_url)
   end
@@ -177,9 +177,9 @@ class IpstackTest < GeocoderTestCase
   def test_api_request_adds_fields_when_specified
     lookup = Geocoder::Lookup.get(:ipstack)
 
-    query_url = lookup.query_url(Geocoder::Query.new("74.200.247.59", fields: ['foo','bar']))
+    query_url = lookup.query_url(Geocoder::Query.new("74.200.247.59", params: { fields: 'foo,bar' }))
 
-    assert_match(/&fields=foo,bar/, query_url)
+    assert_match(/&fields=foo%2Cbar/, query_url)
   end
 
   def test_logs_warning_when_errors_are_set_not_to_raise

--- a/test/unit/lookups/ipstack_test.rb
+++ b/test/unit/lookups/ipstack_test.rb
@@ -73,42 +73,13 @@ class IpstackTest < GeocoderTestCase
     assert result.security.is_a?(Hash)
   end
 
-  def test_legacy_freegeoip_result_api_fields
-    Geocoder.configure(logger: SpyLogger.new)
+  def test_required_base_fields
     result = Geocoder.search("134.201.250.155").first
     assert_equal "California",      result.state
     assert_equal "CA",              result.state_code
     assert_equal "United States",   result.country
     assert_equal "90013",           result.postal_code
-    assert_equal 0,                 result.metro_code
-  end
-
-  def test_logs_use_of_freegeoip_state_field
-    result = Geocoder.search("134.201.250.155").first
-    result.state
-
-    assert @logger.logged?("Ipstack does not implement `state`. Please use `region_name` instead.")
-  end
-
-  def test_logs_use_of_freegeoip_state_code_field
-    result = Geocoder.search("134.201.250.155").first
-    result.state_code
-
-    assert @logger.logged?("Ipstack does not implement `state_code`. Please use `region_code` instead.")
-  end
-
-  def test_logs_use_of_freegeoip_country_field
-    result = Geocoder.search("134.201.250.155").first
-    result.country
-
-    assert @logger.logged?("Ipstack does not implement `country`. Please use `country_name` instead.")
-  end
-
-  def test_logs_use_of_freegeoip_postal_code_field
-    result = Geocoder.search("134.201.250.155").first
-    result.postal_code
-
-    assert @logger.logged?("Ipstack does not implement `postal_code`. Please use `zip` instead.")
+    assert_equal [34.0453, -118.2413], result.coordinates
   end
 
   def test_logs_deprecation_of_metro_code_field


### PR DESCRIPTION
Fixes #1279 

One of the unique problems here is that regardless of whether people update versions of this gem, the functionality for freegeoip will just stop.  We can introduce as many mechanisms in this PR to help with that, but there will probably be quite a few people for whom they wake up July 1st and their project just doesn't work.

### Post Install Message & Wiki
The post install message contains a link to a wiki page (currently just empty) on how to upgrade from freegeoip to Ipstack. I have a draft of what the wiki page could contain on my forks wiki section [here](https://github.com/Heath101/geocoder/wiki/Freegeoip-Discontinuation-Upgrade-Instructions).  I would love as a part of reviewing this PR input on the content of that wiki page as well.  Then when it is ready we can replace the dummy one that I already created [here](https://github.com/alexreisner/geocoder/wiki/Freegeoip-Discontinuation-Upgrade-Instructions)

### Features Not Implemented
There are still a few features of the ipstack api that I have not implemented in this PR.  **Batching**, **JSONP support**, and **Requester IP lookup**.  Since these were not available with freegeoip, I kinda just wanted to get in the stuff that I thought we be the most useful right off the bat.

### Notes on this PR
I noticed that the initializer template still had a reference to freegeoip as the ip_lookup, so I changed that to the new default `:ipinfo_io`.

I tried to keep the object api of the freegeoip and ipstack result objects the same.  There is only one difference and that is that ipstack does not provide a `metro_code`.  This change is noted in the wiki upgrade page.

I did make a slight deviation from one of the patterns I saw in the current code base.  The current code base allows you to pass in params as options to a lookup.  I decided that I wanted to hide the actual values of the params, in favor of a small DSL.  For example:

```ruby
# not implemented this way
Geocoder.search('0.0.0.0', {params: {security: '1'} })

# instead using a small dsl
Geocoder.search('0.0.0.0', {security: true })
```

This DSL is described in the README section for the Ipstack lookup.  If this deviates too much from the params pattern, then I can revisit that.
