### PR TITLE
Update from Mashape to RapidAPI

### DIFF
--- a/README_API_GUIDE.md
+++ b/README_API_GUIDE.md
@@ -421,7 +421,7 @@ IP Address Lookups
 * **Region**: world
 * **SSL support**: yes
 * **Languages**: English
-* **Documentation**: https://market.mashape.com/fcambus/telize
+* **Documentation**: https://rapidapi.com/fcambus/api/telize
 * **Terms of Service**: ?
 * **Limitations**: ?
 * **Notes**: To use Telize set `Geocoder.configure(ip_lookup: :telize, api_key: "your_api_key")`. Or configure your self-hosted telize with the `host` option: `Geocoder.configure(ip_lookup: :telize, telize: {host: "localhost"})`.

--- a/lib/geocoder/lookups/telize.rb
+++ b/lib/geocoder/lookups/telize.rb
@@ -16,7 +16,7 @@ module Geocoder::Lookup
       if configuration[:host]
         "#{protocol}://#{configuration[:host]}/location/#{query.sanitized_text}"
       else
-        "#{protocol}://telize-v1.p.mashape.com/location/#{query.sanitized_text}?mashape-key=#{api_key}"
+        "#{protocol}://telize-v1.p.rapidapi.com/location/#{query.sanitized_text}?rapidapi-key=#{api_key}"
       end
     end
 

--- a/test/unit/lookup_test.rb
+++ b/test/unit/lookup_test.rb
@@ -147,7 +147,7 @@ class LookupTest < GeocoderTestCase
   def test_telize_api_key
     Geocoder.configure(:api_key => "MY_KEY")
     g = Geocoder::Lookup::Telize.new
-    assert_match "mashape-key=MY_KEY", g.query_url(Geocoder::Query.new("232.65.123.94"))
+    assert_match "rapidapi-key=MY_KEY", g.query_url(Geocoder::Query.new("232.65.123.94"))
   end
 
   def test_ipinfo_io_api_key

--- a/test/unit/lookups/telize_test.rb
+++ b/test/unit/lookups/telize_test.rb
@@ -10,14 +10,14 @@ class TelizeTest < GeocoderTestCase
   def test_query_url
     lookup = Geocoder::Lookup::Telize.new
     query = Geocoder::Query.new("74.200.247.59")
-    assert_match %r{^https://telize-v1\.p\.mashape\.com/location/74\.200\.247\.59}, lookup.query_url(query)
+    assert_match %r{^https://telize-v1\.p\.rapidapi\.com/location/74\.200\.247\.59}, lookup.query_url(query)
   end
 
   def test_includes_api_key_when_set
     Geocoder.configure(api_key: "api_key")
     lookup = Geocoder::Lookup::Telize.new
     query = Geocoder::Query.new("74.200.247.59")
-    assert_match %r{/location/74\.200\.247\.59\?mashape-key=api_key}, lookup.query_url(query)
+    assert_match %r{/location/74\.200\.247\.59\?rapidapi-key=api_key}, lookup.query_url(query)
   end
 
   def test_uses_custom_host_when_set
@@ -38,7 +38,7 @@ class TelizeTest < GeocoderTestCase
     Geocoder.configure(use_https: false)
     lookup = Geocoder::Lookup::Telize.new
     query = Geocoder::Query.new("74.200.247.59")
-    assert_match %r{^https://telize-v1\.p\.mashape\.com}, lookup.query_url(query)
+    assert_match %r{^https://telize-v1\.p\.rapidapi\.com}, lookup.query_url(query)
   end
 
   def test_result_on_ip_address_search
@@ -83,7 +83,7 @@ class TelizeTest < GeocoderTestCase
     query = Geocoder::Query.new("8.8.8.8")
     qurl = lookup.send(:query_url, query)
     key = lookup.send(:cache_key, query)
-    assert qurl.include?("mashape-key")
-    assert !key.include?("mashape-key")
+    assert qurl.include?("rapidapi-key")
+    assert !key.include?("rapidapi-key")
   end
 end


### PR DESCRIPTION
The Mashape API proxy has been deprecated and needs to be replaced with RapidAPI proxy URL to work reliably. 