### PR TITLE
fix: unknown keyword: :index_name

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -512,14 +512,14 @@ module Geocoder
     end
 
     class MockAmazonLocationServiceClient
-      def search_place_index_for_position(position: nil)
+      def search_place_index_for_position(params = {}, options = {})
         # Amazon transposes latitude and longitude, so our client does too on the outbound call and inbound data
-        return mock_results if position == ["-75.676333", "45.423733"]
+        return mock_results if params[:position] == ["-75.676333", "45.423733"]
         mock_no_results
       end
 
-      def search_place_index_for_text(text: nil)
-        return mock_results if text.include? "Madison Square Garden"
+      def search_place_index_for_text(params = {}, options = {})
+        return mock_results if params[:text].include? "Madison Square Garden"
         mock_no_results
       end
 

--- a/test/unit/lookups/amazon_location_service_test.rb
+++ b/test/unit/lookups/amazon_location_service_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 
 class AmazonLocationServiceTest < GeocoderTestCase
   def setup
-    Geocoder.configure(lookup: :amazon_location_service)
+    Geocoder.configure(lookup: :amazon_location_service, amazon_location_service: {index_name: "some_index_name"})
   end
 
   def test_amazon_location_service_geocoding


### PR DESCRIPTION
closes #1552

index_name is required parameter. See: https://github.com/aws/aws-sdk-ruby/blob/9557e95a0b72a3c324e81443237745d9b6e3f3e8/gems/aws-sdk-locationservice/lib/aws-sdk-locationservice/client.rb#L2880

https://github.com/aws/aws-sdk-ruby/blob/9557e95a0b72a3c324e81443237745d9b6e3f3e8/gems/aws-sdk-locationservice/lib/aws-sdk-locationservice/client.rb#L3155

existing test didn't reflect this

This PR fixes this.