### PR TITLE
Allow geoapify lookup to perform autocomplete query

### DIFF
--- a/README_API_GUIDE.md
+++ b/README_API_GUIDE.md
@@ -107,6 +107,7 @@ Data Science Toolkit provides an API whose response format is like Google's but 
 * **Languages**: The preferred language of address elements in the result. Language code must be provided according to ISO 639-1 2-character language codes.
 * **Extra query options**:
     * `:limit` - restrict the maximum amount of returned results, e.g. `limit: 5`
+    * `:autocomplete` - Use the automplete API, only when doing forward geocoding e.g. `autocomplete: true`
 * **Extra params** (see [Geoapify documentation](https://apidocs.geoapify.com/docs/geocoding) for more information)
     * `:type` - restricts the type of the results, see API documentation for
       available types, e.g. `params: { type: 'amenity' }`
@@ -711,14 +712,14 @@ IP Address Lookups
 ### 2GIS (`:twogis`)
 
 * **API key**: required
-* **Key signup**: 
-* **Quota**: 
-* **Region**: 
+* **Key signup**:
+* **Quota**:
+* **Region**:
 * **SSL support**: required
 * **Languages**: ru_RU, ru_KG, ru_UZ, uk_UA, en_AE, it_RU, es_RU, ar_AE, cs_CZ, az_AZ, en_SA, en_EG, en_OM, en_QA, en_BH
 * **Documentation**: https://docs.2gis.com/en/api/search/geocoder/overview
-* **Terms of Service**: 
-* **Limitations**: 
+* **Terms of Service**:
+* **Limitations**:
 
 
 Local IP Address Lookups

--- a/lib/geocoder/lookups/geoapify.rb
+++ b/lib/geocoder/lookups/geoapify.rb
@@ -22,7 +22,13 @@ module Geocoder
       private
 
       def base_query_url(query)
-        method = query.reverse_geocode? ? 'reverse' : 'search'
+        method = if query.reverse_geocode?
+          'reverse'
+        elsif query.options[:autocomplete]
+          'autocomplete'
+        else
+          'search'
+        end
         "https://api.geoapify.com/v1/geocode/#{method}?"
       end
 

--- a/test/unit/lookups/geoapify_test.rb
+++ b/test/unit/lookups/geoapify_test.rb
@@ -150,6 +150,17 @@ class GeoapifyTest < GeocoderTestCase
     assert_match(/lon=-75\.676333/, url)
   end
 
+  def test_geoapify_query_url_contains_autocomplete
+    lookup = Geocoder::Lookup::Geoapify.new
+    url = lookup.query_url(
+      Geocoder::Query.new(
+        'Test Query',
+        autocomplete: true
+      )
+    )
+    assert_match(/\/geocode\/autocomplete/, url)
+  end
+
   def test_geoapify_invalid_request
     Geocoder.configure(always_raise: [Geocoder::InvalidRequest])
     assert_raises Geocoder::InvalidRequest do


### PR DESCRIPTION
Geoapify has an [autocomplete api](https://www.geoapify.com/address-autocomplete)

This PR allows to use either the search or autocomplete API 