### PR TITLE
Remove bad information from HERE API docs

### DIFF
--- a/README_API_GUIDE.md
+++ b/README_API_GUIDE.md
@@ -172,7 +172,7 @@ The [Google Places Search API](https://developers.google.com/places/web-service/
 
 ### Here/Nokia (`:here`)
 
-* **API key**: required (set `Geocoder.configure(api_key: [app_id, app_code])`)
+* **API key**: required
 * **Quota**: Depending on the API key
 * **Region**: world
 * **SSL support**: yes


### PR DESCRIPTION
Seems like with https://github.com/alexreisner/geocoder/issues/1429 and https://github.com/alexreisner/geocoder/pull/1430, the API key for HERE integration should now be provided like so:

```
Geocoder.configure(api_key:  "my api key")
```

The API key is displayed in HERE Project Page as documented here: https://developer.here.com/documentation/authentication/dev_guide/topics/api-key-credentials.html

![Pasted_Image_14_1_2020__14_31](https://user-images.githubusercontent.com/482561/72344771-ba9f6480-36da-11ea-9b4c-23cf7a5e1c60.png)
