### PR TITLE
Refactor: Support for SQL Server (WIP for discussion)

### DIFF
--- a/lib/geocoder/sql.rb
+++ b/lib/geocoder/sql.rb
@@ -11,6 +11,8 @@ module Geocoder
     # http://www.scribd.com/doc/2569355/Geo-Distance-Search-with-MySQL
     #
     def full_distance(latitude, longitude, lat_attr, lon_attr, options = {})
+      warn "Direct use of this method is deprecated, prefer Geocoder::Store::ActiveRecord.full_distance_sql"
+
       units = options[:units] || Geocoder.config.units
       earth = Geocoder::Calculations.earth_radius(units)
 
@@ -32,6 +34,8 @@ module Geocoder
     # are not intended for use in production!
     #
     def approx_distance(latitude, longitude, lat_attr, lon_attr, options = {})
+      warn "Direct use of this method is deprecated, prefer Geocoder::Store::ActiveRecord.approx_distance_sql"
+
       units = options[:units] || Geocoder.config.units
       dx = Geocoder::Calculations.longitude_degree_distance(30, units)
       dy = Geocoder::Calculations.latitude_degree_distance(units)
@@ -44,6 +48,8 @@ module Geocoder
     end
 
     def within_bounding_box(sw_lat, sw_lng, ne_lat, ne_lng, lat_attr, lon_attr)
+      warn "Direct use of this method is deprecated, prefer Geocoder::Store::ActiveRecord.within_bounding_box_sql"
+
       spans = "#{lat_attr} BETWEEN #{sw_lat.to_f} AND #{ne_lat.to_f} AND "
       # handle box that spans 180 longitude
       if sw_lng.to_f > ne_lng.to_f
@@ -66,6 +72,8 @@ module Geocoder
     # http://www.beginningspatial.com/calculating_bearing_one_point_another
     #
     def full_bearing(latitude, longitude, lat_attr, lon_attr, options = {})
+      warn "Direct use of this method is deprecated, prefer Geocoder::Store::ActiveRecord.full_bearing_sql"
+
       degrees_per_radian = Geocoder::Calculations::DEGREES_PER_RADIAN
       case options[:bearing] || Geocoder.config.distances
       when :linear
@@ -95,6 +103,8 @@ module Geocoder
     # returns *something* in databases without trig functions.
     #
     def approx_bearing(latitude, longitude, lat_attr, lon_attr, options = {})
+      warn "Direct use of this method is deprecated, prefer Geocoder::Store::ActiveRecord.approx_bearing_sql"
+
       "CASE " +
         "WHEN (#{lat_attr} >= #{latitude.to_f} AND " +
           "#{lon_attr} >= #{longitude.to_f}) THEN  45.0 " +

--- a/lib/geocoder/stores/active_record.rb
+++ b/lib/geocoder/stores/active_record.rb
@@ -256,11 +256,22 @@ module Geocoder::Store
         connection.adapter_name.match(/postgres/i)
       end
 
+      # SQL Server unhelpfully defines ATAN2 as ATN2
+      def using_sqlserver?
+        !!connection.adapter_name.match(/sqlserver/i)
+      end
+
       ##
       # Use OID type when running in PosgreSQL
       #
       def null_value
         using_postgres? ? 'NULL::text' : 'NULL'
+      end
+
+      # When using sql server, use ATN2
+      # For effectively all other DBs
+      def atan2_alias
+        using_sqlserver ? 'ATN2' : 'ATAN2'
       end
 
       ##

