### PR TITLE
Update ip2location lookup for v2 API

### DIFF
--- a/lib/geocoder/lookups/ip2location.rb
+++ b/lib/geocoder/lookups/ip2location.rb
@@ -23,11 +23,11 @@ module Geocoder::Lookup
     end
 
     def query_url_params(query)
-      {
+      super.merge(
         key: configuration.api_key,
         ip: query.sanitized_text,
         package: configuration[:package],
-      }.merge(super)
+      )
     end
 
     def results(query)

--- a/lib/geocoder/lookups/ip2location.rb
+++ b/lib/geocoder/lookups/ip2location.rb
@@ -8,6 +8,10 @@ module Geocoder::Lookup
       "IP2LocationApi"
     end
 
+    def required_api_key_parts
+      ['key']
+    end
+
     def supported_protocols
       [:http, :https]
     end
@@ -15,15 +19,15 @@ module Geocoder::Lookup
     private # ----------------------------------------------------------------
 
     def base_query_url(query)
-      "#{protocol}://api.ip2location.com/?"
+      "#{protocol}://api.ip2location.com/v2/?"
     end
 
     def query_url_params(query)
-      params = super
-      if configuration.has_key?(:package)
-        params.merge!(package: configuration[:package])
-      end
-      params
+      {
+        key: configuration.api_key,
+        ip: query.sanitized_text,
+        package: configuration[:package],
+      }.merge(super)
     end
 
     def results(query)

--- a/test/unit/lookups/ip2location_test.rb
+++ b/test/unit/lookups/ip2location_test.rb
@@ -4,7 +4,21 @@ require 'test_helper'
 class Ip2locationTest < GeocoderTestCase
 
   def setup
-    Geocoder.configure(:ip_lookup => :ip2location)
+    Geocoder::Configuration.instance.data.clear
+    Geocoder::Configuration.set_defaults
+    Geocoder.configure(ip_lookup: :ip2location)
+    set_api_key!(:ip2location)
+  end
+
+  def test_ip2location_query_url
+    query = Geocoder::Query.new('8.8.8.8')
+    assert_equal 'http://api.ip2location.com/v2/?ip=8.8.8.8&key=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', query.url
+  end
+
+  def test_ip2location_query_url_with_package
+    Geocoder.configure(ip2location: {package: 'WS3'})
+    query = Geocoder::Query.new('8.8.8.8')
+    assert_equal 'http://api.ip2location.com/v2/?ip=8.8.8.8&key=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&package=WS3', query.url
   end
 
   def test_ip2location_lookup_address


### PR DESCRIPTION
Just a little PR to update the `ip2location` lookup to use [their v2 API](https://www.ip2location.com/web-service/ip2location).