### PR TITLE
Suggestion to not log full response body as a warning

### DIFF
--- a/lib/geocoder/lookups/base.rb
+++ b/lib/geocoder/lookups/base.rb
@@ -209,7 +209,7 @@ module Geocoder
           JSON.parse(data)
         end
       rescue
-        raise_error(ResponseParseError.new(data)) or do
+        unless raise_error(ResponseParseError.new(data))
           Geocoder.log(:warn, "Geocoding API's response was not valid JSON")
           Geocoder.log(:debug, "Raw response: #{data}")
         end

--- a/lib/geocoder/lookups/base.rb
+++ b/lib/geocoder/lookups/base.rb
@@ -209,7 +209,10 @@ module Geocoder
           JSON.parse(data)
         end
       rescue
-        raise_error(ResponseParseError.new(data)) or Geocoder.log(:warn, "Geocoding API's response was not valid JSON: #{data}")
+        raise_error(ResponseParseError.new(data)) or do
+          Geocoder.log(:warn, "Geocoding API's response was not valid JSON")
+          Geocoder.log(:debug, "Raw response: #{data}")
+        end
       end
 
       ##


### PR DESCRIPTION
When a response can't be parsed it would be nice to be able to see the details when running in debug mode rather than receiving a warning of the full response body as this can be lengthy and uninformative and cause unnecessary noise in production system logs.