### PR TITLE
Disable inherit flag const_get in `Geocoder::Cache#initialize`

### DIFF
--- a/lib/geocoder/cache.rb
+++ b/lib/geocoder/cache.rb
@@ -4,7 +4,7 @@ module Geocoder
   class Cache
 
     def initialize(store, config)
-      @class = (Geocoder::CacheStore.const_get("::Geocoder::CacheStore::#{store.class}", false) rescue Geocoder::CacheStore::Generic)
+      @class = (Geocoder::CacheStore.const_get("#{store.class}", false) rescue Geocoder::CacheStore::Generic)
       @store_service = @class.new(store, config)
     end
 

--- a/lib/geocoder/cache.rb
+++ b/lib/geocoder/cache.rb
@@ -4,7 +4,7 @@ module Geocoder
   class Cache
 
     def initialize(store, config)
-      @class = (Object.const_get("Geocoder::CacheStore::#{store.class}") rescue Geocoder::CacheStore::Generic)
+      @class = (Geocoder::CacheStore.const_get("::Geocoder::CacheStore::#{store.class}", false) rescue Geocoder::CacheStore::Generic)
       @store_service = @class.new(store, config)
     end
 


### PR DESCRIPTION
Based on [this](https://github.com/alexreisner/geocoder/commit/4b9d2c689e8cacb6ce71714a7271bdb0952761cd) conversation, I think we should disable inheritance lookup behaviour for `get_const` method