### PR TITLE
Allow mixed-case Table name and Column names for ActiveRecord

### DIFF
--- a/lib/geocoder/stores/active_record.rb
+++ b/lib/geocoder/stores/active_record.rb
@@ -18,19 +18,19 @@ module Geocoder::Store
 
         # scope: geocoded objects
         scope :geocoded, lambda {
-          where("#{table_name}.#{geocoder_options[:latitude]} IS NOT NULL " +
-            "AND #{table_name}.#{geocoder_options[:longitude]} IS NOT NULL")
+          where("\"#{table_name}\".\"#{geocoder_options[:latitude]}\" IS NOT NULL " +
+            "AND \"#{table_name}\".\"#{geocoder_options[:longitude]}\" IS NOT NULL")
         }
 
         # scope: not-geocoded objects
         scope :not_geocoded, lambda {
-          where("#{table_name}.#{geocoder_options[:latitude]} IS NULL " +
-            "OR #{table_name}.#{geocoder_options[:longitude]} IS NULL")
+          where("\"#{table_name}\".\"#{geocoder_options[:latitude]}\" IS NULL " +
+            "OR \"#{table_name}\".\"#{geocoder_options[:longitude]}\" IS NULL")
         }
 
         # scope: not-reverse geocoded objects
         scope :not_reverse_geocoded, lambda {
-          where("#{table_name}.#{geocoder_options[:fetched_address]} IS NULL")
+          where("\"#{table_name}\".\"#{geocoder_options[:fetched_address]}\" IS NULL")
         }
 
         ##


### PR DESCRIPTION
Quoted Table name and Column names to Allow Uppercase and Mixed Case table/column names.

Example cases:
"address"."LATITUDE"
"ADDRESS"."latitude"
"Address"."Latitude"