### PR TITLE
Freegeoip abides by base class recommendations and supports an api key

### DIFF
--- a/lib/geocoder/lookups/freegeoip.rb
+++ b/lib/geocoder/lookups/freegeoip.rb
@@ -17,14 +17,16 @@ module Geocoder::Lookup
       end
     end
 
-    def query_url(query)
-      "#{protocol}://#{host}/json/#{query.sanitized_text}"
-    end
-
     private # ---------------------------------------------------------------
 
-    def cache_key(query)
-      query_url(query)
+    def base_query_url(query)
+      "#{protocol}://#{host}/json/#{query.sanitized_text}?"
+    end
+
+    def query_url_params(query)
+      {
+        :apikey => configuration.api_key
+      }.merge(super)
     end
 
     def parse_raw_data(raw_data)


### PR DESCRIPTION
The `Lookup::Base` class [recommends](https://github.com/alexreisner/geocoder/blob/31153d518687351b68a5d0abd5e087f47e6f4204/lib/geocoder/lookups/base.rb#L74-L76) that implementations _not_ override the `query_url` method, but instead provide `base_query_url` and `url_query_string` methods. This PR brings the Freegeoip provider inline with that recommendation.

This was necessary in order to add support for an `apikey` parameter, required by some services such as freegeoip.app.