### PR TITLE
Support state_code in results from db-ip.com

### DIFF
--- a/lib/geocoder/results/db_ip_com.rb
+++ b/lib/geocoder/results/db_ip_com.rb
@@ -16,7 +16,7 @@ module Geocoder::Result
     end
 
     def state_code
-      @data['stateProv']
+      @data['stateProvCode']
     end
     alias_method :state, :state_code
 

--- a/test/fixtures/db_ip_com_madison_square_garden
+++ b/test/fixtures/db_ip_com_madison_square_garden
@@ -12,6 +12,7 @@
     "haw",
     "fr"
   ],
+  "stateProvCode": "CA",
   "stateProv": "California",
   "district": "Santa Clara County",
   "city": "Mountain View",

--- a/test/unit/lookups/db_ip_com_test.rb
+++ b/test/unit/lookups/db_ip_com_test.rb
@@ -32,10 +32,10 @@ class DbIpComTest < GeocoderTestCase
     result = Geocoder.search('23.255.240.0').first
 
     assert_equal [37.3861, -122.084], result.coordinates
-    assert_equal 'Mountain View, California 94043, United States', result.address
+    assert_equal 'Mountain View, CA 94043, United States', result.address
     assert_equal 'Mountain View', result.city
     assert_equal 'Santa Clara County', result.district
-    assert_equal 'California', result.state_code
+    assert_equal 'CA', result.state_code
     assert_equal '94043', result.zip_code
     assert_equal 'United States', result.country_name
     assert_equal 'US', result.country_code


### PR DESCRIPTION
Currently, the `state_code` method on a result from db-ip.com returns the full state name. But the data returned from their API actually does include a 2 character state code, under `stateProvCode`.

Here is a sample query that I just performed:

```irb
irb(main):005:0> results = Geocoder.search("96.27.101.109")
irb(main):006:0> results[0].state_code
=> "Ohio"
irb(main):007:0> results[0].data['stateProvCode']
=> "OH"
```