### PR TITLE
Update documentation with instructions for Rails.cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,10 +350,16 @@ This example uses Redis, but the cache store can be any object that supports the
 
 Even a plain Ruby hash will work, though it's not a great choice (cleared out when app is restarted, not shared between app instances, etc).
 
+When using Rails use the Generic cache store as an adapter around `Rails.cache`:
+
+```ruby
+Geocoder.configure(cache: Geocoder::CacheStore::Generic.new(Rails.cache, {}))
+```
+
 You can also set a custom prefix to be used for cache keys:
 
 ```ruby
-Geocoder.configure(cache_prefix: "...")
+Geocoder.configure(cache_options: { prefix: "..." })
 ```
 
 By default the prefix is `geocoder:`


### PR DESCRIPTION
After upgrading we noticed that the configuration we had set originally resulted in a crash (which worked on version 1.6.3 but not after updating to 1.7.2):

```
Geocoder.configure(cache: Rails.cache)
ArgumentError: wrong number of arguments (given 1, expected 0)
from <abbreviated>/gems/activesupport-5.2.6/lib/active_support/cache/redis_cache_store.rb:166:in `initialize'
```

Initially I wrote a simple adapter around `Rails.cache` but when I was preparing a PR I noticed that we could use the Generic cache store wrapper to work with `Rails.cache`.

This PR helps the developer who uses `Rails.cache` to setup Geocoder's caching functionality.
It also instructs the developer to use the non deprecated way of setting the cache prefix as it was moved.


This was the adapter I initially wrote:
```ruby
module Geocoder::CacheStore
  class RailsCache < Base
    def initialize(store = nil, options = {})
      super
      @store = ::Rails.cache
      @expiration = options[:expiration]
    end

    def write(url, value, expire = @expiration)
      if expire.present?
        store.write(key_for(url), value, expires_in: expire)
      else
        store.write(key_for(url), value)
      end
    end

    def read(url)
      store.read key_for(url)
    end

    def remove(key)
      store.delete(key)
    end

    private

    def expire
      @expiration
    end
  end
end
```