### PR TITLE
Fix Missing API Key for Ipdata.co Lookups

### DIFF
--- a/lib/geocoder/lookups/ipdata_co.rb
+++ b/lib/geocoder/lookups/ipdata_co.rb
@@ -13,7 +13,9 @@ module Geocoder::Lookup
     end
 
     def query_url(query)
-      "#{protocol}://#{host}/#{query.sanitized_text}"
+      # Ipdata.co requires that the API key be sent as a query parameter.
+      # It no longer supports API keys sent as headers.
+      "#{protocol}://#{host}/#{query.sanitized_text}?api-key=#{configuration.api_key}"
     end
 
     private # ---------------------------------------------------------------
@@ -23,7 +25,6 @@ module Geocoder::Lookup
     end
 
     def results(query)
-      Geocoder.configure(:ipdata_co => {:http_headers => { "api-key" => configuration.api_key }}) if configuration.api_key
       # don't look up a loopback address, just return the stored result
       return [reserved_result(query.text)] if query.loopback_ip_address?
       # note: Ipdata.co returns plain text on bad request

--- a/test/unit/lookups/ipdata_co_test.rb
+++ b/test/unit/lookups/ipdata_co_test.rb
@@ -42,7 +42,7 @@ class IpdataCoTest < GeocoderTestCase
 
     require 'webmock/test_unit'
     WebMock.enable!
-    stubbed_request = WebMock.stub_request(:get, "https://api.ipdata.co/8.8.8.8").with(headers: {'api-key' => 'XXXX'}).to_return(status: 200)
+    stubbed_request = WebMock.stub_request(:get, "https://api.ipdata.co/8.8.8.8?api-key=XXXX").to_return(status: 200)
 
     g = Geocoder::Lookup::IpdataCo.new
     g.send(:actual_make_api_request, Geocoder::Query.new('8.8.8.8'))


### PR DESCRIPTION
Ipdata.co no longer accepts the API key as a header. It must be sent as a query parameter.

![image](https://user-images.githubusercontent.com/7896757/45225691-1fe37a00-b28b-11e8-97e6-b3ef8a4ddfda.png)
