### PR TITLE
Support for SmartyStreets International API

### DIFF
--- a/lib/geocoder/lookups/smarty_streets.rb
+++ b/lib/geocoder/lookups/smarty_streets.rb
@@ -19,7 +19,9 @@ module Geocoder::Lookup
     private # ---------------------------------------------------------------
 
     def base_query_url(query)
-      if zipcode_only?(query)
+      if international?(query)
+        "#{protocol}://international-street.api.smartystreets.com/verify?"
+      elsif zipcode_only?(query)
         "#{protocol}://us-zipcode.api.smartystreets.com/lookup?"
       else
         "#{protocol}://us-street.api.smartystreets.com/street-address?"
@@ -30,9 +32,17 @@ module Geocoder::Lookup
       !query.text.is_a?(Array) and query.to_s.strip =~ /\A\d{5}(-\d{4})?\Z/
     end
 
+    def international?(query)
+      !query.options[:country].nil?
+    end
+
     def query_url_params(query)
       params = {}
-      if zipcode_only?(query)
+      if international?(query)
+        params[:freeform] = query.sanitized_text
+        params[:country] = query.options[:country]
+        params[:geocode] = true
+      elsif zipcode_only?(query)
         params[:zipcode] = query.sanitized_text
       else
         params[:street] = query.sanitized_text

--- a/lib/geocoder/results/smarty_streets.rb
+++ b/lib/geocoder/results/smarty_streets.rb
@@ -17,7 +17,7 @@ module Geocoder::Result
     def address
       parts =
         if international_endpoint?
