### PR TITLE
Allow to pass language parameter for bing and here lookups

### DIFF
--- a/README_API_GUIDE.md
+++ b/README_API_GUIDE.md
@@ -63,7 +63,7 @@ The [Google Places Search API](https://developers.google.com/places/web-service/
 * **Quota**: 50,0000 requests/day (Windows app), 125,000 requests/year (non-Windows app)
 * **Region**: world
 * **SSL support**: no
-* **Languages**: ?
+* **Languages**: The preferred language of address elements in the result. Language code must be provided according to RFC 4647 standard.
 * **Documentation**: http://msdn.microsoft.com/en-us/library/ff701715.aspx
 * **Terms of Service**: http://www.microsoft.com/maps/product/terms.html
 * **Limitations**: No country codes or state names. Must be used on "public-facing, non-password protected web sites," "in conjunction with Bing Maps or an application that integrates Bing Maps."

--- a/lib/geocoder/lookups/bing.rb
+++ b/lib/geocoder/lookups/bing.rb
@@ -53,7 +53,8 @@ module Geocoder::Lookup
 
     def query_url_params(query)
       {
-        key: configuration.api_key
+        key: configuration.api_key,
+        language: (query.language || configuration.language)
       }.merge(super)
     end
 

--- a/lib/geocoder/lookups/here.rb
+++ b/lib/geocoder/lookups/here.rb
@@ -30,19 +30,20 @@ module Geocoder::Lookup
 
     def query_url_params(query)
       options = {
-        :gen=>4,
-        :app_id=>api_key,
-        :app_code=>api_code
+        gen: 4,
+        app_id: api_key,
+        app_code: api_code,
+        language: (query.language || configuration.language)
       }
 
       if query.reverse_geocode?
         super.merge(options).merge(
-          :prox=>query.sanitized_text,
-          :mode=>:retrieveAddresses
+          prox: query.sanitized_text,
+          mode: :retrieveAddresses
         )
       else
         super.merge(options).merge(
-          :searchtext=>query.sanitized_text
+          searchtext: query.sanitized_text
         )
       end
     end

--- a/test/unit/lookup_test.rb
+++ b/test/unit/lookup_test.rb
@@ -56,8 +56,10 @@ class LookupTest < GeocoderTestCase
   end
 
   {
+    :bing => :language,
     :google => :language,
     :google_premier => :language,
+    :here => :language,
     :nominatim => :"accept-language",
     :yandex => :plng
   }.each do |l,p|


### PR DESCRIPTION
Currently Geocoder doesn't allow us to pass language parameter to `bing` and `here` even though both API's support it.

Let me know is there is something else that needs to be changed.