### PR TITLE
Only require Lookup classes if not defined to allow lookup extensions

### DIFF
--- a/examples/extend_lookup_services.rb
+++ b/examples/extend_lookup_services.rb
@@ -1,0 +1,22 @@
+# To extend the Geocoder with additional lookups that come from the application,
+# not shipped with the gem, define a "child" lookup in your application, based on existing one.
+# This is required because the Geocoder::Configuration is a Singleton and stores one api key per lookup.
+
+# in app/libs/geocoder/lookup/my_preciousss.rb
+module Geocoder::Lookup
+  class MyPreciousss < Google
+  end
+end
+
+# Update Geocoder's street_services on initialize:
+# config/initializers/geocoder.rb
+Geocoder::Lookup.street_services << :my_preciousss
+
+# Override the configuration when necessary (e.g. provide separate Google API key for the account):
+Geocoder.configure(my_preciousss: { api_key: 'abcdef' })
+
+# Lastly, search using your custom lookup service/api keys
+Geocoder.search("Paris", lookup: :my_preciousss)
+
+# This is useful when we have groups of users in the application who use Google paid services
+# and we want to properly separate them and allow using individual API KEYS or timeouts.

--- a/lib/geocoder/lookup.rb
+++ b/lib/geocoder/lookup.rb
@@ -117,8 +117,7 @@ module Geocoder
     def spawn(name)
       if all_services.include?(name)
         name = name.to_s
-        require "geocoder/lookups/#{name}"
-        Geocoder::Lookup.const_get(classify_name(name)).new
+        lookup_instance_from(name)
       else
         valids = all_services.map(&:inspect).join(", ")
         raise ConfigurationError, "Please specify a valid lookup for Geocoder " +
@@ -131,6 +130,19 @@ module Geocoder
     #
     def classify_name(filename)
       filename.to_s.split("_").map{ |i| i[0...1].upcase + i[1..-1] }.join
+    end
+
+    ##
+    # Safely instantiate Lookup
+    #
+    def lookup_instance_from(name)
+      class_name = classify_name(name)
+      begin
+        Geocoder::Lookup.const_get(class_name)
+      rescue NameError
+        require "geocoder/lookups/#{name}"
+      end
+      Geocoder::Lookup.const_get(class_name).new
     end
   end
 end

--- a/lib/geocoder/lookup.rb
+++ b/lib/geocoder/lookup.rb
@@ -117,7 +117,7 @@ module Geocoder
     def spawn(name)
       if all_services.include?(name)
         name = name.to_s
-        lookup_instance_from(name)
+        instantiate_lookup(name)
       else
         valids = all_services.map(&:inspect).join(", ")
         raise ConfigurationError, "Please specify a valid lookup for Geocoder " +
@@ -135,7 +135,7 @@ module Geocoder
     ##
     # Safely instantiate Lookup
     #
-    def lookup_instance_from(name)
+    def instantiate_lookup(name)
       class_name = classify_name(name)
       begin
         Geocoder::Lookup.const_get(class_name)


### PR DESCRIPTION
This will allow for extending Geocoder with additional lookups that come from the application, not shipped with the gem. 


```ruby
# in app/libs/geocoder/lookup/my_preciousss.rb
module Geocoder::Lookup
  class MyPreciousss < Google
  end
end

# config/initializers/geocoder.rb
Geocoder::Lookup.street_services << :my_preciousss
Geocoder::Lookup.street_services << :my_other

# > Geocoder.configure(my_preciousss: { api_key: 'abcdef' })
# > Geocoder.configure(my_other: { api_key: 'fedabc' })

# > Geocoder.search("Paris", lookup: :my_preciousss)
```

An example use case for this is, when we have several groups of users in the application, or tenants who use Google paid services and we want to properly separate these paid services. Since Geocoder Configuration is a `Singleton`, we cannot do this by creating an "instance" of the Geocoder with different api_key(s). As a workaround, you can define Google Lookup subclasses and define a different api_key for each of them.

The main problem I am trying to solve here is that you cannot define different api_keys for particular lookup service for different geocoder instances in one process at runtime.