### PR TITLE
Add config disclaimer and link

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ and run at the command prompt:
 
     bundle install
 
+**You must [configure your geocoding service](#geocoding-service-lookup-configuration) before using**
 
 Object Geocoding
 ----------------


### PR DESCRIPTION
Readme is long and geocoding service configuration instructions are far down the document. Thought this would help.

A different solution could be adding a table of contents, and / or breaking up the readme into wiki files. This readme is just so long.