### PR TITLE
Update HERE lookup to use Geocoder and Search API

### DIFF
--- a/README_API_GUIDE.md
+++ b/README_API_GUIDE.md
@@ -182,10 +182,9 @@ The [Google Places Search API](https://developers.google.com/maps/documentation/
 * **SSL support**: yes
 * **Languages**: The preferred language of address elements in the result. Language code must be provided according to RFC 4647 standard.
 * **Extra params**:
-  * `:bounds` - pass NW and SE coordinates as an array of two arrays to bias results towards a viewport
   * `:country` - pass the country or list of countries using the country code (3 bytes, ISO 3166-1-alpha-3) or the country name, to filter the results
-* **Documentation**: http://developer.here.com/rest-apis/documentation/geocoder
-* **Terms of Service**: http://developer.here.com/faqs#l&t
+* **Documentation**: https://developer.here.com/documentation/geocoding-search-api/dev_guide/topics/endpoint-geocode-brief.html
+* **Terms of Service**: https://developer.here.com/terms-and-conditions
 * **Limitations**: ?
 
 ### LocationIQ (`:location_iq`)

--- a/lib/geocoder/lookups/here.rb
+++ b/lib/geocoder/lookups/here.rb
@@ -25,8 +25,12 @@ module Geocoder::Lookup
     end
 
     def results(query)
+      unless configuration.api_key.is_a?(String)
+        api_key_not_string!
+        return []
+      end
       return [] unless doc = fetch_data(query)
-      return [] unless doc["items"] && !doc["items"].empty?
+      return [] if doc["items"].nil?
 
       doc["items"]
     end
@@ -55,6 +59,15 @@ module Geocoder::Lookup
           q: query.sanitized_text
         )
       end
+    end
+
+    def api_key_not_string!
+      msg = <<~MSG
+        API key for HERE Geocoding and Search API should be a string.
+        For more info on how to obtain it, please see https://developer.here.com/documentation/identity-access-management/dev_guide/topics/plat-using-apikeys.html
+      MSG
+
+      raise_error(Geocoder::ConfigurationError, msg) || Geocoder.log(:warn, msg)
     end
   end
 end

--- a/lib/geocoder/results/here.rb
+++ b/lib/geocoder/results/here.rb
@@ -7,76 +7,71 @@ module Geocoder::Result
     # A string in the given format.
     #
     def address(format = :full)
-      address_data['Label']
+      address_data["label"]
     end
 
     ##
     # A two-element array: [lat, lon].
     #
     def coordinates
-      fail unless d = @data['Location']['DisplayPosition']
-      [d['Latitude'].to_f, d['Longitude'].to_f]
+      fail unless d = @data["position"]
+      [d["lat"].to_f, d["lng"].to_f]
     end
     
     def route
-      address_data['Street']
+      address_data["street"]
     end
     
     def street_number
-      address_data['HouseNumber']
+      address_data["houseNumber"]
     end  
 
     def state
-      fail unless d = address_data['AdditionalData']
-      if v = d.find{|ad| ad['key']=='StateName'}
-        return v['value']
-      end
+      address_data["state"]
     end
 
     def province
-      address_data['County']
+      address_data["county"]
     end
 
     def postal_code
-      address_data['PostalCode']
+      address_data["postalCode"]
     end
 
     def city
-      address_data['City']
+      address_data["city"]
     end
 
     def state_code
-      address_data['State']
+      address_data["stateCode"]
     end
 
     def province_code
-      address_data['State']
+      address_data["state"]
     end
 
     def country
-      fail unless d = address_data['AdditionalData']
-      if v = d.find{|ad| ad['key']=='CountryName'}
-        return v['value']
-      end
+      address_data["countryName"]
     end
 
     def country_code
-      address_data['Country']
+      address_data["countryCode"]
     end
 
     def viewport
-      map_view = data['Location']['MapView'] || fail
-      south = map_view['BottomRight']['Latitude']
-      west = map_view['TopLeft']['Longitude']
-      north = map_view['TopLeft']['Latitude']
-      east = map_view['BottomRight']['Longitude']
+      return [] if data["resultType"] == "place"
+      map_view = data["mapView"]
+      south = map_view["south"]
+      west = map_view["west"]
+      north = map_view["north"]
+      east = map_view["east"]
       [south, west, north, east]
     end
 
     private # ----------------------------------------------------------------
 
     def address_data
-      @data['Location']['Address'] || fail
+      @data["address"] || fail
     end
   end
 end

