### PR TITLE
ArgumentError: unexpected value at params[:lookup]

### DIFF
--- a/lib/geocoder/lookups/amazon_location_service.rb
+++ b/lib/geocoder/lookups/amazon_location_service.rb
@@ -4,13 +4,12 @@ require 'geocoder/results/amazon_location_service'
 module Geocoder::Lookup
   class AmazonLocationService < Base
     def results(query)
-      params = { **global_index_name, **query.options }
-      params.delete(:lookup)
+      params = query.options.except(:lookup).merge(global_index_name)
 
       if query.reverse_geocode?
-        resp = client.search_place_index_for_position(**{ **params, position: query.coordinates.reverse })
+        resp = client.search_place_index_for_position(params.merge(position: query.coordinates.reverse))
       else
-        resp = client.search_place_index_for_text(**{ **params, text: query.text })
+        resp = client.search_place_index_for_text(params.merge(text: query.text))
       end
       resp.results.map(&:place)
     end

--- a/lib/geocoder/lookups/amazon_location_service.rb
+++ b/lib/geocoder/lookups/amazon_location_service.rb
@@ -6,11 +6,12 @@ module Geocoder::Lookup
     def results(query)
       params = query.options.except(:lookup).merge(global_index_name)
 
-      if query.reverse_geocode?
-        resp = client.search_place_index_for_position(params.merge(position: query.coordinates.reverse))
+      resp = if query.reverse_geocode?
+        client.search_place_index_for_position(params.merge(position: query.coordinates.reverse))
       else
-        resp = client.search_place_index_for_text(params.merge(text: query.text))
+        client.search_place_index_for_text(params.merge(text: query.text))
       end
+      
       resp.results.map(&:place)
     end
 

--- a/lib/geocoder/lookups/amazon_location_service.rb
+++ b/lib/geocoder/lookups/amazon_location_service.rb
@@ -5,6 +5,8 @@ module Geocoder::Lookup
   class AmazonLocationService < Base
     def results(query)
       params = { **global_index_name, **query.options }
+      params.delete(:lookup)
+
       if query.reverse_geocode?
         resp = client.search_place_index_for_position(**{ **params, position: query.coordinates.reverse })
       else


### PR DESCRIPTION
aws-sdk-locationservice raises and error when :lookup parameter is given:

```ArgumentError: unexpected value at params[:lookup]```

This Pr fixes this and improves readability