### PR TITLE
Updated esri lookups error handling

### DIFF
--- a/lib/geocoder/lookups/esri.rb
+++ b/lib/geocoder/lookups/esri.rb
@@ -32,16 +32,16 @@ module Geocoder::Lookup
         case [ doc['error']['code'] ]
         when [498]
           raise_error(Geocoder::InvalidApiKey, doc['error']['message']) ||
-            warn("#{self.name} Geocoding API error: #{doc['error']['message']}")
+            Geocoder.log(:warn, "#{self.name} Geocoding API error: #{doc['error']['message']}")
         when [ 403 ]
           raise_error(Geocoder::RequestDenied, 'ESRI request denied') ||
-            warn("#{self.name} ESRI request denied: #{doc['error']['message']}")
+            Geocoder.log(:warn, "#{self.name} ESRI request denied: #{doc['error']['message']}")
         when [ 500 ], [501]
           raise_error(Geocoder::ServiceUnavailable, 'ESRI service unavailable') ||
-            warn("#{self.name} ESRI service error: #{doc['error']['message']}")
+            Geocoder.log(:warn, "#{self.name} ESRI service error: #{doc['error']['message']}")
         else
           raise_error(Geocoder::Error, doc['error']['message']) ||
-            warn("#{self.name} Geocoding error: #{doc['error']['message']}")
+            Geocoder.log(:warn, "#{self.name} Geocoding error: #{doc['error']['message']}")
         end
       end
       return []

--- a/lib/geocoder/lookups/esri.rb
+++ b/lib/geocoder/lookups/esri.rb
@@ -23,15 +23,28 @@ module Geocoder::Lookup
     def results(query)
       return [] unless doc = fetch_data(query)
 
-      if (!query.reverse_geocode?)
-        return [] if !doc['locations'] || doc['locations'].empty?
-      end
-
       if (doc['error'].nil?)
+        if (!query.reverse_geocode?)
+          return [] if !doc['locations'] || doc['locations'].empty?
+        end
         return [ doc ]
       else
-        return []
+        case [ doc['error']['code'] ]
+        when [498]
+          raise_error(Geocoder::InvalidApiKey, doc['error']['message']) ||
+            warn("#{self.name} Geocoding API error: #{doc['error']['message']}")
+        when [ 403 ]
+          raise_error(Geocoder::RequestDenied, 'ESRI request denied') ||
+            warn("#{self.name} ESRI request denied: #{doc['error']['message']}")
+        when [ 500 ], [501]
+          raise_error(Geocoder::ServiceUnavailable, 'ESRI service unavailable') ||
+            warn("#{self.name} ESRI service error: #{doc['error']['message']}")
+        else
+          raise_error(Geocoder::Error, doc['error']['message']) ||
+            warn("#{self.name} Geocoding error: #{doc['error']['message']}")
+        end
       end
+      return []
     end
 
     def query_url_params(query)


### PR DESCRIPTION
Updated error handing for the `results` method in `lookups/esri.rb`

More inline with other geocoding `results` methods - see here: https://github.com/alexreisner/geocoder/blob/1928f7886823d63e0268eebd693ee20314ebdb08/lib/geocoder/lookups/bing.rb#L36

Before when ESRI would fail on a geocode (an example would be an invalid api key) Geocoder would return an empty array instead of an exception. 

Attached issue - https://github.com/alexreisner/geocoder/issues/1610