### PR TITLE
Yandex fix. No more "found" param in meta section

### DIFF
--- a/lib/geocoder/lookups/yandex.rb
+++ b/lib/geocoder/lookups/yandex.rb
@@ -34,7 +34,7 @@ module Geocoder::Lookup
       end
       if doc = doc['response']['GeoObjectCollection']
         meta = doc['metaDataProperty']['GeocoderResponseMetaData']
-        return meta['found'].to_i > 0 ? doc['featureMember'] : []
+        return doc['featureMember'].to_a
       else
         Geocoder.log(:warn, "Yandex Geocoding API error: unexpected response format.")
         return []

--- a/lib/geocoder/lookups/yandex.rb
+++ b/lib/geocoder/lookups/yandex.rb
@@ -33,7 +33,6 @@ module Geocoder::Lookup
         return []
       end
       if doc = doc['response']['GeoObjectCollection']
-        meta = doc['metaDataProperty']['GeocoderResponseMetaData']
         return doc['featureMember'].to_a
       else
         Geocoder.log(:warn, "Yandex Geocoding API error: unexpected response format.")


### PR DESCRIPTION
Yandex response has changed. 
There was param named "found" before. But it was removed. So any geocode request returned empty array.
Actually i consider the condition as redundant.