### PR TITLE
Rails geocoder - Deprecation Warning

### DIFF
--- a/lib/geocoder/ip_address.rb
+++ b/lib/geocoder/ip_address.rb
@@ -21,7 +21,7 @@ module Geocoder
     end
 
     def loopback?
-      valid? and !!(self == "0.0.0.0" or match(/\A127\./) or self == "::1")
+      valid? and !!(self == "0.0.0.0" or self.match(/\A127\./) or self == "::1")
     end
 
     def private?

--- a/lib/geocoder/ip_address.rb
+++ b/lib/geocoder/ip_address.rb
@@ -4,13 +4,16 @@ module Geocoder
     PRIVATE_IPS = [
       '10.0.0.0/8',
       '172.16.0.0/12',
-      '192.168.0.0/16',
+      '192.168.0.0/16'
     ].map { |ip| IPAddr.new(ip) }.freeze
 
     def initialize(ip)
       ip = ip.to_string if ip.is_a?(IPAddr)
-
-      super(ip)
+      if ip.is_a?(Hash)
+        super(**ip)
+      else
+        super(ip)
+      end
     end
 
     def internal?
@@ -18,7 +21,7 @@ module Geocoder
     end
 
     def loopback?
-      valid? and !!(self == "0.0.0.0" or self.match(/\A127\./) or self == "::1")
+      valid? and !!(self == '0.0.0.0' or match(/\A127\./) or self == '::1')
     end
 
     def private?

--- a/lib/geocoder/ip_address.rb
+++ b/lib/geocoder/ip_address.rb
@@ -4,7 +4,7 @@ module Geocoder
     PRIVATE_IPS = [
       '10.0.0.0/8',
       '172.16.0.0/12',
-      '192.168.0.0/16'
+      '192.168.0.0/16',
     ].map { |ip| IPAddr.new(ip) }.freeze
 
     def initialize(ip)
@@ -21,7 +21,7 @@ module Geocoder
     end
 
     def loopback?
-      valid? and !!(self == '0.0.0.0' or match(/\A127\./) or self == '::1')
+      valid? and !!(self == "0.0.0.0" or match(/\A127\./) or self == "::1")
     end
 
     def private?


### PR DESCRIPTION
Resolves the deprecation warning when supplying a hash to Geocoder.search.
Search checks whether the supplied search is_ipaddress? which in turn goes to the below function and displays the warning

`/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/geocoder-1.8.1/lib/geocoder/ip_address.rb:13: warning: Using the last argument as keyword parameters is deprecated`

i.e.
`Geocoder.search({ :city=>"Victoria" })`