### PR TITLE
Fix here mapping for state and add state_code

### DIFF
--- a/lib/geocoder/results/here.rb
+++ b/lib/geocoder/results/here.rb
@@ -26,8 +26,15 @@ module Geocoder::Result
       address_data['HouseNumber']
     end  
 
+    def state_code
+      address_data['State']
+    end
+
     def state
-      address_data['County']
+      fail unless d = address_data['AdditionalData']
+      if v = d.find{|ad| ad['key']=='StateName'}
+        return v['value']
+      end
     end
 
     def province


### PR DESCRIPTION
This pull request fixes a bug with mapping for `Here` as `state` was mapped to `county`.