### PR TITLE
Fixed typo

### DIFF
--- a/lib/geocoder/lookups/smarty_streets.rb
+++ b/lib/geocoder/lookups/smarty_streets.rb
@@ -8,7 +8,7 @@ module Geocoder::Lookup
     end
 
     def required_api_key_parts
-      %w(auti-id auth-token)
+      %w(auth-id auth-token)
     end
 
     # required by API as of 26 March 2015


### PR DESCRIPTION
Fixed a small typo. It shows up when you don't pass SmartyStreets credentials, but doesn't seem to affect the actual geocoding.