### PR TITLE
Update LocationIQ Endpoint

### DIFF
--- a/README_API_GUIDE.md
+++ b/README_API_GUIDE.md
@@ -191,11 +191,11 @@ The [Google Places Search API](https://developers.google.com/maps/documentation/
 ### LocationIQ (`:location_iq`)
 
 * **API key**: required
-* **Quota**: 60 requests/minute (2 req/sec, 10k req/day), then [ability to purchase more](http://locationiq.org/#pricing)
+* **Quota**: 60 requests/minute (2 req/sec, 10k req/day), then [ability to purchase more](http://locationiq.com/pricing)
 * **Region**: world
 * **SSL support**: yes
 * **Languages**: ?
-* **Documentation**: https://locationiq.org/#docs
+* **Documentation**: https://locationiq.com/docs
 * **Terms of Service**: https://unwiredlabs.com/tos
 * **Limitations**: [Data licensed under Open Database License (ODbL) (you must provide attribution).](https://www.openstreetmap.org/copyright)
 

--- a/lib/geocoder/lookups/location_iq.rb
+++ b/lib/geocoder/lookups/location_iq.rb
@@ -25,7 +25,7 @@ module Geocoder::Lookup
     end
 
     def configured_host
-      configuration[:host] || "locationiq.org"
+      configuration[:host] || "us1.locationiq.com"
     end
 
     def results(query)

--- a/lib/geocoder/lookups/location_iq.rb
+++ b/lib/geocoder/lookups/location_iq.rb
@@ -11,6 +11,10 @@ module Geocoder::Lookup
       ["api_key"]
     end
 
+    def supported_protocols
+      [:https]
+    end
+
     private # ----------------------------------------------------------------
 
     def base_query_url(query)


### PR DESCRIPTION
I have no affiliation with LocationIQ besides as a user.

However, per an email received recently, the endpoint used by this gem is being deprecated.

Details below...
```
Hello,
 
We’re pushing a few changes to ensure continued service, higher availability, and lower latencies for our APIs.
 
What’s changing?
 
On 1st June 2022 at 00:00 UTC, we’re going to deprecate some endpoints used to reach our Geocoding, Routing & Timezones APIs. These include older & root domain endpoints such as [us1.locationiq.org/v1](http://us1.locationiq.org/v1), [eu1.locationiq.org/v1](http://eu1.locationiq.org/v1), [locationiq.org/v1](http://locationiq.org/v1), and [locationiq.com/v1](http://locationiq.com/v1).
 
Starting 1st June, our Geocoding, Routing & Timezone APIs will only respond to requests sent to these two endpoints - https://us1.locationiq.com/v1, and https://eu1.locationiq.com/v1. 
 
There are no changes to other APIs:
Autocomplete API requests - [api.locationiq.com/v1](http://api.locationiq.com/v1)
Static Maps - [maps.locationiq.com/v3](http://maps.locationiq.com/v3)
Map Tiles - [tiles.locationiq.com/v3](http://tiles.locationiq.com/v3)
 
What you need to do
 
If you’re using one of our new endpoints - you’re good! If you’re using any of the older endpoints, please update your request URLs to the above-mentioned endpoints. 
 
Please check out our [documentation page](https://locationiq.com/docs) for more information about our APIs. Just hit reply if you have any questions, we’d be happy to help.
 
 
Warm Regards,
LocationIQ Team
```