### PR TITLE
Adds support for country file lookup to MaxMind Local

### DIFF
--- a/lib/geocoder/lookups/maxmind_local.rb
+++ b/lib/geocoder/lookups/maxmind_local.rb
@@ -30,7 +30,13 @@ module Geocoder::Lookup
     def results(query)
       if configuration[:file]
         geoip_class = RUBY_PLATFORM == "java" ? JGeoIP : GeoIP
-        result = geoip_class.new(configuration[:file]).city(query.to_s)
+        geoip_instance = geoip_class.new(configuration[:file])
+        result =
+          if configuration[:package] == :country
+            geoip_instance.country(query.to_s)
+          else
+            geoip_instance.city(query.to_s)
+          end
         result.nil? ? [] : [encode_hash(result.to_hash)]
       elsif configuration[:package] == :city
         addr = IPAddr.new(query.text).to_i


### PR DESCRIPTION
Hey @alexreisner, thanks for this great gem and keeping it up-to-date for 11+ years!

This PR allows the `file` and `package` options to be used together, which allows Geocoder to work with the `geoip-database` Ubuntu package (useful for platforms like [Heroku](https://devcenter.heroku.com/articles/stack-packages)).

```ruby
Geocoder.configure(
  ip_lookup: :maxmind_local,
  maxmind_local: {
    file: "/usr/share/GeoIP/GeoIP.dat",
    package: :country
  }
)
```

Otherwise, lookups fail with:

```text
UncaughtThrowError (uncaught throw "Invalid GeoIP database type, can't look up City by IP")
```

I didn't see any tests for the `file` option, so it's just been tested manually.