### PR TITLE
Remove unnecessary variable

### DIFF
--- a/lib/hash_recursive_merge.rb
+++ b/lib/hash_recursive_merge.rb
@@ -60,9 +60,8 @@ module HashRecursiveMerge
   #    h1.merge(h2)     #=> {"a" => 100, "b" = >254, "c" => {"c1" => 16, "c3" => 94}}
   # 
   def rmerge(other_hash)
-    r = {}
     merge(other_hash) do |key, oldval, newval|
-      r[key] = oldval.class == self.class ? oldval.rmerge(newval) : newval
+      oldval.class == self.class ? oldval.rmerge(newval) : newval
     end
   end
 


### PR DESCRIPTION
`o` variable in the `HashRecursiveMerge#rmerge` method definition is not necessary in the result hash calculation