### PR TITLE
Accept IPAddr when initializing an IpAddress

### DIFF
--- a/lib/geocoder/ip_address.rb
+++ b/lib/geocoder/ip_address.rb
@@ -7,6 +7,12 @@ module Geocoder
       '192.168.0.0/16',
     ].map { |ip| IPAddr.new(ip) }.freeze
 
+    def initialize(ip)
+      ip = ip.to_string if ip.is_a?(IPAddr)
+
+      super(ip)
+    end
+
     def internal?
       loopback? || private?
     end

--- a/test/unit/ip_address_test.rb
+++ b/test/unit/ip_address_test.rb
@@ -5,9 +5,11 @@ class IpAddressTest < GeocoderTestCase
 
   def test_valid
     assert Geocoder::IpAddress.new("232.65.123.94").valid?
+    assert Geocoder::IpAddress.new(IPAddr.new("232.65.123.94")).valid?
     assert !Geocoder::IpAddress.new("666.65.123.94").valid?
     assert Geocoder::IpAddress.new("::ffff:12.34.56.78").valid?
     assert Geocoder::IpAddress.new("3ffe:0b00:0000:0000:0001:0000:0000:000a").valid?
+    assert Geocoder::IpAddress.new(IPAddr.new("3ffe:0b00:0000:0000:0001:0000:0000:000a")).valid?
     assert Geocoder::IpAddress.new("::1").valid?
     assert !Geocoder::IpAddress.new("232.65.123.94.43").valid?
     assert !Geocoder::IpAddress.new("232.65.123").valid?


### PR DESCRIPTION
If using `geocoded_by` with an ActiveRecord column with an `inet` type the value is automatically converted to an `IPAddr`. This then prevents geocoder from recognizing it as an IP, as it expects a string.

This updates the `IpAddress` initializer to accept  and convert an `IPAddr`.