### PR TITLE
Proper language param for bing maps.

### DIFF
--- a/lib/geocoder/lookups/bing.rb
+++ b/lib/geocoder/lookups/bing.rb
@@ -54,7 +54,7 @@ module Geocoder::Lookup
     def query_url_params(query)
       {
         key: configuration.api_key,
-        language: (query.language || configuration.language)
+        culture: (query.language || configuration.language)
       }.merge(super)
     end
 

--- a/test/unit/lookup_test.rb
+++ b/test/unit/lookup_test.rb
@@ -57,7 +57,7 @@ class LookupTest < GeocoderTestCase
   end
 
   {
-    :bing => :language,
+    :bing => :culture,
     :google => :language,
     :google_premier => :language,
     :here => :language,


### PR DESCRIPTION
As you can check documentation https://docs.microsoft.com/en-us/bingmaps/rest-services/common-parameters-and-types/culture-parameter for response in proper language you should add culture param instead language