### PR TITLE
Add adjustment to freegeoip to use freegeoip.app

### DIFF
--- a/lib/geocoder/lookups/freegeoip.rb
+++ b/lib/geocoder/lookups/freegeoip.rb
@@ -10,7 +10,7 @@ module Geocoder::Lookup
 
     def supported_protocols
       if configuration[:host]
-        [:http, :https]
+        [:https]
       else
         # use https for default host
         [:https]
@@ -44,8 +44,8 @@ module Geocoder::Lookup
         "city"         => "",
         "region_code"  => "",
         "region_name"  => "",
-        "metrocode"    => "",
-        "zipcode"      => "",
+        "metro_code"    => "",
+        "zip_code"      => "",
         "latitude"     => "0",
         "longitude"    => "0",
         "country_name" => "Reserved",
@@ -54,7 +54,7 @@ module Geocoder::Lookup
     end
 
     def host
-      configuration[:host] || "freegeoip.net"
+      configuration[:host] || "freegeoip.app"
     end
   end
 end

--- a/test/unit/lookups/freegeoip_test.rb
+++ b/test/unit/lookups/freegeoip_test.rb
@@ -35,6 +35,6 @@ class FreegeoipTest < GeocoderTestCase
     Geocoder.configure(freegeoip: {host: "local.com"})
     lookup = Geocoder::Lookup::Freegeoip.new
     query = Geocoder::Query.new("24.24.24.23")
-    assert_match %r(http://local\.com), lookup.query_url(query)
+    assert_match %r(https://local\.com), lookup.query_url(query)
   end
 end


### PR DESCRIPTION
Since freegeoip was deprecated a similar service called freegeoip.app provides the same results, the only thing mandatory is to use `https`

This PR makes adjustments to work with `:freegeoip` as before without changes for the end user

I was thinking about creating a new API provider but since freegeoip is deprecated, simply modifying it could bring it to life again

The same can be achieved without this PR, using:
```
Geocoder.configure(
  ip_lookup: :freegeoip,
  freegeoip: { host: "freegeoip.app" },
  use_https: true
)
```