### PR TITLE
Call super during test setup

### DIFF
--- a/test/unit/lookups/maxmind_geoip2_test.rb
+++ b/test/unit/lookups/maxmind_geoip2_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 
 class MaxmindGeoip2Test < GeocoderTestCase
   def setup
+    super
     Geocoder.configure(ip_lookup: :maxmind_geoip2)
   end
 


### PR DESCRIPTION
As mentioned over on https://github.com/alexreisner/geocoder/pull/1582, there appears to be some test leakage in this project. One instance of this I found was this test file relying on some setup from another test file. You can see this like so:

```
$ ruby -I test test/unit/lookups/maxmind_geoip2_test.rb
Loaded suite test/unit/lookups/maxmind_geoip2_test
Started
E
================================================================================
Error: test_dynamic_localization(MaxmindGeoip2Test): Geocoder::ConfigurationError: When using MaxMind GeoIP2 you must specify a service and credentials: Geocoder.configure(maxmind_geoip2: {service: ..., basic_auth: {user: ..., password: ...}}), where service is one of: [:country, :city, :insights]
/Users/jon/code/geocoder/lib/geocoder/lookups/maxmind_geoip2.rb:34:in `configured_service!'
/Users/jon/code/geocoder/lib/geocoder/lookups/maxmind_geoip2.rb:18:in `query_url'
/Users/jon/code/geocoder/lib/geocoder/lookups/maxmind_geoip2.rb:24:in `cache_key'
/Users/jon/code/geocoder/lib/geocoder/lookups/base.rb:245:in `fetch_raw_data'
/Users/jon/code/geocoder/lib/geocoder/lookups/base.rb:196:in `fetch_data'
/Users/jon/code/geocoder/lib/geocoder/lookups/maxmind_geoip2.rb:59:in `results'
/Users/jon/code/geocoder/lib/geocoder/lookups/base.rb:46:in `search'
/Users/jon/code/geocoder/lib/geocoder/query.rb:11:in `execute'
/Users/jon/code/geocoder/lib/geocoder.rb:22:in `search'
test/unit/lookups/maxmind_geoip2_test.rb:34:in `test_dynamic_localization'
     31:   end
     32:
     33:   def test_dynamic_localization
  => 34:     result = Geocoder.search('1.2.3.4').first
     35:
     36:     result.language = :ru
     37:
================================================================================
E
================================================================================
Error: test_dynamic_localization_fallback(MaxmindGeoip2Test): Geocoder::ConfigurationError: When using MaxMind GeoIP2 you must specify a service and credentials: Geocoder.configure(maxmind_geoip2: {service: ..., basic_auth: {user: ..., password: ...}}), where service is one of: [:country, :city, :insights]
/Users/jon/code/geocoder/lib/geocoder/lookups/maxmind_geoip2.rb:34:in `configured_service!'
/Users/jon/code/geocoder/lib/geocoder/lookups/maxmind_geoip2.rb:18:in `query_url'
/Users/jon/code/geocoder/lib/geocoder/lookups/maxmind_geoip2.rb:24:in `cache_key'
/Users/jon/code/geocoder/lib/geocoder/lookups/base.rb:245:in `fetch_raw_data'
/Users/jon/code/geocoder/lib/geocoder/lookups/base.rb:196:in `fetch_data'
/Users/jon/code/geocoder/lib/geocoder/lookups/maxmind_geoip2.rb:59:in `results'
/Users/jon/code/geocoder/lib/geocoder/lookups/base.rb:46:in `search'
/Users/jon/code/geocoder/lib/geocoder/query.rb:11:in `execute'
/Users/jon/code/geocoder/lib/geocoder.rb:22:in `search'
test/unit/lookups/maxmind_geoip2_test.rb:44:in `test_dynamic_localization_fallback'
     41:   end
     42:
     43:   def test_dynamic_localization_fallback
  => 44:     result = Geocoder.search('1.2.3.4').first
     45:
     46:     result.language = :unsupported_language
     47:
================================================================================
..E
================================================================================
Error: test_result_attributes(MaxmindGeoip2Test): Geocoder::ConfigurationError: When using MaxMind GeoIP2 you must specify a service and credentials: Geocoder.configure(maxmind_geoip2: {service: ..., basic_auth: {user: ..., password: ...}}), where service is one of: [:country, :city, :insights]
/Users/jon/code/geocoder/lib/geocoder/lookups/maxmind_geoip2.rb:34:in `configured_service!'
/Users/jon/code/geocoder/lib/geocoder/lookups/maxmind_geoip2.rb:18:in `query_url'
/Users/jon/code/geocoder/lib/geocoder/lookups/maxmind_geoip2.rb:24:in `cache_key'
/Users/jon/code/geocoder/lib/geocoder/lookups/base.rb:245:in `fetch_raw_data'
/Users/jon/code/geocoder/lib/geocoder/lookups/base.rb:196:in `fetch_data'
/Users/jon/code/geocoder/lib/geocoder/lookups/maxmind_geoip2.rb:59:in `results'
/Users/jon/code/geocoder/lib/geocoder/lookups/base.rb:46:in `search'
/Users/jon/code/geocoder/lib/geocoder/query.rb:11:in `execute'
/Users/jon/code/geocoder/lib/geocoder.rb:22:in `search'
test/unit/lookups/maxmind_geoip2_test.rb:10:in `test_result_attributes'
      7:   end
      8:
      9:   def test_result_attributes
  => 10:     result = Geocoder.search('1.2.3.4').first
     11:     assert_equal 'Los Angeles, CA 90001, United States', result.address
     12:     assert_equal 'Los Angeles', result.city
     13:     assert_equal 'CA', result.state_code
================================================================================

Finished in 0.010555 seconds.
--------------------------------------------------------------------------------
5 tests, 2 assertions, 0 failures, 3 errors, 0 pendings, 0 omissions, 0 notifications
40% passed
--------------------------------------------------------------------------------
```

I tracked down the leakage to this file:

https://github.com/alexreisner/geocoder/blob/master/test/unit/lookup_test.rb

If that test is run prior to the `maxmind_geoip2` then it passes, if not it fails. So then I realized it was a missing call to `super` in the `setup` method and added that with this PR. I think this gets us on the path to fixing the test leakage but it's far from the end. Still, why not chip away at it, right?