### PR TITLE
Allow https for IPInfo.io queries without an API key

### DIFF
--- a/README_API_GUIDE.md
+++ b/README_API_GUIDE.md
@@ -342,7 +342,7 @@ IP Address Lookups
 * **API key**: optional - see http://ipinfo.io/pricing
 * **Quota**: 1,000/day - more with api key
 * **Region**: world
-* **SSL support**: no (not without access key - see http://ipinfo.io/pricing)
+* **SSL support**: yes
 * **Languages**: English
 * **Documentation**: http://ipinfo.io/developers
 * **Terms of Service**: http://ipinfo.io/developers

--- a/lib/geocoder/lookups/ipinfo_io.rb
+++ b/lib/geocoder/lookups/ipinfo_io.rb
@@ -8,15 +8,6 @@ module Geocoder::Lookup
       "Ipinfo.io"
     end
 
-    # HTTPS available only for paid plans
-    def supported_protocols
-      if configuration.api_key
-        [:http, :https]
-      else
-        [:http]
-      end
-    end
-
     private # ---------------------------------------------------------------
 
     def base_query_url(query)

--- a/test/unit/lookups/ipinfo_io_test.rb
+++ b/test/unit/lookups/ipinfo_io_test.rb
@@ -2,19 +2,6 @@
 require 'test_helper'
 
 class IpinfoIoTest < GeocoderTestCase
-
-  def test_ipinfo_io_use_http_without_token
-    Geocoder.configure(:ip_lookup => :ipinfo_io, :use_https => true)
-    query = Geocoder::Query.new("8.8.8.8")
-    assert_match(/^http:/, query.url)
-  end
-
-  def test_ipinfo_io_uses_https_when_auth_token_set
-    Geocoder.configure(:ip_lookup => :ipinfo_io, :api_key => "FOO_BAR_TOKEN", :use_https => true)
-    query = Geocoder::Query.new("8.8.8.8")
-    assert_match(/^https:/, query.url)
-  end
-
   def test_ipinfo_io_lookup_loopback_address
     Geocoder.configure(:ip_lookup => :ipinfo_io)
     result = Geocoder.search("127.0.0.1").first


### PR DESCRIPTION
It appears that at some point they changed the "TLS only for paying
customers" rule.

See: https://ipinfo.io/developers#https-ssl
"Our API is available over a secure HTTPS connection for all users, even
on the free plan."