### PR TITLE
Reverse coordinates when parsing from NationaalregisterNl

### DIFF
--- a/lib/geocoder/results/nationaal_georegister_nl.rb
+++ b/lib/geocoder/results/nationaal_georegister_nl.rb
@@ -8,7 +8,7 @@ module Geocoder::Result
     end
 
     def coordinates
-      @data['centroide_ll'][6..-2].split(' ').map(&:to_f)
+      @data['centroide_ll'][6..-2].split(' ').map(&:to_f).reverse
     end
 
     def formatted_address

--- a/test/unit/lookups/nationaal_georegister_nl_test.rb
+++ b/test/unit/lookups/nationaal_georegister_nl_test.rb
@@ -2,7 +2,6 @@
 require 'test_helper'
 
 class NationaalGeoregisterNlTest < GeocoderTestCase
-
   def setup
     Geocoder.configure(lookup: :nationaal_georegister_nl)
   end
@@ -18,6 +17,7 @@ class NationaalGeoregisterNlTest < GeocoderTestCase
     assert_equal result.province,       'Noord-Holland'
     assert_equal result.province_code,  'PV27'
     assert_equal result.country_code,   'NL'
+    assert_equal result.latitude,       52.37316397
+    assert_equal result.longitude,      4.89089949
   end
-
 end


### PR DESCRIPTION
The coordinates are returned in a specific notation from the NationaalRegisterNl API:

`POINT(4.89133064 52.3739109)`

The result class parses that so we get 2 individual coordinates. But the gem expects it in this format `[latitude, longitude]`. The result class returned `[longitude, latitude]`. So if you'd use this with the `geocode` method you would get the coordinates saved in the wrong attribute. Therefor I reversed the array. 

Confirmation that the coordinates in the fixture and test are now correct (or close enough ;)):

https://www.coordinatenbepalen.nl/coordinates/144787-nieuwezijds-voorburgwal-147-1012rj-amsterdam

![Screenshot 2020-10-26 at 16 49 37](https://user-images.githubusercontent.com/642544/97195142-46d2d200-17ab-11eb-973b-160e8c13f96b.png)
