### PR TITLE
Add support for the new OS Data Hub to uk_ordnance_survey_names lookup

### DIFF
--- a/lib/geocoder/lookups/uk_ordnance_survey_names.rb
+++ b/lib/geocoder/lookups/uk_ordnance_survey_names.rb
@@ -13,7 +13,7 @@ module Geocoder::Lookup
     end
 
     def base_query_url(query)
-      "#{protocol}://api.ordnancesurvey.co.uk/opennames/v1/find?"
+      "#{protocol}://api.os.uk/search/names/v1/find?"
     end
 
     def required_api_key_parts

--- a/test/fixtures/uk_ordnance_survey_names_SW1A1AA
+++ b/test/fixtures/uk_ordnance_survey_names_SW1A1AA
@@ -1,6 +1,6 @@
 {
     "header": {
-        "uri": "https://api.ordnancesurvey.co.uk/opennames/v1/find?query=SW1a1AA&fq=local_type%3ACity%20local_type%3AHamlet%20local_type%3AOther_Settlement%20local_type%3ATown%20local_type%3AVillage%20local_type%3APostcode",
+        "uri": "https://api.os.uk/search/names/v1/find?query=SW1a1AA&fq=local_type%3ACity%20local_type%3AHamlet%20local_type%3AOther_Settlement%20local_type%3ATown%20local_type%3AVillage%20local_type%3APostcode",
         "query": "SW1a1AA",
         "format": "JSON",
         "maxresults": 100,

--- a/test/fixtures/uk_ordnance_survey_names_london
+++ b/test/fixtures/uk_ordnance_survey_names_london
@@ -1,6 +1,6 @@
 {
     "header": {
-        "uri": "https://api.ordnancesurvey.co.uk/opennames/v1/find?query=London&fq=local_type%3ACity%20local_type%3AHamlet%20local_type%3AOther_Settlement%20local_type%3ATown%20local_type%3AVillage%20local_type%3APostcode",
+        "uri": "https://api.os.uk/search/names/v1/find?query=London&fq=local_type%3ACity%20local_type%3AHamlet%20local_type%3AOther_Settlement%20local_type%3ATown%20local_type%3AVillage%20local_type%3APostcode",
         "query": "London",
         "format": "JSON",
         "maxresults": 100,

--- a/test/fixtures/uk_ordnance_survey_names_no_results
+++ b/test/fixtures/uk_ordnance_survey_names_no_results
@@ -1,6 +1,6 @@
 {
     "header": {
-        "uri": "https://api.ordnancesurvey.co.uk/opennames/v1/find?query=sxz%60x%60zx%60xz%60xz%60&fq=local_type%3ACity%20local_type%3AHamlet%20local_type%3AOther_Settlement%20local_type%3ATown%20local_type%3AVillage%20local_type%3APostcode",
+        "uri": "https://api.os.uk/search/names/v1/find?query=sxz%60x%60zx%60xz%60xz%60&fq=local_type%3ACity%20local_type%3AHamlet%20local_type%3AOther_Settlement%20local_type%3ATown%20local_type%3AVillage%20local_type%3APostcode",
         "query": "sxz`x`zx`xz`xz`",
         "format": "JSON",
         "maxresults": 100,


### PR DESCRIPTION
The Ordnance Survey API have launched [OS Data Hub](https://osdatahub.os.uk/). As part of this, users are being pushed to migrate their use to the Data Hub **before 31 May,** which uses a new API endpoint. 

This PR allows the gem to support the new endpoint alongside the existing one. I'm not sure what will happen to the existing endpoint come 31 May, but for now this will allow those who use this gem and wish to migrate to do just that.

They say that the functionality of their API hasn't changed at all. (see screenshot)

![image](https://user-images.githubusercontent.com/25187547/114041936-e200c500-987c-11eb-8dcc-c4530b3fb03f.png)
