### PR TITLE
Feature/allow coordinates in ban fr

### DIFF
--- a/lib/geocoder/lookups/ban_data_gouv_fr.rb
+++ b/lib/geocoder/lookups/ban_data_gouv_fr.rb
@@ -86,6 +86,12 @@ module Geocoder::Lookup
       unless (citycode = query.options[:citycode]).nil? || !code_param_is_valid?(citycode)
         params[:citycode] = citycode.to_s
       end
+      unless (lat = query.options[:lat]).nil? || !latitude_is_valid?(lat)
+        params[:lat] = lat
+      end
+      unless (lon = query.options[:lon]).nil? || !longitude_is_valid?(lon)
+        params[:lon] = lon
+      end
       params
     end
 
@@ -126,5 +132,12 @@ module Geocoder::Lookup
       (1..99999).include?(param.to_i)
     end
 
+    def latitude_is_valid?(param)
+      param.to_f <= 90 && param.to_f >= -90
+    end
+
+    def longitude_is_valid?(param)
+      param.to_f <= 180 && param.to_f >= -180
+    end
   end
 end

--- a/lib/geocoder/results/ban_data_gouv_fr.rb
+++ b/lib/geocoder/results/ban_data_gouv_fr.rb
@@ -7,7 +7,7 @@ module Geocoder::Result
     #### BASE METHODS ####
 
     def self.response_attributes
-      %w[limit attribution version licence type features]
+      %w[limit attribution version licence type features center]
     end
 
     response_attributes.each do |a|

--- a/test/unit/lookups/ban_data_gouv_fr_test.rb
+++ b/test/unit/lookups/ban_data_gouv_fr_test.rb
@@ -18,7 +18,7 @@ class BanDataGouvFrTest < GeocoderTestCase
     query = Geocoder::Query.new('13 rue yves toudic, 75010 Paris', lat: 48.789, lon: 2.789)
     lookup = Geocoder::Lookup.get(:ban_data_gouv_fr)
     res = lookup.query_url(query)
-    assert_equal 'http://api-adresse.data.gouv.fr/search/?lat=48.789&lon=2.789&q=13+rue+yves+toudic%2C+75010+Paris', res
+    assert_equal 'https://api-adresse.data.gouv.fr/search/?lat=48.789&lon=2.789&q=13+rue+yves+toudic%2C+75010+Paris', res
   end
 
   def test_query_for_reverse_geocode

--- a/test/unit/lookups/ban_data_gouv_fr_test.rb
+++ b/test/unit/lookups/ban_data_gouv_fr_test.rb
@@ -14,6 +14,13 @@ class BanDataGouvFrTest < GeocoderTestCase
     assert_equal 'https://api-adresse.data.gouv.fr/search/?q=13+rue+yves+toudic%2C+75010+Paris', res
   end
 
+  def test_query_for_geocode_with_geographic_priority
+    query = Geocoder::Query.new('13 rue yves toudic, 75010 Paris', lat: 48.789, lon: 2.789)
+    lookup = Geocoder::Lookup.get(:ban_data_gouv_fr)
+    res = lookup.query_url(query)
+    assert_equal 'http://api-adresse.data.gouv.fr/search/?lat=48.789&lon=2.789&q=13+rue+yves+toudic%2C+75010+Paris', res
+  end
+
   def test_query_for_reverse_geocode
     query = Geocoder::Query.new([48.770639, 2.364375])
     lookup = Geocoder::Lookup.get(:ban_data_gouv_fr)


### PR DESCRIPTION
I was not able to complete a bundle install (it has been resolving dependencies for a day now). 

Or start tests as 
```bash
ruby test/unit/lookups/ban_data_gouv_fr_test.rb
```
results in
```bash
Traceback (most recent call last):
	2: from test/unit/lookups/ban_data_gouv_fr_test.rb:2:in `<main>'
	1: from ~/.rbenv/versions/2.6.3/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
~/.rbenv/versions/2.6.3/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require': cannot load such file -- test_helper (LoadError)
```

what am I doing wrong ?

I was however able to load geocoder in irb and test the methods I used.