### PR TITLE
Adjust state_code for Esri lookups

### DIFF
--- a/lib/geocoder/results/esri.rb
+++ b/lib/geocoder/results/esri.rb
@@ -16,11 +16,14 @@ module Geocoder::Result
       end
     end
 
-    def state_code
+    def state
       attributes['Region']
     end
 
-    alias_method :state, :state_code
+    def state_code
+      abbr = attributes['RegionAbbr']
+      abbr.to_s == "" ? state : abbr
+    end
 
     def country
       country_key = reverse_geocode? ? "CountryCode" : "Country"

--- a/test/fixtures/esri_austin_tx
+++ b/test/fixtures/esri_austin_tx
@@ -43,6 +43,7 @@
      "City": "",
      "Subregion": "Travis",
      "Region": "Texas",
+     "RegionAbbr": "TX",
      "Postal": "",
      "PostalExt": "",
      "Country": "USA",

--- a/test/fixtures/esri_madison_square_garden
+++ b/test/fixtures/esri_madison_square_garden
@@ -39,6 +39,7 @@
      "City": "New York",
      "Subregion": "New York",
      "Region": "New York",
+     "RegionAbbr": "NY",
      "Postal": "10001",
      "PostalExt": "",
      "Country": "USA",

--- a/test/fixtures/esri_new_york_ny
+++ b/test/fixtures/esri_new_york_ny
@@ -43,6 +43,7 @@
      "City": "",
      "Subregion": "New York",
      "Region": "New York",
+     "RegionAbbr": "NY",
      "Postal": "",
      "PostalExt": "",
      "Country": "USA",

--- a/test/fixtures/esri_washington_dc
+++ b/test/fixtures/esri_washington_dc
@@ -43,6 +43,7 @@
      "City": "",
      "Subregion": "District of Columbia",
      "Region": "District of Columbia",
+     "RegionAbbr": "DC",
      "Postal": "",
      "PostalExt": "",
      "Country": "USA",

--- a/test/unit/lookups/esri_test.rb
+++ b/test/unit/lookups/esri_test.rb
@@ -122,6 +122,7 @@ class EsriTest < GeocoderTestCase
     assert_equal "Madison Square Garden", result.address
     assert_equal "New York", result.city
     assert_equal "New York", result.state
+    assert_equal "NY", result.state_code
     assert_equal "Madison Square Garden", result.place_name
     assert_equal "Sports Complex", result.place_type
     assert_equal(40.75004981300049, result.coordinates[0])
@@ -132,6 +133,7 @@ class EsriTest < GeocoderTestCase
     result = Geocoder.search("washington dc").first
     assert_equal "Washington", result.city
     assert_equal "District of Columbia", result.state
+    assert_equal "DC", result.state_code
     assert_equal "USA", result.country
     assert_equal "Washington, D. C., District of Columbia, United States", result.address
     assert_equal "Washington", result.place_name
@@ -144,6 +146,7 @@ class EsriTest < GeocoderTestCase
     result = Geocoder.search("austin tx").first
     assert_equal "Austin", result.city
     assert_equal "Texas", result.state
+    assert_equal "TX", result.state_code
     assert_equal "USA", result.country
     assert_equal "Austin, Texas, United States", result.address
     assert_equal "Austin", result.place_name
@@ -156,6 +159,7 @@ class EsriTest < GeocoderTestCase
     result = Geocoder.search("new york ny").first
     assert_equal "New York City", result.city
     assert_equal "New York", result.state
+    assert_equal "NY", result.state_code
     assert_equal "USA", result.country
     assert_equal "New York City, New York, United States", result.address
     assert_equal "New York City", result.place_name
@@ -171,6 +175,7 @@ class EsriTest < GeocoderTestCase
     assert_equal "4 Avenue Gustave Eiffel", result.address
     assert_equal "Paris", result.city
     assert_equal "Île-de-France", result.state
+    assert_equal "Île-de-France", result.state_code
     assert_equal "4 Avenue Gustave Eiffel", result.place_name
     assert_equal "Address", result.place_type
     assert_equal(48.858129997357558, result.coordinates[0])


### PR DESCRIPTION
Not sure if this is a newer addition to the Esri API, but this PR maps `state_code` to the region abbreviation field, and defaults it back to the old implementation of `state` if it's nil or empty. 

Here's an example of Esri location data
```
irb(main):001:0> Geocoder.config.lookup #=> :esri
irb(main):002:0> pp Geocoder.search('Portland, OR').first.data['locations'].first
{"name"=>"Portland, Oregon",
 "extent"=>
  {"xmin"=>-122.82162999999996,
   "ymin"=>45.365790000000075,
   "xmax"=>-122.52962999999995,
   "ymax"=>45.65779000000008},
 "feature"=>
  {"geometry"=>{"x"=>-122.67562999999996, "y"=>45.511790000000076},
   "attributes"=>
    {"Loc_name"=>"World",
     "Status"=>"M",
     "Score"=>100,
     "Match_addr"=>"Portland, Oregon",
     "LongLabel"=>"Portland, OR, USA",
     "ShortLabel"=>"Portland",
     "Addr_type"=>"Locality",
     "Type"=>"City",
     "PlaceName"=>"Portland",
     "Place_addr"=>"Portland, Oregon",
     "Phone"=>"",
     "URL"=>"",
     "Rank"=>3,
     "AddBldg"=>"",
     "AddNum"=>"",
     "AddNumFrom"=>"",
     "AddNumTo"=>"",
     "AddRange"=>"",
     "Side"=>"",
     "StPreDir"=>"",
     "StPreType"=>"",
     "StName"=>"",
     "StType"=>"",
     "StDir"=>"",
     "BldgType"=>"",
     "BldgName"=>"",
     "LevelType"=>"",
     "LevelName"=>"",
     "UnitType"=>"",
     "UnitName"=>"",
     "SubAddr"=>"",
     "StAddr"=>"",
     "Block"=>"",
     "Sector"=>"",
     "Nbrhd"=>"",
     "District"=>"",
     "City"=>"Portland",
     "MetroArea"=>"Portland-Vancouver Metro Area",
     "Subregion"=>"Multnomah County",
     "Region"=>"Oregon",
     "RegionAbbr"=>"OR",
     "Territory"=>"",
     "Zone"=>"",
     "Postal"=>"",
     "PostalExt"=>"",
     "Country"=>"USA",
     "LangCode"=>"ENG",
     "Distance"=>0,
     "X"=>-122.67562999999996,
     "Y"=>45.511790000000076,
     "DisplayX"=>-122.67562999999996,
     "DisplayY"=>45.511790000000076,
     "Xmin"=>-122.82162999999996,
     "Xmax"=>-122.52962999999995,
     "Ymin"=>45.365790000000075,
     "Ymax"=>45.65779000000008,
     "ExInfo"=>""}}}
```

Thanks for this wonderful tool 😄  LMK if there's anything else that needs to be done here