### PR TITLE
Move cache_prefix config option to cache_options

### DIFF
--- a/lib/geocoder/configuration.rb
+++ b/lib/geocoder/configuration.rb
@@ -108,8 +108,8 @@ module Geocoder
       @data[:http_proxy]   = nil         # HTTP proxy server (user:pass@host:port)
       @data[:https_proxy]  = nil         # HTTPS proxy server (user:pass@host:port)
       @data[:api_key]      = nil         # API key for geocoding service
-      @data[:cache]        = nil         # cache object (must respond to #[], #[]=, and #keys)
-      @data[:cache_prefix] = "geocoder:" # - DEPRECATED - prefix (string) to use for all cache keys
+      @data[:cache]        = nil         # cache object (must respond to #[], #[]=, and optionally #keys)
+      @data[:cache_prefix] = nil         # - DEPRECATED - prefix (string) to use for all cache keys
       @data[:basic_auth]   = {}          # user and password for basic auth ({:user => "user", :password => "password"})
       @data[:logger]       = :kernel     # :kernel or Logger instance
       @data[:kernel_logger_level] = ::Logger::WARN # log level, if kernel logger is used
@@ -124,7 +124,8 @@ module Geocoder
       @data[:distances] = :linear  # :linear or :spherical
 
       # explicit cache service options
-      @data[:cache_options] = {}
+      @data[:cache_options] ||= {}
+      @data[:cache_options][:prefix] = "geocoder:"
     end
 
     instance_eval(OPTIONS.map do |option|


### PR DESCRIPTION
When using the Gem on version 1.7.2, i've noticed that when using the cache option it will by default spit out a deprecation warning to not use the configuration option: `cache_prefix` anymore.

```
[Geocoder] cache_prefix is deprecated, please change to cache_options.prefix instead
```

This PR moves the default value for `cache_prefix` to its new desired location so that the deprecation warning will be removed when a developer is not explicitly setting the incorrect option.

See my other PR for a documentation change in the README.md to use the correct location