### PR TITLE
feat: add configuration option for maxminddb local_ip_alias

### DIFF
--- a/lib/geocoder/lookups/geoip2.rb
+++ b/lib/geocoder/lookups/geoip2.rb
@@ -37,6 +37,10 @@ module Geocoder
       def results(query)
         return [] unless configuration[:file]
 
+        if @mmdb.respond_to?(:local_ip_alias) && !configuration[:local_ip_alias].nil?
+          @mmdb.local_ip_alias = configuration[:local_ip_alias]
+        end
+
         result = @mmdb.lookup(query.to_s)
         result.nil? ? [] : [result]
       end


### PR DESCRIPTION
Adds a configuration option to use the local_ip_alias attribute of the maxminddb library to use a local IP address to geolocate during testing. I don't use the Hive::GeoIP2 gem to test it with but the configuration option will only work if the class responds to the attribute so it shouldn't fail if it doesn't exist.