--- a/test/fixtures/here_berlin
+++ b/test/fixtures/here_berlin
@@ -1,0 +1,37 @@
+{
+  "items": [
+    {
+      "title": "Berlin, Germany",
+      "id": "here:cm:namedplace:20187403",
+      "resultType": "locality",
+      "localityType": "city",
+      "address": {
+        "label": "Berlin, Germany",
+        "countryCode": "DEU",
+        "countryName": "Germany",
+        "stateCode": "BE",
+        "state": "Berlin",
+        "countyCode": "B",
+        "county": "Berlin",
+        "city": "Berlin",
+        "postalCode": "10117"
+      },
+      "position": {
+        "lat": 52.51604,
+        "lng": 13.37691
+      },
+      "mapView": {
+        "west": 13.08835,
+        "south": 52.33812,
+        "east": 13.761,
+        "north": 52.6755
+      },
+      "scoring": {
+        "queryScore": 1,
+        "fieldScore": {
+          "city": 1
+        }
+      }
+    }
+  ]
+}

--- a/test/fixtures/here_madison_square_garden
+++ b/test/fixtures/here_madison_square_garden
@@ -1,72 +1,55 @@
 {
-  "Response": {
-    "MetaInfo": {
-      "Timestamp": "2013-02-08T16:26:39.382+0000"
-    },
-    "View": [
-      {
-        "_type": "SearchResultsViewType",
-        "ViewId": 0,
-        "Result": [
-          {
-            "Relevance": 1.0,
-            "MatchLevel": "houseNumber",
-            "MatchQuality": {
-              "State": 1.0,
-              "City": 1.0,
-              "Street": [
-                1.0
-              ],
-              "HouseNumber": 1.0
-            },
-            "MatchType": "pointAddress",
-            "Location": {
-              "LocationId": "NT_ArsGdYbpo6dqjPQel9gTID_4",
-              "LocationType": "point",
-              "DisplayPosition": {
-                "Latitude": 40.7504692,
-                "Longitude": -73.9933777
-              },
-              "NavigationPosition": [
-                {
-                  "Latitude": 40.7500305,
-                  "Longitude": -73.9942398
-                }
-              ],
-              "MapView": {
-                "TopLeft": {
-                  "Latitude": 40.7515934,
-                  "Longitude": -73.9948616
-                },
-                "BottomRight": {
-                  "Latitude": 40.7493451,
-                  "Longitude": -73.9918938
-                }
-              },
-              "Address": {
-                "Label": "4 Penn Plz, New York, NY 10001, United States",
-                "Country": "USA",
-                "State": "NY",
-                "County": "New York",
-                "City": "New York",
-                "Street": "Penn Plz",
-                "HouseNumber": "4",
-                "PostalCode": "10001",
-                "AdditionalData": [
-                  {
-                    "value": "United States",
-                    "key": "CountryName"
-                  },
-                  {
-                    "value": "New York",
-                    "key": "StateName"
-                  }
-                ]
-              }
-            }
-          }
-        ]
+  "items": [
+    {
+      "title": "Madison Square Garden",
+      "id": "here:pds:place:840dr5ru-7bf91d321e434303aa1094c2c5f1f15f",
+      "resultType": "place",
+      "address": {
+        "label": "Madison Square Garden, 4 Penn Plz, New York, NY 10001, United States",
+        "countryCode": "USA",
+        "countryName": "United States",
+        "stateCode": "NY",
+        "state": "New York",
+        "county": "New York",
+        "city": "New York",
+        "district": "Chelsea",
+        "street": "Penn Plz",
+        "postalCode": "10001",
+        "houseNumber": "4"
+      },
+      "position": {
+        "lat": 40.75051,
+        "lng": -73.9934
+      },
+      "access": [
+        {
+          "lat": 40.75003,
+          "lng": -73.99425
+        }
+      ],
+      "categories": [
+        {
+          "id": "800-8600-0180",
+          "name": "Sports Complex/Stadium",
+          "primary": true
+        },
+        {
+          "id": "200-2200-0020",
+          "name": "Performing Arts Center"
+        },
+        {
+          "id": "700-7400-0141",
+          "name": "Business Services"
+        }
+      ],
+      "scoring": {
+        "queryScore": 1,
+        "fieldScore": {
+          "state": 1,
+          "city": 1,
+          "placeName": 1
+        }
       }
-    ]
-  }
+    }
+  ]
 }

--- a/test/fixtures/here_no_results
+++ b/test/fixtures/here_no_results
@@ -1,8 +1,3 @@
 {
-  "Response": {
-    "MetaInfo": {
-      "Timestamp": "2013-02-08T16:41:16.723+0000"
-    },
-    "View": []
-  }
+  "items": []
 }

--- a/test/unit/lookup_test.rb
+++ b/test/unit/lookup_test.rb
@@ -67,7 +67,7 @@ class LookupTest < GeocoderTestCase
     :bing => :culture,
     :google => :language,
     :google_premier => :language,
-    :here => :language,
+    :here => :lang,
     :nominatim => :"accept-language",
     :yandex => :lang
   }.each do |l,p|

