### PR TITLE
Support IP search with port

### DIFF
--- a/lib/geocoder/ip_address.rb
+++ b/lib/geocoder/ip_address.rb
@@ -20,7 +20,8 @@ module Geocoder
     end
 
     def valid?
-      !!((self =~ Resolv::IPv4::Regex) || (self =~ Resolv::IPv6::Regex))
+      ip = self[/(?<=\[)(.*?)(?=\])/] || self
+      !!((ip =~ Resolv::IPv4::Regex) || (ip =~ Resolv::IPv6::Regex))
     end
   end
 end

--- a/test/unit/ip_address_test.rb
+++ b/test/unit/ip_address_test.rb
@@ -13,6 +13,7 @@ class IpAddressTest < GeocoderTestCase
     assert !Geocoder::IpAddress.new("232.65.123").valid?
     assert !Geocoder::IpAddress.new("::ffff:123.456.789").valid?
     assert !Geocoder::IpAddress.new("Test\n232.65.123.94").valid?
+    assert Geocoder::IpAddress.new("[3ffe:0b00:000:0000:0001:0000:0000:000a]:80").valid?
   end
 
   def test_internal


### PR DESCRIPTION
Resolves issue where trying to search via an IP address with a port was not working properly

Example:
`Geocoder.search("[3ffe:0b00:000:0000:0001:0000:0000:000a]:80")`

Resolves https://github.com/alexreisner/geocoder/issues/1396