### PR TITLE
Don't default to the first service defined

### DIFF
--- a/lib/geocoder/lookup.rb
+++ b/lib/geocoder/lookup.rb
@@ -90,14 +90,13 @@ module Geocoder
       @services[name]
     end
 
-
     private # -----------------------------------------------------------------
 
     ##
     # Spawn a Lookup of the given name.
     #
     def spawn(name)
-      if all_services.include?(name)
+      if all_services.include?(name) || name == :empty
         name = name.to_s
         require "geocoder/lookups/#{name}"
         Geocoder::Lookup.const_get(classify_name(name)).new

--- a/lib/geocoder/lookups/empty.rb
+++ b/lib/geocoder/lookups/empty.rb
@@ -1,0 +1,9 @@
+require 'geocoder/lookups/base'
+
+module Geocoder::Lookup
+  class Empty < Base
+    def results(query)
+      []
+    end
+  end
+end

--- a/lib/geocoder/query.rb
+++ b/lib/geocoder/query.rb
@@ -32,12 +32,15 @@ module Geocoder
     # appropriate to the Query text.
     #
     def lookup
+      name = nil
+
       if !options[:street_address] and (options[:ip_address] or ip_address?)
-        name = options[:ip_lookup] || Configuration.ip_lookup || Geocoder::Lookup.ip_services.first
+        name = options[:ip_lookup] || Configuration.ip_lookup
       else
-        name = options[:lookup] || Configuration.lookup || Geocoder::Lookup.street_services.first
+        name = options[:lookup] || Configuration.lookup
       end
-      Lookup.get(name)
+
+      Lookup.get(name || :empty)
     end
 
     def url

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -147,6 +147,8 @@ module Geocoder
       end
     end
 
+    require 'geocoder/lookups/empty'
+
     require 'geocoder/lookups/bing'
     class Bing
       private

--- a/test/unit/lookups/empty_test.rb
+++ b/test/unit/lookups/empty_test.rb
@@ -1,0 +1,13 @@
+# encoding: utf-8
+
+require 'test_helper'
+
+class EmptyTest < GeocoderTestCase
+  def setup
+    Geocoder.configure(lookup: :empty)
+  end
+
+  def test_results_empty
+    assert_empty Geocoder.search('anything')
+  end
+end

--- a/test/unit/query_test.rb
+++ b/test/unit/query_test.rb
@@ -65,6 +65,12 @@ class QueryTest < GeocoderTestCase
     assert_instance_of Geocoder::Lookup::Nominatim, query.lookup
   end
 
+  def test_empty_lookup
+    Geocoder.configure(lookup: nil, ip_lookup: nil)
+    query = Geocoder::Query.new("address")
+    assert_instance_of Geocoder::Lookup::Empty, query.lookup
+  end
+
   def test_force_specify_ip_address
     Geocoder.configure({:ip_lookup => :google})
     query = Geocoder::Query.new("address", {:ip_address => true})


### PR DESCRIPTION
The way that the lookup was previously fetched, setting a lookup to `nil` would result in using the first entry in the services list: https://github.com/alexreisner/geocoder/compare/master...seejohnrun:master#diff-e9708023fb6f4a972c59b374f21a0ad4R37

This was pretty surprising to us and probably not the intended behavior. We'd expect that either:
* Fail when there is no valid lookup for a given type
* Disable that type of lookup when set to `nil`.

This PR goes with the second approach, which also gives us the ability to disable `ip_address` lookup by just setting the configuration value to `nil`.

Thank you for all your work on this gem, and please let me know any feedback! Ultimately our goal is to be able to turn off IP address lookup so if you prefer another way I'd be happy to make up a PR