### PR TITLE
Correct param name for api key is "apikey"

### DIFF
--- a/lib/geocoder/lookups/yandex.rb
+++ b/lib/geocoder/lookups/yandex.rb
@@ -51,7 +51,7 @@ module Geocoder::Lookup
         :geocode => q,
         :format => "json",
         :plng => "#{query.language || configuration.language}", # supports ru, uk, be
-        :api_key => configuration.api_key
+        :apikey => configuration.api_key
       }
       unless (bounds = query.options[:bounds]).nil?
         params[:bbox] = bounds.map{ |point| "%f,%f" % point }.join('~')

--- a/lib/geocoder/lookups/yandex.rb
+++ b/lib/geocoder/lookups/yandex.rb
@@ -51,7 +51,7 @@ module Geocoder::Lookup
         :geocode => q,
         :format => "json",
         :plng => "#{query.language || configuration.language}", # supports ru, uk, be
-        :key => configuration.api_key
+        :api_key => configuration.api_key
       }
       unless (bounds = query.options[:bounds]).nil?
         params[:bbox] = bounds.map{ |point| "%f,%f" % point }.join('~')


### PR DESCRIPTION
https://tech.yandex.ru/maps/doc/geocoder/desc/concepts/input_params-docpage/