### PR TITLE
Add ability to set fields in configuration for Google Places

### DIFF
--- a/README_API_GUIDE.md
+++ b/README_API_GUIDE.md
@@ -154,9 +154,20 @@ The [Google Places Details API](https://developers.google.com/maps/documentation
 * **Region**: world
 * **SSL support**: yes
 * **Languages**: ar, eu, bg, bn, ca, cs, da, de, el, en, en-AU, en-GB, es, eu, fa, fi, fil, fr, gl, gu, hi, hr, hu, id, it, iw, ja, kn, ko, lt, lv, ml, mr, nl, no, pl, pt, pt-BR, pt-PT, ro, ru, sk, sl, sr, sv, tl, ta, te, th, tr, uk, vi, zh-CN, zh-TW (see http://spreadsheets.google.com/pub?key=p9pdwsai2hDMsLkXsoM05KQ&gid=1)
+* **Extra params**:
+  * `:fields` - Requested API response fields (affects pricing, see the [Google Places Details developer guide](https://developers.google.com/maps/documentation/places/web-service/details#fields) for available fields)
 * **Documentation**: https://developers.google.com/maps/documentation/places/web-service/details
 * **Terms of Service**: https://developers.google.com/maps/documentation/places/web-service/policies
 * **Limitations**: "If your application displays Places API data on a page or view that does not also display a Google Map, you must show a "Powered by Google" logo with that data."
+* **Notes**:
+  * You can set the default fields for all queries in the Geocoder configuration, for example:
+    ```rb
+    Geocoder.configure(
+      google_places_details: {
+        fields: %w[business_status formatted_address geometry name photos place_id plus_code types]
+      }
+    )
+    ```
 
 ### Google Places Search (`:google_places_search`)
 
@@ -173,6 +184,16 @@ The [Google Places Search API](https://developers.google.com/maps/documentation/
 * **Documentation**: https://developers.google.com/maps/documentation/places/web-service/search
 * **Terms of Service**: https://developers.google.com/maps/documentation/places/web-service/policies
 * **Limitations**: "If your application displays Places API data on a page or view that does not also display a Google Map, you must show a "Powered by Google" logo with that data."
+* **Notes**:
+  * You can set the default fields for all queries in the Geocoder configuration, for example:
+    ```rb
+    Geocoder.configure(
+      google_places_search: {
+        fields: %w[address_components adr_address business_status formatted_address geometry name
+            photos place_id plus_code types url utc_offset vicinity]
+      }
+    )
+    ```
 
 ### Here/Nokia (`:here`)
 

--- a/lib/geocoder/lookups/google_places_details.rb
+++ b/lib/geocoder/lookups/google_places_details.rb
@@ -33,9 +33,24 @@ module Geocoder
         result
       end
 
+      def fields(query)
+        query_fields = query.options[:fields]
+        return format_fields(query_fields) if query_fields
+
+        config_fields = configuration[:fields]
+        return format_fields(config_fields) if config_fields
+
+        nil  # use Google Places defaults
+      end
+
+      def format_fields(*fields)
+        fields.flatten.join(',')
+      end
+
       def query_url_google_params(query)
         {
           placeid: query.text,
+          fields: fields(query),
           language: query.language || configuration.language
         }
       end

--- a/lib/geocoder/lookups/google_places_search.rb
+++ b/lib/geocoder/lookups/google_places_search.rb
@@ -39,6 +39,9 @@ module Geocoder
         query_fields = query.options[:fields]
         return format_fields(query_fields) if query_fields
 
+        config_fields = configuration[:fields]
+        return format_fields(config_fields) if config_fields
+
         default_fields
       end
 


### PR DESCRIPTION
Thanks so much for your work on this gem, @alexreisner!

This PR adds support for:
1. the `fields` parameter to `:google_places_details`
2. configuring `fields` in `Geocoder.configure`, for both `:google_places_details` and `:google_places_search`

(I know this is two things, but they're very tightly related hard-to-separate things!)

_Limitation:_ If the Geocoder configuration has `fields` configured, you can't override it in the query with `nil`. You can override it with `[]`, but this would add `&fields=&` to the query string (which does the same thing, but would look different to the cache). Open to thoughts on whether this should be modified.

---------------

**Note on relationship with #1514 (@ericds):** In principle they have a similar objective, and this PR includes half of #1514. However, #1514 also specifies a collection of default fields in `google_places_details.rb`. Instead, in this PR I propose falling back to `nil`, which will send a request to Google Places without the `fields=` key, which (at least when I do it) seems to just default to all of the keys available. Reasons I felt this was better:
- retains existing/backwards functionality (_i.e._ if `fields` isn't specified, this will do the same thing as currently)
- when the available Google Places API fields change, this gem doesn't have to be updated to match it

That said, I'd be down to discuss this with @ericds to arrive at an agreement on how this should work, for @alexreisner to consider.