### PR TITLE
add support for host parameter to ipdata_co lookup

### DIFF
--- a/lib/geocoder/lookups/ipdata_co.rb
+++ b/lib/geocoder/lookups/ipdata_co.rb
@@ -47,7 +47,7 @@ module Geocoder::Lookup
     end
 
     def host
-      "api.ipdata.co"
+      configuration[:host] || "api.ipdata.co"
     end
 
     def check_response_for_errors!(response)


### PR DESCRIPTION
ipdata introduced an EU endpoint for API calls. https://docs.ipdata.co/
This pull request adds support for passing host parameter to ipdata_co lookup.