--- a/lib/geocoder/stores/active_record.rb
+++ b/lib/geocoder/stores/active_record.rb
@@ -63,7 +63,7 @@ module Geocoder::Store
         scope :within_bounding_box, lambda{ |*bounds|
           sw_lat, sw_lng, ne_lat, ne_lng = bounds.flatten if bounds
           if sw_lat && sw_lng && ne_lat && ne_lng
-            where(Geocoder::Sql.within_bounding_box(
+            where(self.within_bounding_box_sql(
               sw_lat, sw_lng, ne_lat, ne_lng,
               full_column_name(geocoder_options[:latitude]),
               full_column_name(geocoder_options[:longitude])
@@ -138,7 +138,7 @@ module Geocoder::Store
           full_column_name(latitude_attribute),
           full_column_name(longitude_attribute)
         ]
-        bounding_box_conditions = Geocoder::Sql.within_bounding_box(*args)
+        bounding_box_conditions = self.within_bounding_box_sql(*args)
 
         if using_unextended_sqlite?
           conditions = bounding_box_conditions
@@ -172,8 +172,8 @@ module Geocoder::Store
       #
       def distance_sql(latitude, longitude, options = {})
         method_prefix = using_unextended_sqlite? ? "approx" : "full"
-        Geocoder::Sql.send(
-          method_prefix + "_distance",
+        self.send(
+          method_prefix + "_distance_sql",
           latitude, longitude,
           full_column_name(options[:latitude] || geocoder_options[:latitude]),
           full_column_name(options[:longitude]|| geocoder_options[:longitude]),
@@ -191,8 +191,8 @@ module Geocoder::Store
         end
         if options[:bearing]
           method_prefix = using_unextended_sqlite? ? "approx" : "full"
-          Geocoder::Sql.send(
-            method_prefix + "_bearing",
+          self.send(
+            method_prefix + "_bearing_sql",
             latitude, longitude,
             full_column_name(options[:latitude] || geocoder_options[:latitude]),
             full_column_name(options[:longitude]|| geocoder_options[:longitude]),
@@ -221,6 +221,111 @@ module Geocoder::Store
           clause += "#{bearing} AS #{bearing_column}"
         end
         clause
+      end
+
+      ##
+      # Distance calculation for use with a database that supports POWER(),
+      # SQRT(), PI(), and trigonometric functions SIN(), COS(), ASIN(), 
+      # ATAN2().
+      #
+      # Based on the excellent tutorial at:
+      # http://www.scribd.com/doc/2569355/Geo-Distance-Search-with-MySQL
+      #
+      def full_distance_sql(latitude, longitude, lat_attr, lon_attr, options = {})
+        units = options[:units] || Geocoder.config.units
+        earth = Geocoder::Calculations.earth_radius(units)
+
+        "#{earth} * 2 * ASIN(SQRT(" +
+          "POWER(SIN((#{latitude.to_f} - #{lat_attr}) * PI() / 180 / 2), 2) + " +
+          "COS(#{latitude.to_f} * PI() / 180) * COS(#{lat_attr} * PI() / 180) * " +
+          "POWER(SIN((#{longitude.to_f} - #{lon_attr}) * PI() / 180 / 2), 2)" +
+        "))"
+      end
+
+      ##
+      # Distance calculation for use with a database without trigonometric
+      # functions, like SQLite. Approach is to find objects within a square
+      # rather than a circle, so results are very approximate (will include
+      # objects outside the given radius).
+      #
+      # Distance and bearing calculations are *extremely inaccurate*. To be
+      # clear: this only exists to provide interface consistency. Results
+      # are not intended for use in production!
+      #
+      def approx_distance_sql(latitude, longitude, lat_attr, lon_attr, options = {})
+        units = options[:units] || Geocoder.config.units
+        dx = Geocoder::Calculations.longitude_degree_distance(30, units)
+        dy = Geocoder::Calculations.latitude_degree_distance(units)
+
+        # sin of 45 degrees = average x or y component of vector
+        factor = Math.sin(Math::PI / 4)
+
+        "(#{dy} * ABS(#{lat_attr} - #{latitude.to_f}) * #{factor}) + " +
+          "(#{dx} * ABS(#{lon_attr} - #{longitude.to_f}) * #{factor})"
+      end
+
+      def within_bounding_box_sql(sw_lat, sw_lng, ne_lat, ne_lng, lat_attr, lon_attr)
+        spans = "#{lat_attr} BETWEEN #{sw_lat.to_f} AND #{ne_lat.to_f} AND "
+        # handle box that spans 180 longitude
+        if sw_lng.to_f > ne_lng.to_f
+          spans + "(#{lon_attr} BETWEEN #{sw_lng.to_f} AND 180 OR " +
+          "#{lon_attr} BETWEEN -180 AND #{ne_lng.to_f})"
+        else
+          spans + "#{lon_attr} BETWEEN #{sw_lng.to_f} AND #{ne_lng.to_f}"
+        end
+      end
+
+      ##
+      # Fairly accurate bearing calculation. Takes a latitude, longitude,
+      # and an options hash which must include a :bearing value
+      # (:linear or :spherical).
+      #
+      # For use with a database that supports MOD() and trigonometric functions
+      # SIN(), COS(), ASIN(), ATAN2().
+      #
+      # Based on:
+      # http://www.beginningspatial.com/calculating_bearing_one_point_another
+      #
+      def full_bearing_sql(latitude, longitude, lat_attr, lon_attr, options = {})
+        degrees_per_radian = Geocoder::Calculations::DEGREES_PER_RADIAN
+        case options[:bearing] || Geocoder.config.distances
+        when :linear
+          "MOD(CAST(" +
+            "(ATAN2( " +
+              "((#{lon_attr} - #{longitude.to_f}) / #{degrees_per_radian}), " +
+              "((#{lat_attr} - #{latitude.to_f}) / #{degrees_per_radian})" +
+            ") * #{degrees_per_radian}) + 360 " +
+          "AS decimal), 360)"
+        when :spherical
+          "MOD(CAST(" +
+            "(ATAN2( " +
+              "SIN( (#{lon_attr} - #{longitude.to_f}) / #{degrees_per_radian} ) * " +
+              "COS( (#{lat_attr}) / #{degrees_per_radian} ), (" +
+                "COS( (#{latitude.to_f}) / #{degrees_per_radian} ) * SIN( (#{lat_attr}) / #{degrees_per_radian})" +
+              ") - (" +
+                "SIN( (#{latitude.to_f}) / #{degrees_per_radian}) * COS((#{lat_attr}) / #{degrees_per_radian}) * " +
+                "COS( (#{lon_attr} - #{longitude.to_f}) / #{degrees_per_radian})" +
+              ")" +
+            ") * #{degrees_per_radian}) + 360 " +
+          "AS decimal), 360)"
+        end
+      end
+
+      ##
+      # Totally lame bearing calculation. Basically useless except that it
+      # returns *something* in databases without trig functions.
+      #
+      def approx_bearing_sql(latitude, longitude, lat_attr, lon_attr, options = {})
+        "CASE " +
+          "WHEN (#{lat_attr} >= #{latitude.to_f} AND " +
+            "#{lon_attr} >= #{longitude.to_f}) THEN  45.0 " +
+          "WHEN (#{lat_attr} <  #{latitude.to_f} AND " +
+            "#{lon_attr} >= #{longitude.to_f}) THEN 135.0 " +
+          "WHEN (#{lat_attr} <  #{latitude.to_f} AND " +
+            "#{lon_attr} <  #{longitude.to_f}) THEN 225.0 " +
+          "WHEN (#{lat_attr} >= #{latitude.to_f} AND " +
+            "#{lon_attr} <  #{longitude.to_f}) THEN 315.0 " +
+        "END"
       end
 
       ##


### PR DESCRIPTION
Previously:

- #934
- #532
- https://gist.github.com/ttilberg/fe5ac60351ad33b865550c08857f612f via @ttilberg 

## Problem

Right now, SQL Server has bespoke SQL required to do bearing calculations.
Other datastores have a similar problem, ie SQLite, depending on what is available.

At some point, Geocoder::Sql was split out to try to make managing this a little bit easier, but it accidentally lead to the situation where:

* `Geocoder::Store::Activerecord` had a number of methods and conditionals to decide which of the other class' methods to call
* `Geocoder::Sql` doesn't know what database it is connected to, so can't generate correct SQL for every situation

## Recommended solution

Ultimately, I think the responsibility for which datastore am I connected to does live in `Geocoder::Store::Activerecord`; *but* specific backends should be available for standard sql, vs sqlite, vs postgres, vs sql server.

This might seem like it violates DRY, but ultimately it would help acheive a single-responsibility-principle.

### Transitioning and backwards compatibility

What I have done in this PR is really a step 1; where the standalone methods are marked deprecated.
This allows a future major version to remove them.

Additionally, at least for now I have shifted the sql generating concerns back into Geocoder::Store::Activerecord. This is because there is an implicit coupling between "which SQL should I generate" and "what am I connected to?". It introduces an extra layer of conditionals in the sql generation temporarily.


A subsequent PR should (with a major version to indicate the BC break)

* Implement Geocoder::Store::ActiveRecord::Postgres
* Implement Geocoder::Store::ActiveRecord::SQLServer
* Implement Geocoder::Store::ActiveRecord::SQLite
* Implement Geocoder::Store::ActiveRecord::SQLiteWithExtensions
* Implement Geocoder::Store::ActiveRecord::Postgis?
* Implement Geocoder::Store::ActiveRecord::OGC or SQL/MM if relevant?
