### PR TITLE
Add support for fields param to google_places_details lookup

### DIFF
--- a/lib/geocoder/lookups/google_places_details.rb
+++ b/lib/geocoder/lookups/google_places_details.rb
@@ -36,8 +36,30 @@ module Geocoder
       def query_url_google_params(query)
         {
           placeid: query.text,
+          fields: fields(query),
           language: query.language || configuration.language
         }
+      end
+
+      def fields(query)
+        query_fields = query.options[:fields]
+        return format_fields(query_fields) if query_fields
+
+        default_fields
+      end
+
+      # https://developers.google.com/maps/documentation/places/web-service/details#fields
+      def default_fields
+        legacy = %w[permanently_closed]
+        basic = %w[address_component adr_address business_status formatted_address geometry icon name
+          photo place_id plus_code type url utc_offset vicinity]
+        contact = %w[formatted_phone_number international_phone_number opening_hours website]
+        atmosphere = %W[price_level rating review user_ratings_total]
+        format_fields(legacy, basic, contact, atmosphere)
+      end
+
+      def format_fields(*fields)
+        fields.flatten.join(',')
       end
     end
   end


### PR DESCRIPTION
Hi @alexreisner, 

I modeled support for a fields param after the fields param in the [google_places_search](https://github.com/alexreisner/geocoder/blob/master/lib/geocoder/lookups/google_places_search.rb) lookup. 

This adds support for a fields param without changing existing behavior if you don't pass a fields param.

Please let me know if you're open to adding support for a fields param to this lookup and if you'd like to see any changes. If you're open to the change, I could also update the readme as a part of the PR.

Thanks!