### PR TITLE
Integrate configurable filters for Pelias Lookup

### DIFF
--- a/README_API_GUIDE.md
+++ b/README_API_GUIDE.md
@@ -205,6 +205,21 @@ The [Google Places Search API](https://developers.google.com/places/web-service/
 * **Limitations**: See terms
 * **Notes**: Configure your self-hosted pelias with the `endpoint` option: `Geocoder.configure(lookup: :pelias, api_key: 'your_api_key', pelias: {endpoint: 'self.hosted/pelias'})`. Defaults to `localhost`.
 
+  Optional Query filters available on the Pelias API can also be applied here, such as `sources`, `layers` and `boundary.country`:
+
+      Geocoder.configure(
+        lookup: :pelias,
+        api_key: 'your_api_key',
+        pelias: {
+          endpoint: 'self.hosted/pelias',
+          sources: 'osm, oa', # One or multiple sources
+          layers: 'venue', # One or multiple layer types
+          limit_to_country: 'SG'
+        }
+      )
+
+  [More info on Pelias API](https://github.com/pelias/documentation#core-features-and-api-documentation)
+
 ### Data Science Toolkit (`:dstk`)
 
 Data Science Toolkit provides an API whose response format is like Google's but which can be set up as a privately hosted service.

--- a/lib/geocoder/lookups/pelias.rb
+++ b/lib/geocoder/lookups/pelias.rb
@@ -35,6 +35,9 @@ module Geocoder::Lookup
       else
         params[:text] = query.text
       end
+
+      apply_configurable_filters(params)
+
       params
     end
 
@@ -59,6 +62,14 @@ module Geocoder::Lookup
       end
 
       doc['features'] || []
+    end
+
+    def apply_configurable_filters(params)
+      if configuration[:limit_to_country]
+        params[:'boundary.country'] = configuration[:limit_to_country]
+      end
+      params[:layers] = configuration[:layers] if configuration[:layers]
+      params[:sources] = configuration[:sources] if configuration[:sources]
     end
   end
 end

--- a/lib/geocoder/results/pelias.rb
+++ b/lib/geocoder/results/pelias.rb
@@ -18,6 +18,10 @@ module Geocoder::Result
       properties['country_a']
     end
 
+    def place_name
+      properties['name']
+    end
+
     def postal_code
       properties['postalcode'].to_s
     end
@@ -35,7 +39,10 @@ module Geocoder::Result
     end
 
     def self.response_attributes
-      %w[county confidence country gid id layer localadmin locality neighborhood]
+      %w[
+        county confidence country gid id layer localadmin locality
+        neighborhood street source
+      ]
     end
 
     response_attributes.each do |a|
@@ -55,4 +62,3 @@ module Geocoder::Result
     end
   end
 end
-

--- a/test/unit/lookups/pelias_test.rb
+++ b/test/unit/lookups/pelias_test.rb
@@ -3,7 +3,11 @@ require 'test_helper'
 
 class PeliasTest < GeocoderTestCase
   def setup
-    Geocoder.configure(lookup: :pelias, api_key: 'abc123', pelias: {}) # Empty pelias hash only for test (pollution control)
+    Geocoder.configure(
+      lookup: :pelias,
+      api_key: 'abc123',
+      pelias: {}
+    ) # Empty pelias hash only for test (pollution control)
   end
 
   def test_configure_default_endpoint
@@ -12,7 +16,13 @@ class PeliasTest < GeocoderTestCase
   end
 
   def test_configure_custom_endpoint
-    Geocoder.configure(lookup: :pelias, api_key: 'abc123', pelias: {endpoint: 'self.hosted.pelias/proxy'})
+    Geocoder.configure(
+      lookup: :pelias,
+      api_key: 'abc123',
+      pelias: {
+        endpoint: 'self.hosted.pelias/proxy'
+      }
+    )
     query = Geocoder::Query.new('Madison Square Garden, New York, NY')
     assert_true query.url.start_with?('http://self.hosted.pelias/proxy/v1/search'), query.url
   end
@@ -26,5 +36,23 @@ class PeliasTest < GeocoderTestCase
     lookup = Geocoder::Lookup::Pelias.new
     url = lookup.query_url(Geocoder::Query.new([45.423733, -75.676333]))
     assert_match(/point.lat=45.423733&point.lon=-75.676333&size=1/, url)
+  end
+
+  def test_query_for_custom_filters
+    Geocoder.configure(
+      lookup: :pelias,
+      api_key: 'abc123',
+      pelias: {
+        endpoint: 'self.hosted.pelias/proxy',
+        layers: 'venue',
+        sources: 'osm',
+        limit_to_country: 'USA'
+      }
+    )
+    query = Geocoder::Query.new('Madison Square Garden, New York, NY')
+
+    assert_match 'sources=osm', query.url
+    assert_match 'layers=venue', query.url
+    assert_match 'boundary.country=USA', query.url
   end
 end


### PR DESCRIPTION
Pelias supports filtering of results to a specific country, source or type of location (venue, region, etc).

Since there was already a custom configuration to set the pelias endpoint, I think it might be a good idea to customize the filtering parameters that one might need:

- Only get venues as results;
- Limit results to a specific country;
- Limit results to the OSM dataset;

More integrations can be done, but I think at least these are a nice-to-have.

Some info on the API itself: https://github.com/pelias/documentation#core-features-and-api-documentation

- Enable specification of custom filters on the initializer and apply these to the request params;
- Added test for custom filters;
- Updated the documentation on how to configure the Pelias lookup (these filters are optional);
- Adding extra properties to Pelias Results:
  - place_name
  - street
  - source