### PR TITLE
Improve ban_data_gouv_fr result

### DIFF
--- a/lib/geocoder/results/ban_data_gouv_fr.rb
+++ b/lib/geocoder/results/ban_data_gouv_fr.rb
@@ -4,6 +4,27 @@ require 'geocoder/results/base'
 module Geocoder::Result
   class BanDataGouvFr < Base
 
+    STATE_CODE_MAPPINGS = {
+      "Guadeloupe" => "01",
+      "Martinique" => "02",
+      "Guyane" => "03",
+      "La Réunion" => "04",
+      "Mayotte" => "06",
+      "Île-de-France" => "11",
+      "Centre-Val de Loire" => "24",
+      "Bourgogne-Franche-Comté" => "27",
+      "Normandie" => "28",
+      "Hauts-de-France" => "32",
+      "Grand Est" => "44",
+      "Pays de la Loire" => "52",
+      "Bretagne" => "53",
+      "Nouvelle-Aquitaine" => "75",
+      "Occitanie" => "76",
+      "Auvergne-Rhône-Alpes" => "84",
+      "Provence-Alpes-Côte d'Azur" => "93",
+      "Corse" => "94"
+    }.freeze
+
     #### BASE METHODS ####
 
     def self.response_attributes
@@ -209,6 +230,10 @@ module Geocoder::Result
       end
     end
 
+    def region_code
+      STATE_CODE_MAPPINGS[region_name]
+    end
+
     def country
       "France"
     end
@@ -235,7 +260,7 @@ module Geocoder::Result
     alias_method :street, :street_name
     alias_method :city, :city_name
     alias_method :state, :region_name
-    alias_method :state_code, :state
+    alias_method :state_code, :region_code
 
     #### CITIES' METHODS ####
 

--- a/test/fixtures/ban_data_gouv_fr_montpellier
+++ b/test/fixtures/ban_data_gouv_fr_montpellier
@@ -20,7 +20,7 @@
         "name": "Montpellier",
         "city": "Montpellier",
         "postcode": "34080",
-        "context": "34, Hérault, Languedoc-Roussillon",
+        "context": "34, Hérault, Occitanie",
         "score": 0.9785090909090908,
         "label": "Montpellier",
         "id": "34172_34080",

--- a/test/unit/lookups/ban_data_gouv_fr_test.rb
+++ b/test/unit/lookups/ban_data_gouv_fr_test.rb
@@ -47,6 +47,7 @@ class BanDataGouvFrTest < GeocoderTestCase
     assert_equal '75', result.department_code
     assert_equal 'Paris', result.department_name
     assert_equal 'Île-de-France', result.region_name
+    assert_equal '11', result.region_code
     assert_equal 'France', result.country
     assert_equal 'FR', result.country_code
     assert_equal(48.870131, result.coordinates[0])
@@ -67,6 +68,7 @@ class BanDataGouvFrTest < GeocoderTestCase
     assert_equal '75', result.department_code
     assert_equal 'Paris', result.department_name
     assert_equal 'Île-de-France', result.region_name
+    assert_equal '11', result.region_code
     assert_equal(48.8589, result.coordinates[0])
     assert_equal(2.3469, result.coordinates[1])
   end
@@ -82,7 +84,8 @@ class BanDataGouvFrTest < GeocoderTestCase
     assert_equal(255100, result.population)
     assert_equal '34', result.department_code
     assert_equal 'Hérault', result.department_name
-    assert_equal 'Languedoc-Roussillon', result.region_name
+    assert_equal 'Occitanie', result.region_name
+    assert_equal '76', result.region_code
     assert_equal(43.611024, result.coordinates[0])
     assert_equal(3.875521, result.coordinates[1])
   end
@@ -105,6 +108,7 @@ class BanDataGouvFrTest < GeocoderTestCase
     assert_equal '94', result.department_code
     assert_equal 'Val-de-Marne', result.department_name
     assert_equal 'Île-de-France', result.region_name
+    assert_equal '11', result.region_code
     assert_equal 'France', result.country
     assert_equal 'FR', result.country_code
     assert_equal(48.770639, result.coordinates[0])


### PR DESCRIPTION
We have `region_name`, but unfortunately we don't have `region_code`. When storing regions in a database I feel like it's much better to store a technical code rather than a name, it can be error prone especially because of different ways to write it (french is weird).

Unfortunately the ban_data_gouv API does not provide with the region code, only its name.

I used the [region API](https://geo.api.gouv.fr/decoupage-administratif/regions) to get a hard-coded list of regions and their code and use it as lookup.

Those region names and code should not change so often so I figure this is an OK way to solve the problem, I don't think making an API call to get the region code would be advised, maybe if hardcoding the codes is a no-go, we could memoize or cache the API result so we only make one extra API call.

WDYT ?