### PR TITLE
Open for extensions + redis expiration

### DIFF
--- a/lib/generators/geocoder/config/templates/initializer.rb
+++ b/lib/generators/geocoder/config/templates/initializer.rb
@@ -10,7 +10,7 @@ Geocoder.configure(
   # api_key: nil,               # API key for geocoding service
   # cache: nil,                 # cache object (must respond to #[], #[]=, and #del)
   # cache_prefix: 'geocoder:',  # prefix (string) to use for all cache keys
-  # expire: 1.day,              # expiration time (ttl)
+  # cache_expiration: 1.day,    # expiration time (ttl)
 
   # Exceptions that should not be rescued by default
   # (if you want to implement custom error handling);

--- a/lib/generators/geocoder/config/templates/initializer.rb
+++ b/lib/generators/geocoder/config/templates/initializer.rb
@@ -9,7 +9,7 @@ Geocoder.configure(
   # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
   # api_key: nil,               # API key for geocoding service
   # cache: nil,                 # cache object (must respond to #[], #[]=, and #del)
-  # cache_prefix: 'geocoder:',  # - DEPRECATED - prefix (string) to use for all cache keys
+  # cache_prefix: 'geocoder:',  # - DEPRECATED - prefix (string) to use for all cache keys, set false to disable
 
   # Exceptions that should not be rescued by default
   # (if you want to implement custom error handling);

--- a/lib/generators/geocoder/config/templates/initializer.rb
+++ b/lib/generators/geocoder/config/templates/initializer.rb
@@ -10,6 +10,7 @@ Geocoder.configure(
   # api_key: nil,               # API key for geocoding service
   # cache: nil,                 # cache object (must respond to #[], #[]=, and #del)
   # cache_prefix: 'geocoder:',  # prefix (string) to use for all cache keys
+  # expire: 1.day,              # expiration time (ttl)
 
   # Exceptions that should not be rescued by default
   # (if you want to implement custom error handling);

--- a/lib/generators/geocoder/config/templates/initializer.rb
+++ b/lib/generators/geocoder/config/templates/initializer.rb
@@ -9,8 +9,7 @@ Geocoder.configure(
   # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
   # api_key: nil,               # API key for geocoding service
   # cache: nil,                 # cache object (must respond to #[], #[]=, and #del)
-  # cache_prefix: 'geocoder:',  # prefix (string) to use for all cache keys
-  # cache_expiration: 1.day,    # expiration time (ttl)
+  # cache_prefix: 'geocoder:',  # - DEPRECATED - prefix (string) to use for all cache keys
 
   # Exceptions that should not be rescued by default
   # (if you want to implement custom error handling);
@@ -20,4 +19,13 @@ Geocoder.configure(
   # Calculation options
   # units: :mi,                 # :km for kilometers or :mi for miles
   # distances: :linear          # :spherical or :linear
+
+  # Cache service type-specific configurations
+  # cache_options: {}
+
+  # Redis cache configurations (for cache_options):
+  #     {
+  #       expiration: 2.days          # redis ttl for all cache
+  #       prefix: 'geocoder:'         # prefix to add to redis keys, if used cache_prefix will be ignored
+  #     }
 )

--- a/lib/geocoder/cache.rb
+++ b/lib/geocoder/cache.rb
@@ -4,7 +4,7 @@ module Geocoder
   class Cache
 
     def initialize(store, config)
-      @class = (Object.const_get("Geocoder::CacheStore::#{store.class}") rescue Geocoder::CacheStore::Other)
+      @class = (Object.const_get("Geocoder::CacheStore::#{store.class}") rescue Geocoder::CacheStore::Generic)
       @store_service = @class.new(store, config)
     end
 

--- a/lib/geocoder/cache.rb
+++ b/lib/geocoder/cache.rb
@@ -3,9 +3,9 @@ Dir["#{__dir__}/cache_stores/*.rb"].each {|file| require file }
 module Geocoder
   class Cache
 
-    def initialize(store, configs)
+    def initialize(store, config)
       @class = ("Geocoder::CacheStore::#{store.class}".constantize rescue Geocoder::CacheStore::Other)
-      @store_service = @class.new(store, configs)
+      @store_service = @class.new(store, config)
     end
 
     ##

--- a/lib/geocoder/cache.rb
+++ b/lib/geocoder/cache.rb
@@ -4,7 +4,7 @@ module Geocoder
   class Cache
 
     def initialize(store, config)
-      @class = ("Geocoder::CacheStore::#{store.class}".constantize rescue Geocoder::CacheStore::Other)
+      @class = (Object.const_get("Geocoder::CacheStore::#{store.class}") rescue Geocoder::CacheStore::Other)
       @store_service = @class.new(store, config)
     end
 

--- a/lib/geocoder/cache_stores/base.rb
+++ b/lib/geocoder/cache_stores/base.rb
@@ -1,0 +1,40 @@
+module Geocoder::CacheStore
+  class Base
+    def initialize(store, options)
+      @store = store
+      @configs = options
+      @prefix = configs[:cache_prefix]
+    end
+
+    ##
+    # Array of keys with the currently configured prefix
+    # that have non-nil values.
+    def keys
+      store.keys.select { |k| k.match(/^#{prefix}/) and self[k] }
+    end
+
+    ##
+    # Array of cached URLs.
+    #
+    def urls
+      keys
+    end
+
+    protected # ----------------------------------------------------------------
+
+    def prefix; @prefix; end
+    def store; @store; end
+    def configs; @configs; end
+
+    ##
+    # Cache key for a given URL.
+    #
+    def key_for(url)
+      if url.match(/^#{prefix}/)
+        url
+      else
+        [prefix, url].join
+      end
+    end
+  end
+end

--- a/lib/geocoder/cache_stores/base.rb
+++ b/lib/geocoder/cache_stores/base.rb
@@ -3,7 +3,7 @@ module Geocoder::CacheStore
     def initialize(store, options)
       @store = store
       @config = options
-      @prefix = config[:cache_prefix]
+      @prefix = config[:prefix]
     end
 
     ##

--- a/lib/geocoder/cache_stores/base.rb
+++ b/lib/geocoder/cache_stores/base.rb
@@ -2,8 +2,8 @@ module Geocoder::CacheStore
   class Base
     def initialize(store, options)
       @store = store
-      @configs = options
-      @prefix = configs[:cache_prefix]
+      @config = options
+      @prefix = config[:cache_prefix]
     end
 
     ##
@@ -24,7 +24,7 @@ module Geocoder::CacheStore
 
     def prefix; @prefix; end
     def store; @store; end
-    def configs; @configs; end
+    def config; @config; end
 
     ##
     # Cache key for a given URL.

--- a/lib/geocoder/cache_stores/generic.rb
+++ b/lib/geocoder/cache_stores/generic.rb
@@ -1,5 +1,5 @@
 module Geocoder::CacheStore
-  class Other < Base
+  class Generic < Base
     def write(url, value)
       case
       when store.respond_to?(:[]=)

--- a/lib/geocoder/cache_stores/other.rb
+++ b/lib/geocoder/cache_stores/other.rb
@@ -1,0 +1,33 @@
+module Geocoder::CacheStore
+  class Other < Base
+    def write(url, value)
+      case
+      when store.respond_to?(:[]=)
+        store[key_for(url)] = value
+      when store.respond_to?(:set)
+        store.set key_for(url), value
+      when store.respond_to?(:write)
+        store.write key_for(url), value
+      end
+    end
+
+    def read(url)
+      case
+      when store.respond_to?(:[])
+        store[key_for(url)]
+      when store.respond_to?(:get)
+        store.get key_for(url)
+      when store.respond_to?(:read)
+        store.read key_for(url)
+      end
+    end
+
+    def keys
+      store.keys
+    end
+
+    def remove(key)
+      store.delete(key)
+    end
+  end
+end

--- a/lib/geocoder/cache_stores/redis.rb
+++ b/lib/geocoder/cache_stores/redis.rb
@@ -5,8 +5,12 @@ module Geocoder::CacheStore
       @expire = options[:expire]
     end
 
-    def write(url, value)
-      store.set key_for(url), value
+    def write(url, value, expire = @expire)
+      if expire.present?
+        store.set key_for(url), value, ex: expire
+      else
+        store.set key_for(url), value
+      end
     end
 
     def read(url)

--- a/lib/geocoder/cache_stores/redis.rb
+++ b/lib/geocoder/cache_stores/redis.rb
@@ -2,10 +2,10 @@ module Geocoder::CacheStore
   class Redis < Base
     def initialize(store, options)
       super
-      @cache_expiration = options[:cache_expiration]
+      @expiration = options[:expiration]
     end
 
-    def write(url, value, expire = @cache_expiration)
+    def write(url, value, expire = @expiration)
       if expire.present?
         store.set key_for(url), value, ex: expire
       else
@@ -27,6 +27,6 @@ module Geocoder::CacheStore
 
     private # ----------------------------------------------------------------
 
-    def expire; @cache_expiration; end
+    def expire; @expiration; end
   end
 end

--- a/lib/geocoder/cache_stores/redis.rb
+++ b/lib/geocoder/cache_stores/redis.rb
@@ -1,0 +1,28 @@
+module Geocoder::CacheStore
+  class Redis < Base
+    def initialize(store, options)
+      super
+      @expire = options[:expire]
+    end
+
+    def write(url, value)
+      store.set key_for(url), value
+    end
+
+    def read(url)
+      store.get key_for(url)
+    end
+
+    def keys
+      store.keys("#{prefix}*")
+    end
+
+    def remove(key)
+      store.del(key)
+    end
+
+    private # ----------------------------------------------------------------
+
+    def expire; @expire; end
+  end
+end

--- a/lib/geocoder/cache_stores/redis.rb
+++ b/lib/geocoder/cache_stores/redis.rb
@@ -2,10 +2,10 @@ module Geocoder::CacheStore
   class Redis < Base
     def initialize(store, options)
       super
-      @expire = options[:expire]
+      @cache_expiration = options[:cache_expiration]
     end
 
-    def write(url, value, expire = @expire)
+    def write(url, value, expire = @cache_expiration)
       if expire.present?
         store.set key_for(url), value, ex: expire
       else
@@ -27,6 +27,6 @@ module Geocoder::CacheStore
 
     private # ----------------------------------------------------------------
 
-    def expire; @expire; end
+    def expire; @cache_expiration; end
   end
 end

--- a/lib/geocoder/configuration.rb
+++ b/lib/geocoder/configuration.rb
@@ -68,7 +68,8 @@ module Geocoder
       :distances,
       :basic_auth,
       :logger,
-      :kernel_logger_level
+      :kernel_logger_level,
+      :expire
     ]
 
     attr_accessor :data

--- a/lib/geocoder/configuration.rb
+++ b/lib/geocoder/configuration.rb
@@ -69,7 +69,7 @@ module Geocoder
       :basic_auth,
       :logger,
       :kernel_logger_level,
-      :expire
+      :cache_expiration
     ]
 
     attr_accessor :data

--- a/lib/geocoder/configuration.rb
+++ b/lib/geocoder/configuration.rb
@@ -69,7 +69,7 @@ module Geocoder
       :basic_auth,
       :logger,
       :kernel_logger_level,
-      :cache_expiration
+      :cache_options
     ]
 
     attr_accessor :data
@@ -109,7 +109,7 @@ module Geocoder
       @data[:https_proxy]  = nil         # HTTPS proxy server (user:pass@host:port)
       @data[:api_key]      = nil         # API key for geocoding service
       @data[:cache]        = nil         # cache object (must respond to #[], #[]=, and #keys)
-      @data[:cache_prefix] = "geocoder:" # prefix (string) to use for all cache keys
+      @data[:cache_prefix] = "geocoder:" # - DEPRECATED - prefix (string) to use for all cache keys
       @data[:basic_auth]   = {}          # user and password for basic auth ({:user => "user", :password => "password"})
       @data[:logger]       = :kernel     # :kernel or Logger instance
       @data[:kernel_logger_level] = ::Logger::WARN # log level, if kernel logger is used
@@ -122,6 +122,9 @@ module Geocoder
       # calculation options
       @data[:units]     = :mi      # :mi or :km
       @data[:distances] = :linear  # :linear or :spherical
+
+      # explicit cache service options
+      @data[:cache_options] = {}
     end
 
     instance_eval(OPTIONS.map do |option|

--- a/lib/geocoder/lookups/base.rb
+++ b/lib/geocoder/lookups/base.rb
@@ -85,7 +85,8 @@ module Geocoder
       def cache
         if @cache.nil? && (store = configuration.cache)
           cache_options = configuration.cache_options
-          if configuration.cache_prefix.present?
+          cache_prefix = (configuration.cache_prefix rescue false)
+          if cache_prefix
             cache_options[:prefix] ||= configuration.cache_prefix
             warn '[Geocoder] cache_prefix is deprecated, please change to cache_options.prefix instead'
           end

--- a/lib/geocoder/lookups/base.rb
+++ b/lib/geocoder/lookups/base.rb
@@ -83,8 +83,13 @@ module Geocoder
       # The working Cache object.
       #
       def cache
-        if @cache.nil? and store = configuration.cache
-          @cache = Cache.new(store, configuration.except(:cache))
+        if @cache.nil? && (store = configuration.cache)
+          cache_options = configuration.cache_options
+          if configuration.cache_prefix.present?
+            cache_options[:prefix] ||= configuration.cache_prefix
+            warn '[Geocoder] cache_prefix is deprecated, please change to cache_options.prefix instead'
+          end
+          @cache = Cache.new(store, cache_options)
         end
         @cache
       end

--- a/lib/geocoder/lookups/base.rb
+++ b/lib/geocoder/lookups/base.rb
@@ -84,7 +84,7 @@ module Geocoder
       #
       def cache
         if @cache.nil? and store = configuration.cache
-          @cache = Cache.new(store, configuration.cache_prefix)
+          @cache = Cache.new(store, configuration.except(:cache))
         end
         @cache
       end


### PR DESCRIPTION
Applying open for extensions principle
and Adding support for redis expiration (ttl)

usage:
```ruby
Geocoder.configure(
  lookup: :google,
  api_key: ENV['GMAPS_PLAECS_KEY'].try(:freeze),
  cache: Redis.current,
  cache_prefix: "GeocoderCache:",
  expire: 2.days
)
```