### PR TITLE
#1556 Made the Nominatim parsing more robust

### DIFF
--- a/lib/geocoder/results/nominatim.rb
+++ b/lib/geocoder/results/nominatim.rb
@@ -4,7 +4,7 @@ module Geocoder::Result
   class Nominatim < Base
 
     def poi
-      return address_data[place_type] if address.key?(place_type)
+      return address_data[place_type] if address_data.key?(place_type)
       return nil
     end
 
@@ -18,14 +18,14 @@ module Geocoder::Result
 
     def street
       %w[road pedestrian highway].each do |key|
-        return address_data[key] if address.key?(key)
+        return address_data[key] if address_data.key?(key)
       end
       return nil
     end
 
     def city
       %w[city town village hamlet].each do |key|
-        return address_data[key] if address.key?(key)
+        return address_data[key] if address_data.key?(key)
       end
       return nil
     end

--- a/lib/geocoder/results/nominatim.rb
+++ b/lib/geocoder/results/nominatim.rb
@@ -4,12 +4,12 @@ module Geocoder::Result
   class Nominatim < Base
 
     def poi
-      return @data['address'][place_type] if @data['address'].key?(place_type)
+      return address_data[place_type] if address.key?(place_type)
       return nil
     end
 
     def house_number
-      @data['address']['house_number']
+      address_data['house_number']
     end
 
     def address
@@ -18,69 +18,71 @@ module Geocoder::Result
 
     def street
       %w[road pedestrian highway].each do |key|
-        return @data['address'][key] if @data['address'].key?(key)
+        return address_data[key] if address.key?(key)
       end
       return nil
     end
 
     def city
       %w[city town village hamlet].each do |key|
-        return @data['address'][key] if @data['address'].key?(key)
+        return address_data[key] if address.key?(key)
       end
       return nil
     end
 
     def village
-      @data['address']['village']
+      address_data['village']
     end
 
     def town
-      @data['address']['town']
+      address_data['town']
     end
 
     def state
-      @data['address']['state']
+      address_data['state']
     end
 
     alias_method :state_code, :state
 
     def postal_code
-      @data['address']['postcode']
+      address_data['postcode']
     end
 
     def county
-      @data['address']['county']
+      address_data['county']
     end
 
     def country
-      @data['address']['country']
+      address_data['country']
     end
 
     def country_code
-      @data['address']['country_code']
+      address_data['country_code']
     end
 
     def suburb
-      @data['address']['suburb']
+      address_data['suburb']
     end
 
     def city_district
-      @data['address']['city_district']
+      address_data['city_district']
     end
 
     def state_district
-      @data['address']['state_district']
+      address_data['state_district']
     end
 
     def neighbourhood
-      @data['address']['neighbourhood']
+      address_data['neighbourhood']
     end
 
     def municipality
-      @data['address']['municipality']
+      address_data['municipality']
     end
 
     def coordinates
+      return [] unless @data['lat'] && @data['lon']
+
       [@data['lat'].to_f, @data['lon'].to_f]
     end
 
@@ -108,6 +110,12 @@ module Geocoder::Result
           @data[a]
         end
       end
+    end
+
+    private
+
+    def address_data
+      @data['address'] || {}
     end
   end
 end


### PR DESCRIPTION
To mitigate the issues reported in https://github.com/alexreisner/geocoder/issues/1556
I've moved the direct lookup of `address` within `@data` to a new private method `#address_data` that always returns a Hash if the result is nil, allowing the lookup methods to return nil instead of an error.

Also the `#coordinates` method now returns an empty array, which will be picked up by `#geocoded?` as false:

```ruby
module Geocoder
  module Store
    module Base
        ##
        # Is this object geocoded? (Does it have latitude and longitude?)
        #
        def geocoded?
          to_coordinates.compact.size == 2
        end
    end
  end
end

```

I choose the `#address_data` method name as the `#address` method is already used within other result objects as a public method.

I was unable to run the test suite on my M1, so that still needs some checking.