### PR TITLE
Improve ipqualityscore OverQueryLimitError detection

### DIFF
--- a/lib/geocoder/lookups/ipqualityscore.rb
+++ b/lib/geocoder/lookups/ipqualityscore.rb
@@ -29,7 +29,7 @@ module Geocoder::Lookup
       when /invalid (.*) key/i
         raise_error Geocoder::InvalidApiKey ||
                     Geocoder.log(:warn, "#{name} API error: invalid api key.")
-      when /insufficient credits/
+      when /insufficient credits/, /exceeded your request quota/
         raise_error Geocoder::OverQueryLimitError ||
                     Geocoder.log(:warn, "#{name} API error: query limit exceeded.")
       when /invalid (.*) address/i

--- a/test/fixtures/ipqualityscore_insufficient_credits
+++ b/test/fixtures/ipqualityscore_insufficient_credits
@@ -1,0 +1,5 @@
+{
+  "success": false,
+  "message": "You have insufficient credits to make this query. Please contact IPQualityScore support if this error persists.",
+  "request_id": "5DqddgrDBo9DWfl"
+}

--- a/test/fixtures/ipqualityscore_quota_exceeded
+++ b/test/fixtures/ipqualityscore_quota_exceeded
@@ -1,5 +1,5 @@
 {
   "success": false,
-  "message": "You have insufficient credits to make this query. Please contact IPQualityScore support if this error persists.",
+  "message": "You have exceeded your request quota of 200 per day. Please upgrade to increase your request quota.",
   "request_id": "5DqddgrDBo9DWfl"
 }

--- a/test/unit/lookups/ipqualityscore_test.rb
+++ b/test/unit/lookups/ipqualityscore_test.rb
@@ -68,7 +68,14 @@ class IpqualityscoreTest < GeocoderTestCase
     end
   end
 
-  def test_raises_over_query_limit_exception
+  def test_raises_over_query_limit_exception_insufficient_credits
+    Geocoder.configure always_raise: :all
+    assert_raises Geocoder::OverQueryLimitError do
+      Geocoder::Lookup::Ipqualityscore.new.send(:results, Geocoder::Query.new('insufficient credits'))
+    end
+  end
+
+  def test_raises_over_query_limit_exception_quota_exceeded
     Geocoder.configure always_raise: :all
     assert_raises Geocoder::OverQueryLimitError do
       Geocoder::Lookup::Ipqualityscore.new.send(:results, Geocoder::Query.new('quota exceeded'))


### PR DESCRIPTION
A small update to improve the over-quota handling for IPQualityScore geocoding lookups.