### PR TITLE
Replace Kernel.warn with Geocoder.log

### DIFF
--- a/lib/geocoder/cache.rb
+++ b/lib/geocoder/cache.rb
@@ -14,7 +14,7 @@ module Geocoder
     def [](url)
       interpret store_service.read(url)
     rescue => e
-      warn "Geocoder cache read error: #{e}"
+      Geocoder.log(:warn, "Geocoder cache read error: #{e}")
     end
 
     ##
@@ -23,7 +23,7 @@ module Geocoder
     def []=(url, value)
       store_service.write(url, value)
     rescue => e
-      warn "Geocoder cache write error: #{e}"
+      Geocoder.log(:warn, "Geocoder cache write error: #{e}")
     end
 
     ##

--- a/lib/geocoder/lookups/amap.rb
+++ b/lib/geocoder/lookups/amap.rb
@@ -32,10 +32,10 @@ module Geocoder::Lookup
         return doc['geocodes'] unless doc['geocodes'].blank?
       when ['0', 'INVALID_USER_KEY']
         raise_error(Geocoder::InvalidApiKey, "invalid api key") ||
-          warn("#{self.name} Geocoding API error: invalid api key.")
+          Geocoder.log(:warn, "#{self.name} Geocoding API error: invalid api key.")
       else
         raise_error(Geocoder::Error, "server error.") ||
-          warn("#{self.name} Geocoding API error: server error - [#{doc['info']}]")
+          Geocoder.log(:warn, "#{self.name} Geocoding API error: server error - [#{doc['info']}]")
       end
       return []
     end

--- a/lib/geocoder/lookups/geoportail_lu.rb
+++ b/lib/geocoder/lookups/geoportail_lu.rb
@@ -56,7 +56,7 @@ module Geocoder
         else
           result = []
           raise_error(Geocoder::Error) ||
-              warn("Geportail.lu Geocoding API error")
+              Geocoder.log(:warn, "Geportail.lu Geocoding API error")
         end
         result
       end


### PR DESCRIPTION
Closes #1576

I left the warn-statement in `maxmind.rake`, as this task does not require `geocoder` as a whole, so `Geocoder.log` might be undefined.