### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Advanced Features:
 * [Geospatial Calculations](#geospatial-calculations)
 * [Batch Geocoding](#batch-geocoding)
 * [Testing](#testing)
-* [Error Handling](#error-handing)
+* [Error Handling](#error-handling)
 * [Command Line Interface](#command-line-interface)
 
 The Rest:


### PR DESCRIPTION
Closes #1340 
Corrects the link anchor in table of contents to the Error Handling section