### PR TITLE
 Add connect_timeout to configuration

### DIFF
--- a/lib/generators/geocoder/config/templates/initializer.rb
+++ b/lib/generators/geocoder/config/templates/initializer.rb
@@ -1,5 +1,6 @@
 Geocoder.configure(
   # Geocoding options
+  # connect_timeout: nil,       # geocoding service connection timeout (optional, secs)
   # timeout: 3,                 # geocoding service timeout (secs)
   # lookup: :nominatim,         # name of geocoding service (symbol)
   # ip_lookup: :ipinfo_io,      # name of IP address geocoding service (symbol)

--- a/lib/geocoder/configuration.rb
+++ b/lib/geocoder/configuration.rb
@@ -51,6 +51,7 @@ module Geocoder
     include Singleton
 
     OPTIONS = [
+      :connect_timeout,
       :timeout,
       :lookup,
       :ip_lookup,
@@ -102,6 +103,7 @@ module Geocoder
     def set_defaults
 
       # geocoding options
+      @data[:connect_timeout] = nil      # geocoding service connection timeout (secs)
       @data[:timeout]      = 3           # geocoding service timeout (secs)
       @data[:lookup]       = :nominatim  # name of street address geocoding service (symbol)
       @data[:ip_lookup]    = :ipinfo_io  # name of IP address geocoding service (symbol)

--- a/lib/geocoder/lookups/base.rb
+++ b/lib/geocoder/lookups/base.rb
@@ -297,7 +297,7 @@ module Geocoder
       def make_api_request(query)
         uri = URI.parse(query_url(query))
         Geocoder.log(:debug, "Geocoder: HTTP request being made for #{uri.to_s}")
-        http_client.start(uri.host, uri.port, use_ssl: use_ssl?, open_timeout: configuration.timeout, read_timeout: configuration.timeout) do |client|
+        http_client.start(uri.host, uri.port, use_ssl: use_ssl?, **timeout_opts) do |client|
           configure_ssl!(client) if use_ssl?
           req = Net::HTTP::Get.new(uri.request_uri, configuration.http_headers)
           if configuration.basic_auth[:user] and configuration.basic_auth[:password]
@@ -325,6 +325,13 @@ module Geocoder
       end
 
       def configure_ssl!(client); end
+
+      def timeout_opts
+        {
+          open_timeout: configuration.connect_timeout || configuration.timeout,
+          read_timeout: configuration.timeout
+        }
+      end
 
       def check_api_key_configuration!(query)
         key_parts = query.lookup.required_api_key_parts


### PR DESCRIPTION
This PR allows `open_timeout` to be configurable. I have a case where it is critical to quickly switch to another geocoding provider if the primary one is unavailable or responds too slowly.

Failed requests caused by exceeding `open_timeout` or `timeout` will be handled the same way thanks to [the current error handling approach](https://github.com/alexreisner/geocoder/blob/059bf127fe5967d013783faf01586504b2fe1b6f/lib/geocoder/lookups/base.rb#L311-L312).
<img width="815" alt="image" src="https://user-images.githubusercontent.com/62102328/217029110-2cfbabf8-56f3-4de5-ab27-c1650849b3bf.png">
