### PR TITLE
Feature: Include region on AWS lookup client config

### DIFF
--- a/lib/geocoder/lookups/amazon_location_service.rb
+++ b/lib/geocoder/lookups/amazon_location_service.rb
@@ -30,6 +30,7 @@ module Geocoder::Lookup
       keys = configuration.api_key
       if keys
         @client = Aws::LocationService::Client.new(
+          region: keys[:region],
           access_key_id: keys[:access_key_id],
           secret_access_key: keys[:secret_access_key],
         )

--- a/lib/geocoder/lookups/amazon_location_service.rb
+++ b/lib/geocoder/lookups/amazon_location_service.rb
@@ -29,11 +29,11 @@ module Geocoder::Lookup
       require_sdk
       keys = configuration.api_key
       if keys
-        @client = Aws::LocationService::Client.new(
+        @client = Aws::LocationService::Client.new(**{
           region: keys[:region],
           access_key_id: keys[:access_key_id],
-          secret_access_key: keys[:secret_access_key],
-        )
+          secret_access_key: keys[:secret_access_key]
+        }.compact)
       else
         @client = Aws::LocationService::Client.new
       end


### PR DESCRIPTION
# Changelog

- Include region on Aws::LocationService::Client config
- Remove region key when is nil 

## Why

To avoid setup region via ENV vars while its using the keys approach