### PR TITLE
Update Pelias documentation

### DIFF
--- a/README_API_GUIDE.md
+++ b/README_API_GUIDE.md
@@ -187,15 +187,20 @@ The [Google Places Search API](https://developers.google.com/places/web-service/
 
 ### Pelias (`:pelias`)
 
+Open source geocoding engine which can be self-hosted. There are multiple service providers that can host Pelias instances (see notes).
+
 * **API key**: configurable (self-hosted service)
 * **Quota**: none (self-hosted service)
 * **Region**: world
 * **SSL support**: yes
-* **Languages**: en; see https://mapzen.com/documentation/search/language-codes/
-* **Documentation**: http://pelias.io/
-* **Terms of Service**: http://pelias.io/data_licenses.html
-* **Limitations**: See terms
+* **Languages**: en; see https://github.com/pelias/documentation/blob/master/language-codes.md
+* **Extra params**: See [Pelias documentation](https://github.com/pelias/documentation/blob/master/search.md#available-search-parameters)
+* **Documentation**: https://github.com/pelias/documentation/
+* **Terms of Service**: https://github.com/pelias/documentation/blob/master/data-sources.md
+* **Limitations**: See service provider terms
 * **Notes**: Configure your self-hosted pelias with the `endpoint` option: `Geocoder.configure(lookup: :pelias, api_key: 'your_api_key', pelias: {endpoint: 'self.hosted/pelias'})`. Defaults to `localhost`.
+    * [Geocode Earth](https://geocode.earth/cloud) - Cleared for Takeoff, Inc. (USA)
+    * [Geoapify](https://www.geoapify.com/maps-geocoging-routing-on-premise-installations/) - Geoapify GmbH (Germany)
 
 ### Data Science Toolkit (`:dstk`)
 


### PR DESCRIPTION
Some of the links in the Pelias documentation are not up to date.

This updates them to refer to the up to date documentation available at:
https://github.com/pelias/documentation

This also adds information about a couple of service providers for managed instances I found. There doesn't seem to be any references available to any other service providers than the "official" one (Geocode Earth). I just accidentally noticed Geoapify is also providing such service when implementing #1462 (their cloud service is not Pelias compatible but they provide managed Pelias as a separate service). I think these deserve to be listed somewhere for easier discovery.