### PR TITLE
existing constant name shadowing a lookup class name results in NoMethodError

### DIFF
--- a/lib/geocoder/lookup.rb
+++ b/lib/geocoder/lookup.rb
@@ -138,9 +138,9 @@ module Geocoder
     # Safely instantiate Lookup
     #
     def instantiate_lookup(name)
-      class_name = "Geocoder::Lookup::#{classify_name(name)}"
+      class_name = classify_name(name)
       begin
-        Geocoder::Lookup.const_get(class_name)
+        Geocoder::Lookup.const_get(class_name, inherit=false)
       rescue NameError
         require "geocoder/lookups/#{name}"
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -772,3 +772,6 @@ class MockHttpResponse
     @headers[key]
   end
 end
+
+module Google
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -773,5 +773,5 @@ class MockHttpResponse
   end
 end
 
-module Google
+module MockLookup
 end

--- a/test/unit/lookup_test.rb
+++ b/test/unit/lookup_test.rb
@@ -2,7 +2,6 @@
 require 'test_helper'
 
 class LookupTest < GeocoderTestCase
-
   def test_responds_to_name_method
     Geocoder::Lookup.all_services.each do |l|
       lookup = Geocoder::Lookup.get(l)
@@ -185,14 +184,15 @@ class LookupTest < GeocoderTestCase
     end
   end
 
-  def test_lookup_instantiates_when_class_name_shadowed_by_existing_constant
-    # "Unloads" Google /lookups/google.rb
-    Object.const_get("::Geocoder::Lookup").send(:remove_const, :Google)
-    $LOADED_FEATURES.reject! { |path| path =~ /\/lookups\/google.rb/ }
+  def test_lookup_requires_lookup_file_when_class_name_shadowed_by_existing_constant
+    Geocoder::Lookup.street_services << :mock_lookup
 
-    Geocoder.configure(:lookup => :google, :api_key => "MY_KEY")
-    Geocoder.search("Madison Square Garden, New York, NY  10001, United States")
-    assert_const_defined(::Geocoder::Lookup, :Google)
+    assert_raises LoadError do
+      Geocoder.configure(:lookup => :mock_lookup, :api_key => "MY_KEY")
+      Geocoder.search("Madison Square Garden, New York, NY  10001, United States")
+    end
+
+    Geocoder::Lookup.street_services.reject! { |service| service == :mock_lookup }
   end
 
   def test_handle

--- a/test/unit/lookup_test.rb
+++ b/test/unit/lookup_test.rb
@@ -185,6 +185,16 @@ class LookupTest < GeocoderTestCase
     end
   end
 
+  def test_lookup_instantiates_when_class_name_shadowed_by_existing_constant
+    # "Unloads" Google /lookups/google.rb
+    Object.const_get("::Geocoder::Lookup").send(:remove_const, :Google)
+    $LOADED_FEATURES.reject! { |path| path =~ /\/lookups\/google.rb/ }
+
+    Geocoder.configure(:lookup => :google, :api_key => "MY_KEY")
+    Geocoder.search("Madison Square Garden, New York, NY  10001, United States")
+    assert_const_defined(::Geocoder::Lookup, :Google)
+  end
+
   def test_handle
     assert_equal :google, Geocoder::Lookup::Google.new.handle
     assert_equal :geocoder_ca, Geocoder::Lookup::GeocoderCa.new.handle


### PR DESCRIPTION
Related issue here: https://github.com/alexreisner/geocoder/issues/1568

It was marked as close and resolved, but I'm still seeing the same problem. I was able to recreate the bug on ruby `2.6.3` and geocoder version `1.8.0` with the following

```
require 'geocoder'

module Google
end

Geocoder.configure(:api_key => "YOUR-KEY", :lookup => :google)
Geocoder.search("Something")
```

Results in

```
Traceback (most recent call last):
        6: from test.rb:7:in `<main>'
        5: from /Users/avramtwitchell/.rvm/gems/ruby-2.6.3/gems/geocoder-1.8.0/lib/geocoder.rb:22:in `search'
        4: from /Users/avramtwitchell/.rvm/gems/ruby-2.6.3/gems/geocoder-1.8.0/lib/geocoder/query.rb:11:in `execute'
        3: from /Users/avramtwitchell/.rvm/gems/ruby-2.6.3/gems/geocoder-1.8.0/lib/geocoder/query.rb:40:in `lookup'
        2: from /Users/avramtwitchell/.rvm/gems/ruby-2.6.3/gems/geocoder-1.8.0/lib/geocoder/lookup.rb:108:in `get'
        1: from /Users/avramtwitchell/.rvm/gems/ruby-2.6.3/gems/geocoder-1.8.0/lib/geocoder/lookup.rb:121:in `spawn'
/Users/avramtwitchell/.rvm/gems/ruby-2.6.3/gems/geocoder-1.8.0/lib/geocoder/lookup.rb:146:in `instantiate_lookup': undefined method `new' for Google:Module (NoMethodError)
```

I added the `inherit=false` flag to the `const_get` call, which prevents looking up constants higher up in the module namespace. I also added a test that fails with the code as it was. I'm unfamiliar with using the `test-unit` gem for testing, so feel free to make suggestions!