### PR TITLE
Avoid name collision by const_get only lookups from Geocoder::Lookup

### DIFF
--- a/lib/geocoder/lookup.rb
+++ b/lib/geocoder/lookup.rb
@@ -136,7 +136,7 @@ module Geocoder
     # Safely instantiate Lookup
     #
     def instantiate_lookup(name)
-      class_name = classify_name(name)
+      class_name = "Geocoder::Lookup::#{classify_name(name)}"
       begin
         Geocoder::Lookup.const_get(class_name)
       rescue NameError


### PR DESCRIPTION
This will prevent name collisions with modules or classes with the same name as classes in Lookup in the development environment where code is not eager loaded. However, this introduces an additional limitation for additional Lookup classes defined by the gem users, they must be defined in the namespace `Geocoder::Lookup`.

Resolves:  https://github.com/alexreisner/geocoder/issues/1568

Missing a proper test where we could reproduce the name collision.