### PR TITLE
[dont merge] Configure tests with random order

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -717,6 +717,7 @@ end
 
 
 class GeocoderTestCase < Test::Unit::TestCase
+  self.test_order = :random
 
   def setup
     super


### PR DESCRIPTION
I confess that I don't have a lot of experience using Test Unit in Ruby - I've mostly used Rspec. For a while now I've been making changes and running all the tests with this:

```
$ bundle exec rake test
```

But I finally decided to stop being lazy and learn something about Test Unit - I discovered I could run an individual test like so:

```
$ ruby -I test path/to/file.rb
```

This really helped me make some progress on the stuff I'm trying to add to this library but then I discovered that I'm able to run tests in isolation that succeed in the full suite - test leakage!!

Here's an example:

```
$ ruby -I test test/unit/lookups/maxmind_geoip2_test.rb
```

<details>
<summary>test/unit/lookups/maxmind_geoip2_test.rb</summary>

```
Loaded suite test/unit/lookups/maxmind_geoip2_test
Started
.E
===============================================================================
Error: test_dynamic_localization_fallback(MaxmindGeoip2Test): Geocoder::ConfigurationError: When using MaxMind GeoIP2 you must specify a service and credentials: Geocoder.configure(maxmind_geoip2: {service: ..., basic_auth: {user: ..., password: ...}}), where service is one of: [:country, :city, :insights]
/Users/jon/code/geocoder/lib/geocoder/lookups/maxmind_geoip2.rb:34:in `configured_service!'
/Users/jon/code/geocoder/lib/geocoder/lookups/maxmind_geoip2.rb:18:in `query_url'
/Users/jon/code/geocoder/lib/geocoder/lookups/maxmind_geoip2.rb:24:in `cache_key'
/Users/jon/code/geocoder/lib/geocoder/lookups/base.rb:245:in `fetch_raw_data'
/Users/jon/code/geocoder/lib/geocoder/lookups/base.rb:196:in `fetch_data'
/Users/jon/code/geocoder/lib/geocoder/lookups/maxmind_geoip2.rb:59:in `results'
/Users/jon/code/geocoder/lib/geocoder/lookups/base.rb:46:in `search'
/Users/jon/code/geocoder/lib/geocoder/query.rb:11:in `execute'
/Users/jon/code/geocoder/lib/geocoder.rb:22:in `search'
test/unit/lookups/maxmind_geoip2_test.rb:44:in `test_dynamic_localization_fallback'
     41:   end
     42: 
     43:   def test_dynamic_localization_fallback
  => 44:     result = Geocoder.search('1.2.3.4').first
     45: 
     46:     result.language = :unsupported_language
     47: 
===============================================================================
E
===============================================================================
Error: test_dynamic_localization(MaxmindGeoip2Test): Geocoder::ConfigurationError: When using MaxMind GeoIP2 you must specify a service and credentials: Geocoder.configure(maxmind_geoip2: {service: ..., basic_auth: {user: ..., password: ...}}), where service is one of: [:country, :city, :insights]
/Users/jon/code/geocoder/lib/geocoder/lookups/maxmind_geoip2.rb:34:in `configured_service!'
/Users/jon/code/geocoder/lib/geocoder/lookups/maxmind_geoip2.rb:18:in `query_url'
/Users/jon/code/geocoder/lib/geocoder/lookups/maxmind_geoip2.rb:24:in `cache_key'
/Users/jon/code/geocoder/lib/geocoder/lookups/base.rb:245:in `fetch_raw_data'
/Users/jon/code/geocoder/lib/geocoder/lookups/base.rb:196:in `fetch_data'
/Users/jon/code/geocoder/lib/geocoder/lookups/maxmind_geoip2.rb:59:in `results'
/Users/jon/code/geocoder/lib/geocoder/lookups/base.rb:46:in `search'
/Users/jon/code/geocoder/lib/geocoder/query.rb:11:in `execute'
/Users/jon/code/geocoder/lib/geocoder.rb:22:in `search'
test/unit/lookups/maxmind_geoip2_test.rb:34:in `test_dynamic_localization'
     31:   end
     32: 
     33:   def test_dynamic_localization
  => 34:     result = Geocoder.search('1.2.3.4').first
     35: 
     36:     result.language = :ru
     37: 
===============================================================================
.E
===============================================================================
Error: test_result_attributes(MaxmindGeoip2Test): Geocoder::ConfigurationError: When using MaxMind GeoIP2 you must specify a service and credentials: Geocoder.configure(maxmind_geoip2: {service: ..., basic_auth: {user: ..., password: ...}}), where service is one of: [:country, :city, :insights]
/Users/jon/code/geocoder/lib/geocoder/lookups/maxmind_geoip2.rb:34:in `configured_service!'
/Users/jon/code/geocoder/lib/geocoder/lookups/maxmind_geoip2.rb:18:in `query_url'
/Users/jon/code/geocoder/lib/geocoder/lookups/maxmind_geoip2.rb:24:in `cache_key'
/Users/jon/code/geocoder/lib/geocoder/lookups/base.rb:245:in `fetch_raw_data'
/Users/jon/code/geocoder/lib/geocoder/lookups/base.rb:196:in `fetch_data'
/Users/jon/code/geocoder/lib/geocoder/lookups/maxmind_geoip2.rb:59:in `results'
/Users/jon/code/geocoder/lib/geocoder/lookups/base.rb:46:in `search'
/Users/jon/code/geocoder/lib/geocoder/query.rb:11:in `execute'
/Users/jon/code/geocoder/lib/geocoder.rb:22:in `search'
test/unit/lookups/maxmind_geoip2_test.rb:10:in `test_result_attributes'
      7:   end
      8: 
      9:   def test_result_attributes
  => 10:     result = Geocoder.search('1.2.3.4').first
     11:     assert_equal 'Los Angeles, CA 90001, United States', result.address
     12:     assert_equal 'Los Angeles', result.city
     13:     assert_equal 'CA', result.state_code
===============================================================================

Finished in 0.007089 seconds.
-------------------------------------------------------------------------------
5 tests, 2 assertions, 0 failures, 3 errors, 0 pendings, 0 omissions, 0 notifications
40% passed
-------------------------------------------------------------------------------
705.32 tests/s, 282.13 assertions/s
```

</details>

This test passes when you run the entire suite and fails when you run it in isolation. So then I looked around and found that you can configure Test Unit to run tests in a random order. I did that and ran the test rake task that was previously working every time and now it's not working at all. 😭 😭 😭 

I looked at the failures and they aren't one thing. Some of them are related to constants being defined or not. I found a CGI issue. I actually did diagnose the one for the example above and it turns out to be due to a missing `super` call in the `setup` method. I'll PR that separately - seems worth merging.

But yeah, this is rough! I'm not sure where to go with this but I figured opening a PR and at least bringing this up was worth doing. I think ultimately it should be a goal of the geocoder project to be able to run the tests randomly because that's a best practice. What do you think @alexreisner?