### PR TITLE
Update README to document services that do not support caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,12 @@ Do *not* include the prefix when passing a URL to be expired. Expiring `:all` wi
 
 _Before you implement caching in your app please be sure that doing so does not violate the Terms of Service for your geocoding service._
 
+The following services do not support caching:
+
+* Amazon Location Service (`:amazon_location_service`)
+* GeoLite2 (`:geoip2`)
+* MaxMind Local (`:maxmind_local`) 
+
 
 Advanced Model Configuration
 ----------------------------


### PR DESCRIPTION
I was recently working on a Geocoder integration using the Amazon Location Service backend but was confused by why lookups weren't being cached. 

I've updated the README to reflect the services which do not appear to support caching to help future developers. [I've based this list on an existing test.](https://github.com/alexreisner/geocoder/blob/de6be6790646accbe6e377145ea60a7a3c1d5730/test/unit/cache_test.rb#L19)

I'm unclear if caching is not permitted with AWS, but if there is an desire to add it then I can look into raising a PR with support for it.