### PR TITLE
Fix link to CONTRIBUTING.md in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ The Rest:
 * [Technical Discussions](#technical-discussions)
 * [Troubleshooting](#troubleshooting)
 * [Known Issues](#known-issues)
-* [Reporting Issues](#reporting-issues)
-* [Contributing](#contributing)
+* [Reporting Issues](https://github.com/alexreisner/geocoder/blob/master/CONTRIBUTING.md#reporting-bugs)
+* [Contributing](https://github.com/alexreisner/geocoder/blob/master/CONTRIBUTING.md#making-changes)
 
 See Also:
 


### PR DESCRIPTION
Hi folks! 👋 

The documentation section on contributing was moved to a separate file in https://github.com/alexreisner/geocoder/commit/a81e028cf21d1fd31f3990ed22c466962f138a21, but the link in the main README still used anchors to the README itself for both the 'Contributing' and 'Reporting Issues' links.

This updates those links so they point to the contributing file on GitHub. Even though it's now a small document, both links point to the heading for the relevant section using anchors.