### PR TITLE
Attempts to Fix Test Failure That Happens Only On Github

### DIFF
--- a/test/unit/lookups/here_test.rb
+++ b/test/unit/lookups/here_test.rb
@@ -17,8 +17,7 @@ class HereTest < GeocoderTestCase
 
   def test_here_viewport
     result = Geocoder.search("Berlin").first
-    assert_equal [52.33812, 13.08835, 52.6755, 13.761],
-                 result.viewport
+    assert_equal [52.33812, 13.08835, 52.6755, 13.761], result.viewport
   end
 
   def test_here_no_viewport

--- a/test/unit/lookups/here_test.rb
+++ b/test/unit/lookups/here_test.rb
@@ -16,7 +16,7 @@ class HereTest < GeocoderTestCase
   end
 
   def test_here_viewport
-    result = Geocoder.search("Berlin").first
+    result = Geocoder.search('berlin').first
     puts "RESULT: #{result.data}"
     assert_equal [52.33812, 13.08835, 52.6755, 13.761], result.viewport
   end

--- a/test/unit/lookups/here_test.rb
+++ b/test/unit/lookups/here_test.rb
@@ -17,6 +17,7 @@ class HereTest < GeocoderTestCase
 
   def test_here_viewport
     result = Geocoder.search("Berlin").first
+    puts "RESULT: #{result.data}"
     assert_equal [52.33812, 13.08835, 52.6755, 13.761], result.viewport
   end
 


### PR DESCRIPTION
```Failure: test_here_viewport(HereTest)
/home/runner/work/geocoder/geocoder/test/unit/lookups/here_test.rb:20:in `test_here_viewport'
     17: 
     18:   def test_here_viewport
     19:     result = Geocoder.search("Berlin").first
  => 20:     assert_equal [52.33812, 13.08835, 52.6755, 13.761],
     21:                  result.viewport
     22:   end
     23: 
<[52.33812, 13.08835, 52.[67](https://github.com/alexreisner/geocoder/runs/7511674594?check_suite_focus=true#step:4:68)55, 13.761]> expected but was
<[]>

diff:
? [52.33812, 13.08835, 52.6755, 13.761]
```