### PR TITLE
Remove duplicate Geocoder.configure

### DIFF
--- a/test/unit/lookups/geocodio_test.rb
+++ b/test/unit/lookups/geocodio_test.rb
@@ -47,21 +47,21 @@ class GeocodioTest < GeocoderTestCase
   end
 
   def test_raises_invalid_request_exception
-    Geocoder.configure Geocoder.configure(:always_raise => [Geocoder::InvalidRequest])
+    Geocoder.configure(:always_raise => [Geocoder::InvalidRequest])
     assert_raises Geocoder::InvalidRequest do
       Geocoder.search("invalid")
     end
   end
 
   def test_raises_api_key_exception
-    Geocoder.configure Geocoder.configure(:always_raise => [Geocoder::InvalidApiKey])
+    Geocoder.configure(:always_raise => [Geocoder::InvalidApiKey])
     assert_raises Geocoder::InvalidApiKey do
       Geocoder.search("bad api key")
     end
   end
 
   def test_raises_over_limit_exception
-    Geocoder.configure Geocoder.configure(:always_raise => [Geocoder::OverQueryLimitError])
+    Geocoder.configure(:always_raise => [Geocoder::OverQueryLimitError])
     assert_raises Geocoder::OverQueryLimitError do
       Geocoder.search("over query limit")
     end


### PR DESCRIPTION
I made a copy of these tests to start which is how I introduced the typo here: https://github.com/alexreisner/geocoder/pull/1521#discussion_r695942405

So I figured I'd remove it from this file so no one else makes the same copy-pasta mistake