-          (1..4).map { |i| @data["address#{i}"] }
+          (1..12).map { |i| @data["address#{i}"] }
         else
           [
             delivery_line_1,
@@ -64,7 +64,7 @@ module Geocoder::Result
 
     def street
       international_endpoint? ?
-        @data['address1'] :
+        components['thoroughfare_name'] :
         components['street_name']
     end
 

--- a/lib/geocoder/results/smarty_streets.rb
+++ b/lib/geocoder/results/smarty_streets.rb
@@ -15,51 +15,77 @@ module Geocoder::Result
     end
 
     def address
-      [
-        delivery_line_1,
-        delivery_line_2,
-        last_line
-      ].select{ |i| i.to_s != "" }.join(" ")
+      parts =
+        if international_endpoint?
+          (1..4).map { |i| @data["address#{i}"] }
+        else
+          [
+            delivery_line_1,
+            delivery_line_2,
+            last_line
+          ]
+        end
+      parts.select{ |i| i.to_s != "" }.join(" ")
     end
 
     def state
-      zipcode_endpoint? ?
-        city_states.first['state'] :
+      if international_endpoint?
+        components['administrative_area']
+      elsif zipcode_endpoint?
+        city_states.first['state']
+      else
         components['state_abbreviation']
+      end
     end
 
     def state_code
-      zipcode_endpoint? ?
-        city_states.first['state_abbreviation'] :
+      if international_endpoint?
+        components['administrative_area']
+      elsif zipcode_endpoint?
+        city_states.first['state_abbreviation']
+      else
         components['state_abbreviation']
+      end
     end
 
     def country
-      # SmartyStreets returns results for USA only
-      "United States"
+      international_endpoint? ?
+        components['country_iso_3'] :
+        "United States"
     end
 
     def country_code
-      # SmartyStreets returns results for USA only
-      "US"
+      international_endpoint? ?
+        components['country_iso_3'] :
+        "US"
     end
 
     ## Extra methods not in base.rb ------------------------
 
     def street
-      components['street_name']
+      international_endpoint? ?
+        @data['address1'] :
+        components['street_name']
     end
 
     def city
-      zipcode_endpoint? ?
-        city_states.first['city'] :
+      if international_endpoint?
+        components['locality']
+      elsif zipcode_endpoint?
+        city_states.first['city']
+      else
         components['city_name']
+      end
     end
 
     def zipcode
-      zipcode_endpoint? ?
-        zipcodes.first['zipcode'] :
+      if international_endpoint?
+        components['postal_code']
+      elsif zipcode_endpoint?
+        zipcodes.first['zipcode']
+      else
         components['zipcode']
+      end
     end
     alias_method :postal_code, :zipcode
 
@@ -76,6 +102,10 @@ module Geocoder::Result
 
     def zipcode_endpoint?
       zipcodes.any?
+    end
+
+    def international_endpoint?
+      !@data['address1'].nil?
     end
 
     [

--- a/test/fixtures/smarty_streets_13_rue_yves_toudic_75010
+++ b/test/fixtures/smarty_streets_13_rue_yves_toudic_75010
@@ -1,0 +1,33 @@
+[
+  {
+    "address1": "13 Rue Yves Toudic",
+    "address2": "10E Arrondissement",
+    "address3": "75010 Paris",
+    "components": {
+      "super_administrative_area": "Ile-De-France",
+      "administrative_area": "Paris",
+      "country_iso_3": "FRA",
+      "locality": "Paris",
+      "dependent_locality": "10E Arrondissement",
+      "postal_code": "75010",
+      "postal_code_short": "75010",
+      "premise": "13",
+      "premise_number": "13",
+      "thoroughfare": "Rue Yves Toudic",
+      "thoroughfare_name": "Yves Toudic",
+      "thoroughfare_type": "Rue"
+    },
+    "metadata": {
+      "latitude": 48.870131,
+      "longitude": 2.363473,
+      "geocode_precision": "Premise",
+      "max_geocode_precision": "DeliveryPoint",
+      "address_format": "premise thoroughfare|dependent_locality|postal_code locality"
+    },
+    "analysis": {
+      "verification_status": "Verified",
+      "address_precision": "Premise",
+      "max_address_precision": "DeliveryPoint"
+    }
+  }
+]

--- a/test/unit/lookups/smarty_streets_test.rb
+++ b/test/unit/lookups/smarty_streets_test.rb
@@ -29,6 +29,11 @@ class SmartyStreetsTest < GeocoderTestCase
     assert_match(/us-zipcode\.api\.smartystreets\.com\/lookup\?/, query.url)
   end
 
+  def test_query_for_international_geocode
+    query = Geocoder::Query.new("13 rue yves toudic 75010", country: "France")
+    assert_match(/international-street\.api\.smartystreets\.com\/verify\?/, query.url)
+  end
+
   def test_smarty_streets_result_components
     result = Geocoder.search("Madison Square Garden, New York, NY").first
     assert_equal "Penn", result.street
@@ -36,6 +41,7 @@ class SmartyStreetsTest < GeocoderTestCase
     assert_equal "1703", result.zip4
     assert_equal "New York", result.city
     assert_equal "36061", result.fips
+    assert_equal "US", result.country_code
     assert !result.zipcode_endpoint?
   end
 
@@ -44,7 +50,17 @@ class SmartyStreetsTest < GeocoderTestCase
     assert_equal "Brooklyn", result.city
     assert_equal "New York", result.state
     assert_equal "NY", result.state_code
+    assert_equal "US", result.country_code
     assert result.zipcode_endpoint?
+  end
+
+  def test_smarty_streets_result_components_with_international_query
+    result = Geocoder.search("13 rue yves toudic 75010", country: "France").first
+    assert_equal 'Yves Toudic', result.street
+    assert_equal 'Paris', result.city
+    assert_equal '75010', result.postal_code
+    assert_equal 'FRA', result.country_code
+    assert result.international_endpoint?
   end
 
   def test_smarty_streets_when_longitude_latitude_does_not_exist


### PR DESCRIPTION
Hi, thanks for this great project 👍 This PR adds support for the SmartyStreets [International API](https://smartystreets.com/docs/cloud/international-street-api).

The international endpoint will be used if the user passes a country, which is a required parameter for it.

```ruby
Geocoder.search(address, country: "France")
```