### PR TITLE
Add a default TTL when caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,8 +249,8 @@ Geocoder.configure(
   # warning: `cache_prefix` is deprecated, use `cache_options` instead
   cache: Redis.new,
   cache_options: {
-    expiration: 2.days, # Redis ttl
-    prefix: "..."
+    expiration: 1.day, # Defaults to two days
+    prefix: "another_key:" # Defaults to `geocoder:`
   }
 )
 ```

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Geocoder.configure(
   # warning: `cache_prefix` is deprecated, use `cache_options` instead
   cache: Redis.new,
   cache_options: {
-    expiration: 1.day, # Defaults to two days
+    expiration: 1.day, # Defaults to `nil`
     prefix: "another_key:" # Defaults to `geocoder:`
   }
 )

--- a/lib/geocoder/configuration.rb
+++ b/lib/geocoder/configuration.rb
@@ -121,12 +121,14 @@ module Geocoder
       @data[:units]     = :mi      # :mi or :km
       @data[:distances] = :linear  # :linear or :spherical
 
-      # Set the default values for the caching
+      # Set the default values for the caching mechanism
+      # By default, the cache keys will not expire as IP addresses and phyiscal
+      # addresses will rarely change.
       @data[:cache]        = nil   # cache object (must respond to #[], #[]=, and optionally #keys)
       @data[:cache_prefix] = nil   # - DEPRECATED - prefix (string) to use for all cache keys
       @data[:cache_options] = {
         prefix: 'geocoder:',
-        expiration: 172_800 # Default TTL is 2 days
+        expiration: nil
       }
     end
 

--- a/lib/geocoder/configuration.rb
+++ b/lib/geocoder/configuration.rb
@@ -108,8 +108,6 @@ module Geocoder
       @data[:http_proxy]   = nil         # HTTP proxy server (user:pass@host:port)
       @data[:https_proxy]  = nil         # HTTPS proxy server (user:pass@host:port)
       @data[:api_key]      = nil         # API key for geocoding service
-      @data[:cache]        = nil         # cache object (must respond to #[], #[]=, and optionally #keys)
-      @data[:cache_prefix] = nil         # - DEPRECATED - prefix (string) to use for all cache keys
       @data[:basic_auth]   = {}          # user and password for basic auth ({:user => "user", :password => "password"})
       @data[:logger]       = :kernel     # :kernel or Logger instance
       @data[:kernel_logger_level] = ::Logger::WARN # log level, if kernel logger is used
@@ -123,9 +121,13 @@ module Geocoder
       @data[:units]     = :mi      # :mi or :km
       @data[:distances] = :linear  # :linear or :spherical
 
-      # explicit cache service options
-      @data[:cache_options] ||= {}
-      @data[:cache_options][:prefix] = "geocoder:"
+      # Set the default values for the caching
+      @data[:cache]        = nil   # cache object (must respond to #[], #[]=, and optionally #keys)
+      @data[:cache_prefix] = nil   # - DEPRECATED - prefix (string) to use for all cache keys
+      @data[:cache_options] = {
+        prefix: 'geocoder:',
+        expiration: 172_800 # Default TTL is 2 days
+      }
     end
 
     instance_eval(OPTIONS.map do |option|

--- a/test/unit/geocoder_test.rb
+++ b/test/unit/geocoder_test.rb
@@ -76,7 +76,7 @@ class GeocoderTest < GeocoderTestCase
 
   def test_default_geocoder_caching_config
     assert_nil Geocoder.config[:cache]
+    assert_nil Geocoder.config[:cache_options][:expiration]
     assert_equal 'geocoder:', Geocoder.config[:cache_options][:prefix]
-    assert_equal 172_800, Geocoder.config[:cache_options][:expiration]
   end
 end

--- a/test/unit/geocoder_test.rb
+++ b/test/unit/geocoder_test.rb
@@ -73,4 +73,10 @@ class GeocoderTest < GeocoderTestCase
     v.reverse_geocode
     assert_equal "Geocoder::Result::Nominatim", v.result_class.to_s
   end
+
+  def test_default_geocoder_caching_config
+    assert_nil Geocoder.config[:cache]
+    assert_equal 'geocoder:', Geocoder.config[:cache_options][:prefix]
+    assert_equal 172_800, Geocoder.config[:cache_options][:expiration]
+  end
 end


### PR DESCRIPTION
Hi there, 

Thanks for the awesome work on the Geocoder gem! We noticed there isn't a default TTL for any cache key after we saw our Redis instances get filled up with cached Geocoder lookup calls.

Based on the current documentation, I would have expected a default TTL of two days. However, that's not the case. To make sure others won't have the same issue, I thought it would make sense to add a default TTL for every key of two days. 

Looking forward to any feedback.