### PR TITLE
Remove Geocoder::Results::Geoip2#data

### DIFF
--- a/lib/geocoder/results/geoip2.rb
+++ b/lib/geocoder/results/geoip2.rb
@@ -64,10 +64,6 @@ module Geocoder
 
       private
 
-      def data
-        @data.to_hash
-      end
-
       def default_language
         @default_language = Geocoder.config[:language].to_s
       end


### PR DESCRIPTION
As requested and discussed on #1291, removing `data` method so we can access the `@data` variable made available on `Geocoder::Result::Base`.

Ran the specs locally and none started failing after the change (had one already failing before the change).