### PR TITLE
Allow single stubs to be removed in test mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,10 +532,14 @@ With the above stub defined, any query for "New York, NY" will return the result
       ]
     )
 
+You may also delete a single stub, or reset all stubs _including the default stub_:
+
+    Geocoder::Lookup::Test.delete_stub('New York, NY')
+    Geocoder::Lookup::Test.reset
+
 Notes:
 
 - Keys must be strings (not symbols) when calling `add_stub` or `set_default_stub`. For example `'country' =>` not `:country =>`.
-- To clear stubs (e.g. prior to another spec), use `Geocoder::Lookup::Test.reset`. This will clear all stubs _including the default stub_.
 - The stubbed result objects returned by the Test lookup do not support all the methods real result objects do. If you need to test interaction with real results it may be better to use an external stubbing tool and something like WebMock or VCR to prevent network calls.
 
 

--- a/lib/geocoder/lookups/test.rb
+++ b/lib/geocoder/lookups/test.rb
@@ -28,6 +28,10 @@ module Geocoder
         @stubs ||= {}
       end
 
+      def self.delete_stub(query_text)
+        stubs.delete(query_text)
+      end
+
       def self.reset
         @stubs = {}
         @default_stub = nil

--- a/test/unit/test_mode_test.rb
+++ b/test/unit/test_mode_test.rb
@@ -60,6 +60,20 @@ class TestModeTest < GeocoderTestCase
     assert_equal [], result
   end
 
+  def test_unsetting_stub
+    Geocoder::Lookup::Test.add_stub("New York, NY", [mock_attributes])
+
+    assert_nothing_raised ArgumentError do
+      Geocoder.search("New York, NY")
+    end
+
+    Geocoder::Lookup::Test.delete_stub("New York, NY")
+
+    assert_raise ArgumentError do
+      Geocoder.search("New York, NY")
+    end
+  end
+
   private
   def mock_attributes
     coordinates = [40.7143528, -74.0059731]


### PR DESCRIPTION
Hope this is a welcome possibility. I've got a test suite where folks want more fine-grained cleanup in their tests:

```ruby
  before(:all) do
    Geocoder::Lookup::Test.add_stub(
      "New York City, NY", [
        {  'coordinates'  => [40.7143528, -74.0059731] }
      ]
    )
  end

  after(:all) do
    Geocoder::Lookup::Test.delete_stub('New York City, NY')
  end
```

We didn't want to `reset` because the default stub doesn't need to change across the suite.

I took a stab at a name (`delete`, versus the word `reset` you use elsewhere, or maybe a more generic `remove`). Happy to take feedback. The unit test is also a _little_ indirect, but I think it covers the case?