### PR TITLE
Modify Pelias lookup to return multiple results

### DIFF
--- a/lib/geocoder/lookups/pelias.rb
+++ b/lib/geocoder/lookups/pelias.rb
@@ -24,12 +24,11 @@ module Geocoder::Lookup
 
     def query_url_params(query)
       params = {
-        api_key: configuration.api_key,
-        size: 1
+        api_key: configuration.api_key
       }.merge(super)
 
       if query.reverse_geocode?
-        lat,lon = query.coordinates
+        lat, lon = query.coordinates
         params[:'point.lat'] = lat
         params[:'point.lon'] = lon
       else

--- a/test/unit/lookups/pelias_test.rb
+++ b/test/unit/lookups/pelias_test.rb
@@ -17,14 +17,9 @@ class PeliasTest < GeocoderTestCase
     assert_true query.url.start_with?('http://self.hosted.pelias/proxy/v1/search'), query.url
   end
 
-  def test_query_url_defaults_to_one
-    query = Geocoder::Query.new('Madison Square Garden, New York, NY')
-    assert_match 'size=1', query.url
-  end
-
   def test_query_for_reverse_geocode
     lookup = Geocoder::Lookup::Pelias.new
     url = lookup.query_url(Geocoder::Query.new([45.423733, -75.676333]))
-    assert_match(/point.lat=45.423733&point.lon=-75.676333&size=1/, url)
+    assert_match(/point.lat=45.423733&point.lon=-75.676333/, url)
   end
 end


### PR DESCRIPTION
- Fixes #1353
  - Do not limit the results returned from Pelias to 1;
  - Removed test that was enforcing this condition;