--- a/test/unit/lookups/here_test.rb
+++ b/test/unit/lookups/here_test.rb
@@ -9,9 +9,40 @@ class HereTest < GeocoderTestCase
   end
 
   def test_here_viewport
-    result = Geocoder.search('Madison Square Garden, New York, NY').first
-    assert_equal [40.7493451, -73.9948616, 40.7515934, -73.9918938],
+    result = Geocoder.search("Berlin").first
+    assert_equal [52.33812, 13.08835, 52.6755, 13.761],
                  result.viewport
+  end
+
+  def test_here_no_viewport
+    result = Geocoder.search("Madison Square Garden, New York, NY").first
+    assert_equal [], result.viewport
+  end
+
+  def test_here_query_url_for_reverse_geocoding
+    lookup = Geocoder::Lookup::Here.new
+    url = lookup.query_url(
+      Geocoder::Query.new(
+        "42.42,21.21"
+      )
+    )
+
+    expected = /revgeocode\.search\.hereapi\.com\/v1\/revgeocode.+at=42\.42%2C21\.21/
+
+    assert_match(expected, url)
+  end
+
+  def test_here_query_url_for_geocode
+    lookup = Geocoder::Lookup::Here.new
+    url = lookup.query_url(
+      Geocoder::Query.new(
+        "Madison Square Garden, New York, NY"
+      )
+    )
+
+    expected = /geocode\.search\.hereapi\.com\/v1\/geocode.+q=Madison\+Square\+Garden%2C\+New\+York%2C\+NY/
+
+    assert_match(expected, url)
   end
 
   def test_here_query_url_contains_country
@@ -22,18 +53,7 @@ class HereTest < GeocoderTestCase
         country: 'GBR'
       )
     )
-    assert_match(/country=GBR/, url)
-  end
-
-  def test_here_query_url_contains_mapview
-    lookup = Geocoder::Lookup::Here.new
-    url = lookup.query_url(
-      Geocoder::Query.new(
-        'Some Intersection',
-        bounds: [[40.0, -120.0], [39.0, -121.0]]
-      )
-    )
-    assert_match(/mapview=40.0+%2C-120.0+%3B39.0+%2C-121.0+/, url)
+    assert_match(/in=countryCode%3AGBR/, url)
   end
 
   def test_here_query_url_contains_api_key
@@ -43,6 +63,6 @@ class HereTest < GeocoderTestCase
         'Some Intersection'
       )
     )
-    assert_match(/apikey=+/, url)
+    assert_match(/apiKey=+/, url)
   end
 end

--- a/test/unit/lookups/here_test.rb
+++ b/test/unit/lookups/here_test.rb
@@ -8,6 +8,17 @@ class HereTest < GeocoderTestCase
     set_api_key!(:here)
   end
 
+  def test_with_array_api_key_raises_when_configured
+    Geocoder.configure(api_key: %w[foo bar])
+    Geocoder.configure(always_raise: :all)
+    assert_raises(Geocoder::ConfigurationError) { Geocoder.search("Berlin").first }
+  end
+
+  def test_with_array_api_key_no_result_when_not_raised
+    Geocoder.configure(api_key: %w[foo bar])
+    assert_equal Geocoder.search("Berlin"), []
+  end
+
   def test_here_viewport
     result = Geocoder.search("Berlin").first
     assert_equal [52.33812, 13.08835, 52.6755, 13.761],


### PR DESCRIPTION
@alexreisner Please take a look.

Docs for new API:
* [Guide on geocoding](https://developer.here.com/documentation/geocoding-search-api/dev_guide/topics/endpoint-geocode-brief.html)
* [Guide on reverse geocode](https://developer.here.com/documentation/geocoding-search-api/dev_guide/topics/endpoint-reverse-geocode-brief.html)
* [API reference](https://developer.here.com/documentation/geocoding-search-api/api-reference-swagger.html)

Some things to note regarding new API:
* It doesn't support bounding box as query param. For geocoding it supports the country code, and for reverse geocode it supports a circular area.
* For `resultType: place`, the result is missing `viewport` now (that's why I've added a Berlin fixture)