### PR TITLE
Add country and mapview as extra parameters to here lookup

### DIFF
--- a/README_API_GUIDE.md
+++ b/README_API_GUIDE.md
@@ -178,7 +178,7 @@ The [Google Places Search API](https://developers.google.com/places/web-service/
 * **SSL support**: yes
 * **Languages**: The preferred language of address elements in the result. Language code must be provided according to RFC 4647 standard.
 * **Extra params**:
-  * `:mapview` - pass NW and SE coordinates as an array of two arrays to bias results towards a viewport
+  * `:bounds` - pass NW and SE coordinates as an array of two arrays to bias results towards a viewport
   * `:country` - pass the country or list of countries using the country code (3 bytes, ISO 3166-1-alpha-3) or the country name, to filter the results
 * **Documentation**: http://developer.here.com/rest-apis/documentation/geocoder
 * **Terms of Service**: http://developer.here.com/faqs#l&t

--- a/README_API_GUIDE.md
+++ b/README_API_GUIDE.md
@@ -177,6 +177,9 @@ The [Google Places Search API](https://developers.google.com/places/web-service/
 * **Region**: world
 * **SSL support**: yes
 * **Languages**: The preferred language of address elements in the result. Language code must be provided according to RFC 4647 standard.
+* **Extra params**:
+  * `:mapview` - pass NW and SE coordinates as an array of two arrays to bias results towards a viewport
+  * `:country` - pass the country or list of countries using the country code (3 bytes, ISO 3166-1-alpha-3) or the country name, to filter the results
 * **Documentation**: http://developer.here.com/rest-apis/documentation/geocoder
 * **Terms of Service**: http://developer.here.com/faqs#l&t
 * **Limitations**: ?

--- a/lib/geocoder/lookups/here.rb
+++ b/lib/geocoder/lookups/here.rb
@@ -44,7 +44,7 @@ module Geocoder::Lookup
         options[:country] = country
       end
 
-      unless (mapview = query.options[:mapview]).nil?
+      unless (mapview = query.options[:bounds]).nil?
         options[:mapview] = mapview.map{ |point| "%f,%f" % point }.join(';')
       end
       options

--- a/lib/geocoder/lookups/here.rb
+++ b/lib/geocoder/lookups/here.rb
@@ -28,34 +28,48 @@ module Geocoder::Lookup
       []
     end
 
-    def query_url_params(query)
+    def query_url_here_options(query, reverse_geocode)
       options = {
-        gen: 4,
+        gen: 9,
         app_id: api_key,
         app_code: api_code,
         language: (query.language || configuration.language)
       }
+      if reverse_geocode
+        options[:mode] = :retrieveAddresses
+        return options
+      end
 
+      unless (country = query.options[:country]).nil?
+        options[:country] = country
+      end
+
+      unless (mapview = query.options[:mapview]).nil?
+        options[:mapview] = mapview.map{ |point| "%f,%f" % point }.join(';')
+      end
+      options
+    end
+
+    def query_url_params(query)
       if query.reverse_geocode?
-        super.merge(options).merge(
-          prox: query.sanitized_text,
-          mode: :retrieveAddresses
+        super.merge(query_url_here_options(query, true)).merge(
+          prox: query.sanitized_text
         )
       else
-        super.merge(options).merge(
+        super.merge(query_url_here_options(query, false)).merge(
           searchtext: query.sanitized_text
         )
       end
     end
 
     def api_key
-      if a=configuration.api_key
+      if (a = configuration.api_key)
         return a.first if a.is_a?(Array)
       end
     end
 
     def api_code
-      if a=configuration.api_key
+      if (a = configuration.api_key)
         return a.last if a.is_a?(Array)
       end
     end

--- a/test/unit/lookups/here_test.rb
+++ b/test/unit/lookups/here_test.rb
@@ -3,16 +3,36 @@ $: << File.join(File.dirname(__FILE__), "..", "..")
 require 'test_helper'
 
 class HereTest < GeocoderTestCase
-
   def setup
     Geocoder.configure(lookup: :here)
     set_api_key!(:here)
   end
 
   def test_here_viewport
-    result = Geocoder.search("Madison Square Garden, New York, NY").first
+    result = Geocoder.search('Madison Square Garden, New York, NY').first
     assert_equal [40.7493451, -73.9948616, 40.7515934, -73.9918938],
-      result.viewport
+                 result.viewport
   end
 
+  def test_here_query_url_contains_country
+    lookup = Geocoder::Lookup::Here.new
+    url = lookup.query_url(
+      Geocoder::Query.new(
+        'Some Intersection',
+        country: 'GBR'
+      )
+    )
+    assert_match(/country=GBR/, url)
+  end
+
+  def test_here_query_url_contains_mapview
+    lookup = Geocoder::Lookup::Here.new
+    url = lookup.query_url(
+      Geocoder::Query.new(
+        'Some Intersection',
+        mapview: [[40.0, -120.0], [39.0, -121.0]]
+      )
+    )
+    assert_match(/mapview=40.0+%2C-120.0+%3B39.0+%2C-121.0+/, url)
+  end
 end

--- a/test/unit/lookups/here_test.rb
+++ b/test/unit/lookups/here_test.rb
@@ -30,7 +30,7 @@ class HereTest < GeocoderTestCase
     url = lookup.query_url(
       Geocoder::Query.new(
         'Some Intersection',
-        mapview: [[40.0, -120.0], [39.0, -121.0]]
+        bounds: [[40.0, -120.0], [39.0, -121.0]]
       )
     )
     assert_match(/mapview=40.0+%2C-120.0+%3B39.0+%2C-121.0+/, url)


### PR DESCRIPTION
Currently Geocoder uses an old version of the `here` API. This change updates the API version and allows the support of country and mapview parameters.