### PR TITLE
[Yandex] Wrong condition for locality data

### DIFF
--- a/lib/geocoder/results/yandex.rb
+++ b/lib/geocoder/results/yandex.rb
@@ -98,7 +98,7 @@ module Geocoder::Result
     end
 
     def locality_data
-      dependent_locality && subadmin_locality && admin_locality
+      dependent_locality || subadmin_locality || admin_locality
     end
 
     def admin_locality

--- a/test/unit/lookups/yandex_test.rb
+++ b/test/unit/lookups/yandex_test.rb
@@ -73,4 +73,20 @@ class YandexTest < GeocoderTestCase
       assert_equal "", result.city
     end
   end
+
+  def test_yandex_result_returns_street_name
+    assert_nothing_raised do
+      set_api_key!(:yandex)
+      result = Geocoder.search("canada rue dupuis 14")[6]
+      assert_equal "Rue Hormidas-Dupuis", result.street
+    end
+  end
+
+  def test_yandex_result_returns_street_number
+    assert_nothing_raised do
+      set_api_key!(:yandex)
+      result = Geocoder.search("canada rue dupuis 14")[6]
+      assert_equal "14", result.street_number
+    end
+  end
 end


### PR DESCRIPTION
We should use one of these, cause geocoding results are different.

I add one commit with failing tests and another commit with a fix

I can't get `street` and `street_number` for such geocoding result:
```
 #<Geocoder::Result::Yandex:0x00007f7fcce5f288
  @data={
    "GeoObject"=>{
      "metaDataProperty"=>{
        "GeocoderMetaData"=>{
          "precision"=>"exact",
          "text"=>"Россия, Воронеж, Ленинский проспект, 184Б",
          "kind"=>"house",
          "Address"=>{
            "country_code"=>"RU",
            "formatted"=>"Россия, Воронеж, Ленинский проспект, 184Б",
            "postal_code"=>"394021",
            "Components"=>[
              {"kind"=>"country", "name"=>"Россия"},
              {"kind"=>"province", "name"=>"Центральный федеральный округ"},
              {"kind"=>"province", "name"=>"Воронежская область"},
              {"kind"=>"area", "name"=>"городской округ Воронеж"},
              {"kind"=>"locality", "name"=>"Воронеж"},
              {"kind"=>"street", "name"=>"Ленинский проспект"},
              {"kind"=>"house", "name"=>"184Б"}
            ]
          },
          "AddressDetails"=>{
            "Country"=>{
              "AddressLine"=>"Россия, Воронеж, Ленинский проспект, 184Б",
              "CountryNameCode"=>"RU",
              "CountryName"=>"Россия",
              "AdministrativeArea"=>{
                "AdministrativeAreaName"=>"Воронежская область",
                "SubAdministrativeArea"=>{
                  "SubAdministrativeAreaName"=>"городской округ Воронеж",
                  "Locality"=>{
                    "LocalityName"=>"Воронеж",
                    "Thoroughfare"=>{
                      "ThoroughfareName"=>"Ленинский проспект",
                      "Premise"=>{
                        "PremiseNumber"=>"184Б",
                        "PostalCode"=>{
                          "PostalCodeNumber"=>"394021"
                        }
                      }
                    }
                  }
                }
              }
            }
          }
        }
      },
      "name"=>"Ленинский проспект, 184Б",
      "description"=>"Воронеж, Россия",
      "boundedBy"=>{"Envelope"=>{"lowerCorner"=>"39.273033 51.705314", "upperCorner"=>"39.281243 51.710415"}},
      "Point"=>{"pos"=>"39.277138 51.707864"}
    }
  },
  @cache_hit=nil
>
```