### PR TITLE
Add locationbias parameter to Google Places Search

### DIFF
--- a/README_API_GUIDE.md
+++ b/README_API_GUIDE.md
@@ -180,17 +180,19 @@ The [Google Places Search API](https://developers.google.com/maps/documentation/
 * **SSL support**: yes
 * **Languages**: ar, eu, bg, bn, ca, cs, da, de, el, en, en-AU, en-GB, es, eu, fa, fi, fil, fr, gl, gu, hi, hr, hu, id, it, iw, ja, kn, ko, lt, lv, ml, mr, nl, no, pl, pt, pt-BR, pt-PT, ro, ru, sk, sl, sr, sv, tl, ta, te, th, tr, uk, vi, zh-CN, zh-TW (see http://spreadsheets.google.com/pub?key=p9pdwsai2hDMsLkXsoM05KQ&gid=1)
 * **Extra params**:
-  * `:fields` - Requested API response fields (affects pricing, see the [source](https://github.com/alexreisner/geocoder/blob/master/lib/geocoder/lookups/google_places_search.rb) for available fields)
+  * `:fields` - requested API response fields (affects pricing, see the [source](https://github.com/alexreisner/geocoder/blob/master/lib/geocoder/lookups/google_places_search.rb) for available fields)
+  * `:locationbias` - bias towards results in or near a specified area, using a string in one of the formats specified in the [API documentation](https://developers.google.com/maps/documentation/places/web-service/search-find-place#locationbias), e.g., `locationbias: "point:-36.8509,174.7645"`
 * **Documentation**: https://developers.google.com/maps/documentation/places/web-service/search
 * **Terms of Service**: https://developers.google.com/maps/documentation/places/web-service/policies
 * **Limitations**: "If your application displays Places API data on a page or view that does not also display a Google Map, you must show a "Powered by Google" logo with that data."
 * **Notes**:
-  * You can set the default fields for all queries in the Geocoder configuration, for example:
+  * You can set the default fields and/or location bias for all queries in the Geocoder configuration, for example:
     ```rb
     Geocoder.configure(
       google_places_search: {
         fields: %w[address_components adr_address business_status formatted_address geometry name
-            photos place_id plus_code types url utc_offset vicinity]
+            photos place_id plus_code types url utc_offset vicinity],
+        locationbias: "point:-36.8509,174.7645"
       }
     )
     ```

--- a/lib/geocoder/lookups/google_places_search.rb
+++ b/lib/geocoder/lookups/google_places_search.rb
@@ -31,6 +31,7 @@ module Geocoder
           input: query.text,
           inputtype: 'textquery',
           fields: fields(query),
+          locationbias: locationbias(query),
           language: query.language || configuration.language
         }
       end
@@ -61,6 +62,14 @@ module Geocoder
         return if flattened.empty?
 
         flattened.join(',')
+      end
+
+      def locationbias(query)
+        if query.options.has_key?(:locationbias)
+          query.options[:locationbias]
+        else
+          configuration[:locationbias]
+        end
       end
     end
   end

--- a/test/unit/lookups/google_places_search_test.rb
+++ b/test/unit/lookups/google_places_search_test.rb
@@ -83,6 +83,37 @@ class GooglePlacesSearchTest < GeocoderTestCase
     Geocoder.configure(google_places_search: {})
   end
 
+  def test_google_places_search_query_url_omits_locationbias_by_default
+    url = lookup.query_url(Geocoder::Query.new("some-address"))
+    assert_no_match(/locationbias=/, url)
+  end
+
+  def test_google_places_search_query_url_contains_locationbias_when_configured
+    Geocoder.configure(google_places_search: {locationbias: "point:-36.8509,174.7645"})
+    url = lookup.query_url(Geocoder::Query.new("some-address"))
+    assert_match(/locationbias=point%3A-36.8509%2C174.7645/, url)
+    Geocoder.configure(google_places_search: {})
+  end
+
+  def test_google_places_search_query_url_contains_locationbias_when_given
+    url = lookup.query_url(Geocoder::Query.new("some-address", locationbias: "point:-36.8509,174.7645"))
+    assert_match(/locationbias=point%3A-36.8509%2C174.7645/, url)
+  end
+
+  def test_google_places_search_query_url_uses_given_locationbias_over_configured
+    Geocoder.configure(google_places_search: {locationbias: "point:37.4275,-122.1697"})
+    url = lookup.query_url(Geocoder::Query.new("some-address", locationbias: "point:-36.8509,174.7645"))
+    assert_match(/locationbias=point%3A-36.8509%2C174.7645/, url)
+    Geocoder.configure(google_places_search: {})
+  end
+
+  def test_google_places_search_query_url_omits_locationbias_when_nil_given
+    Geocoder.configure(google_places_search: {locationbias: "point:37.4275,-122.1697"})
+    url = lookup.query_url(Geocoder::Query.new("some-address", locationbias: nil))
+    assert_no_match(/locationbias=/, url)
+    Geocoder.configure(google_places_search: {})
+  end
+
   def test_google_places_search_query_url_uses_find_place_service
     url = lookup.query_url(Geocoder::Query.new("some-address"))
     assert_match(%r{//maps.googleapis.com/maps/api/place/findplacefromtext/}, url)


### PR DESCRIPTION
Hi again! I needed to add the `locationbias` parameter for my work and figured other users could maybe take advantage of it too. This PR adds a simple form of support for `locationbias` to the `:google_places_search` lookup.

It can be specified in either the query options or configuration. If both, query takes precedence. A `nil` in the query options overrides a configured value, to omit `locationbias` from the API call, in a similar manner to #1572.

The way I've written it, it only takes a string, e.g. `"point:-36.8509,174.7645"`, which is just passed directly to the API call. I thought about being more sophisticated, _e.g._, getting it to take a hash of the form `{point: [-36.8509, 174.7645]}` instead. But my thinking on this right now is:
- Google Places Search supports four different types of location biases (`ipbias`, `point:lat,lng`, `circle:radius@lat,lng`, `rectangle:south,west|north,east`), each with a different syntax, and it's not obvious a priori how we'd unify them
- If Google adds more types of location biases in the future, it'd be nice for users to be able to use them (even if clunkily) without a gem update. This doesn't mean we should _only_ support strings, but it does mean users should be able to use a string to override whatever smart processing this gem does—so we'd want to support a string anyway, whether or not we also support hashes or other types

That said, very open to suggestions about how to specify this.

Thanks again!