### PR TITLE
request metadata in Trimble maps single search call

### DIFF
--- a/lib/geocoder/lookups/pc_miler.rb
+++ b/lib/geocoder/lookups/pc_miler.rb
@@ -35,9 +35,17 @@ module Geocoder::Lookup
     def results(query)
       return [] unless data = fetch_data(query)
       if data['Locations']
+        add_metadata_to_locations(data)
         data['Locations']
       else
         []
+      end
+    end
+
+    def add_metadata_to_locations(data)
+      confidence = data['QueryConfidence']
+      data['Locations'].each do |location|
+        location['QueryConfidence'] = confidence
       end
     end
 

--- a/lib/geocoder/lookups/pc_miler.rb
+++ b/lib/geocoder/lookups/pc_miler.rb
@@ -35,14 +35,14 @@ module Geocoder::Lookup
     def results(query)
       return [] unless data = fetch_data(query)
       if data['Locations']
-        add_metadata_to_locations(data)
+        add_metadata_to_locations!(data)
         data['Locations']
       else
         []
       end
     end
 
-    def add_metadata_to_locations(data)
+    def add_metadata_to_locations!(data)
       confidence = data['QueryConfidence']
       data['Locations'].each do |location|
         location['QueryConfidence'] = confidence

--- a/lib/geocoder/lookups/pc_miler.rb
+++ b/lib/geocoder/lookups/pc_miler.rb
@@ -51,7 +51,9 @@ module Geocoder::Lookup
 
       {
         authToken: configuration.api_key,
-        query: escaped_query
+        query: escaped_query,
+        # to add additional metadata to response such as QueryConfidence
+        include: 'Meta'
       }.merge(super(query))
     end
 

--- a/lib/geocoder/results/pc_miler.rb
+++ b/lib/geocoder/results/pc_miler.rb
@@ -3,38 +3,48 @@ require 'geocoder/results/base'
 module Geocoder::Result
   class PcMiler < Base
     # sample response:
-    # https://singlesearch.alk.com/NA/api/search?query=Duluth MN
+    # https://singlesearch.alk.com/na/api/search?authToken=<TOKEN>&include=Meta&query=Feasterville
     #
-    # {
-    #     "Err": 0,
-    #     "Locations": [
-    #         {
-    #             "Address": {
-    #                 "StreetAddress": "",
-    #                 "LocalArea": "",
-    #                 "City": "Duluth",
-    #                 "State": "MN",
-    #                 "StateName": "Minnesota",
-    #                 "Zip": "55806",
-    #                 "County": "St. Louis",
-    #                 "Country": "US",
-    #                 "CountryFullName": "United States",
-    #                 "SPLC": null
-    #             },
-    #             "Coords": {
-    #                 "Lat": "46.776443",
-    #                 "Lon": "-92.110529"
-    #             },
-    #             "Region": 4,
-    #             "POITypeID": 0,
-    #             "PersistentPOIID": -1,
-    #             "SiteID": -1,
-    #             "ResultType": 3,
-    #             "ShortString": "Duluth, MN, US, St. Louis 55806",
-    #             "TimeZone": "GMT-5:00 CDT"
-    #         }
-    #     ]
-    # }
+    #   "Err": 0,
+    #   "ErrString": "OK",
+    #   "QueryConfidence": 1,
+    #   "TimeInMilliseconds": 125,
+    #   "GridDataVersion": "GRD_ALK.NA.2023.01.18.29.1.1",
+    #   "CommitID": "pcmws-22.08.11.0-1778-g586da49bd1b: 05/30/2023 20:14",
+    #   "Locations": [
+    #     {
+    #       "Address": {
+    #         "StreetAddress": "",
+    #         "LocalArea": "",
+    #         "City": "Feasterville Trevose",
+    #         "State": "PA",
+    #         "StateName": "Pennsylvania",
+    #         "Zip": "19053",
+    #         "County": "Bucks",
+    #         "Country": "US",
+    #         "CountryFullName": "United States",
+    #         "SPLC": null
+    #       },
+    #       "Coords": {
+    #         "Lat": "40.150025",
+    #         "Lon": "-75.002511"
+    #       },
+    #       "StreetCoords": {
+    #         "Lat": "40.150098",
+    #         "Lon": "-75.002827"
+    #       },
+    #       "Region": 4,
+    #       "POITypeID": 0,
+    #       "PersistentPOIID": -1,
+    #       "SiteID": -1,
+    #       "ResultType": 4,
+    #       "ShortString": "Feasterville",
+    #       "GridID": 37172748,
+    #       "LinkID": 188,
+    #       "Percent": 6291,
+    #       "TimeZone": "GMT-4:00 EDT"
+    #     }
+    #   ]
 
     def address(format=:unused)
       [street, city, state, postal_code, country]

--- a/lib/geocoder/results/pc_miler.rb
+++ b/lib/geocoder/results/pc_miler.rb
@@ -3,38 +3,50 @@ require 'geocoder/results/base'
 module Geocoder::Result
   class PcMiler < Base
     # sample response:
-    # https://singlesearch.alk.com/NA/api/search?query=Duluth MN
+    # https://singlesearch.alk.com/na/api/search?authToken=<TOKEN>&include=Meta&query=Feasterville
     #
-    # {
+    #   {
     #     "Err": 0,
+    #     "ErrString": "OK",
+    #     "QueryConfidence": 1,
+    #     "TimeInMilliseconds": 93,
+    #     "GridDataVersion": "GRD_ALK.NA.2023.01.18.29.1.1",
+    #     "CommitID": "pcmws-22.08.11.0-1778-g586da49bd1b: 05/30/2023 20:14",
     #     "Locations": [
-    #         {
-    #             "Address": {
-    #                 "StreetAddress": "",
-    #                 "LocalArea": "",
-    #                 "City": "Duluth",
-    #                 "State": "MN",
-    #                 "StateName": "Minnesota",
-    #                 "Zip": "55806",
-    #                 "County": "St. Louis",
-    #                 "Country": "US",
-    #                 "CountryFullName": "United States",
-    #                 "SPLC": null
-    #             },
-    #             "Coords": {
-    #                 "Lat": "46.776443",
-    #                 "Lon": "-92.110529"
-    #             },
-    #             "Region": 4,
-    #             "POITypeID": 0,
-    #             "PersistentPOIID": -1,
-    #             "SiteID": -1,
-    #             "ResultType": 3,
-    #             "ShortString": "Duluth, MN, US, St. Louis 55806",
-    #             "TimeZone": "GMT-5:00 CDT"
-    #         }
+    #       {
+    #         "Address": {
+    #           "StreetAddress": "",
+    #           "LocalArea": "",
+    #           "City": "Feasterville",
+    #           "State": "PA",
+    #           "StateName": "Pennsylvania",
+    #           "Zip": "19053",
+    #           "County": "Bucks",
+    #           "Country": "US",
+    #           "CountryFullName": "United States",
+    #           "SPLC": null
+    #         },
+    #         "Coords": {
+    #           "Lat": "40.150025",
+    #           "Lon": "-75.002511"
+    #         },
+    #         "StreetCoords": {
+    #           "Lat": "40.150098",
+    #           "Lon": "-75.002827"
+    #         },
+    #         "Region": 4,
+    #         "POITypeID": 0,
+    #         "PersistentPOIID": -1,
+    #         "SiteID": -1,
+    #         "ResultType": 4,
+    #         "ShortString": "Feasterville",
+    #         "GridID": 37172748,
+    #         "LinkID": 188,
+    #         "Percent": 6291,
+    #         "TimeZone": "GMT-4:00 EDT"
+    #       }
     #     ]
-    # }
+    #   }
 
     def address(format=:unused)
       [street, city, state, postal_code, country]

--- a/lib/geocoder/results/pc_miler.rb
+++ b/lib/geocoder/results/pc_miler.rb
@@ -3,48 +3,38 @@ require 'geocoder/results/base'
 module Geocoder::Result
   class PcMiler < Base
     # sample response:
-    # https://singlesearch.alk.com/na/api/search?authToken=<TOKEN>&include=Meta&query=Feasterville
+    # https://singlesearch.alk.com/NA/api/search?query=Duluth MN
     #
-    #   "Err": 0,
-    #   "ErrString": "OK",
-    #   "QueryConfidence": 1,
-    #   "TimeInMilliseconds": 125,
-    #   "GridDataVersion": "GRD_ALK.NA.2023.01.18.29.1.1",
-    #   "CommitID": "pcmws-22.08.11.0-1778-g586da49bd1b: 05/30/2023 20:14",
-    #   "Locations": [
-    #     {
-    #       "Address": {
-    #         "StreetAddress": "",
-    #         "LocalArea": "",
-    #         "City": "Feasterville Trevose",
-    #         "State": "PA",
-    #         "StateName": "Pennsylvania",
-    #         "Zip": "19053",
-    #         "County": "Bucks",
-    #         "Country": "US",
-    #         "CountryFullName": "United States",
-    #         "SPLC": null
-    #       },
-    #       "Coords": {
-    #         "Lat": "40.150025",
-    #         "Lon": "-75.002511"
-    #       },
-    #       "StreetCoords": {
-    #         "Lat": "40.150098",
-    #         "Lon": "-75.002827"
-    #       },
-    #       "Region": 4,
-    #       "POITypeID": 0,
-    #       "PersistentPOIID": -1,
-    #       "SiteID": -1,
-    #       "ResultType": 4,
-    #       "ShortString": "Feasterville",
-    #       "GridID": 37172748,
-    #       "LinkID": 188,
-    #       "Percent": 6291,
-    #       "TimeZone": "GMT-4:00 EDT"
-    #     }
-    #   ]
+    # {
+    #     "Err": 0,
+    #     "Locations": [
+    #         {
+    #             "Address": {
+    #                 "StreetAddress": "",
+    #                 "LocalArea": "",
+    #                 "City": "Duluth",
+    #                 "State": "MN",
+    #                 "StateName": "Minnesota",
+    #                 "Zip": "55806",
+    #                 "County": "St. Louis",
+    #                 "Country": "US",
+    #                 "CountryFullName": "United States",
+    #                 "SPLC": null
+    #             },
+    #             "Coords": {
+    #                 "Lat": "46.776443",
+    #                 "Lon": "-92.110529"
+    #             },
+    #             "Region": 4,
+    #             "POITypeID": 0,
+    #             "PersistentPOIID": -1,
+    #             "SiteID": -1,
+    #             "ResultType": 3,
+    #             "ShortString": "Duluth, MN, US, St. Louis 55806",
+    #             "TimeZone": "GMT-5:00 CDT"
+    #         }
+    #     ]
+    # }
 
     def address(format=:unused)
       [street, city, state, postal_code, country]

--- a/test/fixtures/pc_miler_duluth_mn
+++ b/test/fixtures/pc_miler_duluth_mn
@@ -1,29 +1,41 @@
 {
     "Err": 0,
+    "ErrString": "OK",
+    "QueryConfidence": 1,
+    "TimeInMilliseconds": 16,
+    "GridDataVersion": "GRD_ALK.NA.2023.01.18.29.1.1",
+    "CommitID": "pcmws-22.08.11.0-1778-g586da49bd1b: 05/30/2023 20:14",
     "Locations": [
         {
             "Address": {
-                "City": "Duluth",
-                "Country": "US",
-                "CountryFullName": "United States",
-                "County": "St. Louis",
+                "StreetAddress": "",
                 "LocalArea": "",
-                "SPLC": null,
+                "City": "Duluth",
                 "State": "MN",
                 "StateName": "Minnesota",
-                "StreetAddress": "",
-                "Zip": "55806"
+                "Zip": "55806",
+                "County": "St. Louis",
+                "Country": "US",
+                "CountryFullName": "United States",
+                "SPLC": null
             },
             "Coords": {
                 "Lat": "46.776443",
                 "Lon": "-92.110529"
             },
+            "StreetCoords": {
+                "Lat": "46.776536",
+                "Lon": "-92.110673"
+            },
+            "Region": 4,
             "POITypeID": 0,
             "PersistentPOIID": -1,
-            "Region": 4,
+            "SiteID": -1,
             "ResultType": 3,
             "ShortString": "Duluth, MN, US, St. Louis 55806",
-            "SiteID": -1,
+            "GridID": 16543728,
+            "LinkID": 39,
+            "Percent": 4307,
             "TimeZone": "GMT-5:00 CDT"
         }
     ]

--- a/test/fixtures/pc_miler_madison_square_garden
+++ b/test/fixtures/pc_miler_madison_square_garden
@@ -1,30 +1,42 @@
 {
-  "Err": 0,
-  "Locations": [
-    {
-      "Address": {
-        "StreetAddress": "4 Pennsylvania Plaza",
-        "LocalArea": "",
-        "City": "New York",
-        "State": "NY",
-        "StateName": "New York",
-        "Zip": "10001",
-        "County": "New York",
-        "Country": "US",
-        "CountryFullName": "United States",
-        "SPLC": null
-      },
-      "Coords": {
-        "Lat": "40.750712",
-        "Lon": "-73.994241"
-      },
-      "Region": 4,
-      "POITypeID": 116,
-      "PersistentPOIID": 198701,
-      "SiteID": -1,
-      "ResultType": 9,
-      "ShortString": "Madison Square Garden",
-      "TimeZone": "GMT-4:00 EDT"
-    }
-  ]
+    "Err": 0,
+    "ErrString": "OK",
+    "QueryConfidence": 1,
+    "TimeInMilliseconds": 31,
+    "GridDataVersion": "GRD_ALK.NA.2023.01.18.29.1.1",
+    "CommitID": "pcmws-22.08.11.0-1778-g586da49bd1b: 05/30/2023 20:14",
+    "Locations": [
+        {
+            "Address": {
+                "StreetAddress": "4 Pennsylvania Plaza",
+                "LocalArea": "",
+                "City": "New York",
+                "State": "NY",
+                "StateName": "New York",
+                "Zip": "10001",
+                "County": "New York",
+                "Country": "US",
+                "CountryFullName": "United States",
+                "SPLC": null
+            },
+            "Coords": {
+                "Lat": "40.750712",
+                "Lon": "-73.994241"
+            },
+            "StreetCoords": {
+                "Lat": "40.750806",
+                "Lon": "-73.994472"
+            },
+            "Region": 4,
+            "POITypeID": 116,
+            "PersistentPOIID": 198701,
+            "SiteID": -1,
+            "ResultType": 9,
+            "ShortString": "Madison Square Garden",
+            "GridID": 19445260,
+            "LinkID": 565,
+            "Percent": 7364,
+            "TimeZone": "GMT-4:00 EDT"
+        }
+    ]
 }

--- a/test/fixtures/pc_miler_madison_square_garden
+++ b/test/fixtures/pc_miler_madison_square_garden
@@ -1,42 +1,30 @@
 {
-    "Err": 0,
-    "ErrString": "OK",
-    "QueryConfidence": 1,
-    "TimeInMilliseconds": 31,
-    "GridDataVersion": "GRD_ALK.NA.2023.01.18.29.1.1",
-    "CommitID": "pcmws-22.08.11.0-1778-g586da49bd1b: 05/30/2023 20:14",
-    "Locations": [
-        {
-            "Address": {
-                "StreetAddress": "4 Pennsylvania Plaza",
-                "LocalArea": "",
-                "City": "New York",
-                "State": "NY",
-                "StateName": "New York",
-                "Zip": "10001",
-                "County": "New York",
-                "Country": "US",
-                "CountryFullName": "United States",
-                "SPLC": null
-            },
-            "Coords": {
-                "Lat": "40.750712",
-                "Lon": "-73.994241"
-            },
-            "StreetCoords": {
-                "Lat": "40.750806",
-                "Lon": "-73.994472"
-            },
-            "Region": 4,
-            "POITypeID": 116,
-            "PersistentPOIID": 198701,
-            "SiteID": -1,
-            "ResultType": 9,
-            "ShortString": "Madison Square Garden",
-            "GridID": 19445260,
-            "LinkID": 565,
-            "Percent": 7364,
-            "TimeZone": "GMT-4:00 EDT"
-        }
-    ]
+  "Err": 0,
+  "Locations": [
+    {
+      "Address": {
+        "StreetAddress": "4 Pennsylvania Plaza",
+        "LocalArea": "",
+        "City": "New York",
+        "State": "NY",
+        "StateName": "New York",
+        "Zip": "10001",
+        "County": "New York",
+        "Country": "US",
+        "CountryFullName": "United States",
+        "SPLC": null
+      },
+      "Coords": {
+        "Lat": "40.750712",
+        "Lon": "-73.994241"
+      },
+      "Region": 4,
+      "POITypeID": 116,
+      "PersistentPOIID": 198701,
+      "SiteID": -1,
+      "ResultType": 9,
+      "ShortString": "Madison Square Garden",
+      "TimeZone": "GMT-4:00 EDT"
+    }
+  ]
 }

--- a/test/fixtures/pc_miler_reverse
+++ b/test/fixtures/pc_miler_reverse
@@ -1,30 +1,42 @@
 {
     "Err": 0,
+    "ErrString": "OK",
+    "QueryConfidence": 1,
+    "TimeInMilliseconds": 0,
+    "GridDataVersion": "GRD_ALK.NA.2023.01.18.29.1.1",
+    "CommitID": "pcmws-22.08.11.0-1778-g586da49bd1b: 05/30/2023 20:14",
     "Locations": [
         {
             "Address": {
-                "City": "Alliance",
+                "StreetAddress": "",
+                "LocalArea": "",
+                "City": "Monroe Township",
+                "State": "NJ",
+                "StateName": "New Jersey",
+                "Zip": "08831",
+                "County": "Middlesex",
                 "Country": "US",
                 "CountryFullName": "United States",
-                "County": "Box Butte",
-                "LocalArea": "",
-                "SPLC": null,
-                "State": "NE",
-                "StateName": "Nebraska",
-                "StreetAddress": "2093 NE-87",
-                "Zip": "69301"
+                "SPLC": null
             },
             "Coords": {
-                "Lat": "42.14228",
-                "Lon": "-102.85796"
+                "Lat": "40.355924",
+                "Lon": "-74.451975"
             },
+            "StreetCoords": {
+                "Lat": "40.356483",
+                "Lon": "-74.451665"
+            },
+            "Region": 4,
             "POITypeID": 0,
             "PersistentPOIID": -1,
-            "Region": 4,
-            "ResultType": 14,
-            "ShortString": "2093 NE-87, Alliance, NE, US, Box Butte 69301",
             "SiteID": -1,
-            "TimeZone": "GMT-6:00 MDT"
+            "ResultType": 14,
+            "ShortString": "Monroe Township, NJ, US, Middlesex 08831",
+            "GridID": 54638092,
+            "LinkID": 504,
+            "Percent": 4980,
+            "TimeZone": "GMT-4:00 EDT"
         }
     ]
 }

--- a/test/fixtures/pc_miler_reverse
+++ b/test/fixtures/pc_miler_reverse
@@ -1,42 +1,30 @@
 {
     "Err": 0,
-    "ErrString": "OK",
-    "QueryConfidence": 1,
-    "TimeInMilliseconds": 0,
-    "GridDataVersion": "GRD_ALK.NA.2023.01.18.29.1.1",
-    "CommitID": "pcmws-22.08.11.0-1778-g586da49bd1b: 05/30/2023 20:14",
     "Locations": [
         {
             "Address": {
-                "StreetAddress": "",
-                "LocalArea": "",
-                "City": "Monroe Township",
-                "State": "NJ",
-                "StateName": "New Jersey",
-                "Zip": "08831",
-                "County": "Middlesex",
+                "City": "Alliance",
                 "Country": "US",
                 "CountryFullName": "United States",
-                "SPLC": null
+                "County": "Box Butte",
+                "LocalArea": "",
+                "SPLC": null,
+                "State": "NE",
+                "StateName": "Nebraska",
+                "StreetAddress": "2093 NE-87",
+                "Zip": "69301"
             },
             "Coords": {
-                "Lat": "40.355924",
-                "Lon": "-74.451975"
+                "Lat": "42.14228",
+                "Lon": "-102.85796"
             },
-            "StreetCoords": {
-                "Lat": "40.356483",
-                "Lon": "-74.451665"
-            },
-            "Region": 4,
             "POITypeID": 0,
             "PersistentPOIID": -1,
-            "SiteID": -1,
+            "Region": 4,
             "ResultType": 14,
-            "ShortString": "Monroe Township, NJ, US, Middlesex 08831",
-            "GridID": 54638092,
-            "LinkID": 504,
-            "Percent": 4980,
-            "TimeZone": "GMT-4:00 EDT"
+            "ShortString": "2093 NE-87, Alliance, NE, US, Box Butte 69301",
+            "SiteID": -1,
+            "TimeZone": "GMT-6:00 MDT"
         }
     ]
 }

--- a/test/fixtures/pc_miler_reverse
+++ b/test/fixtures/pc_miler_reverse
@@ -1,29 +1,41 @@
 {
     "Err": 0,
+    "ErrString": "OK",
+    "QueryConfidence": 1,
+    "TimeInMilliseconds": 0,
+    "GridDataVersion": "GRD_ALK.NA.2023.01.18.29.1.1",
+    "CommitID": "pcmws-22.08.11.0-1778-g586da49bd1b: 05/30/2023 20:14",
     "Locations": [
         {
             "Address": {
-                "City": "Alliance",
-                "Country": "US",
-                "CountryFullName": "United States",
-                "County": "Box Butte",
+                "StreetAddress": "2093 NE-87",
                 "LocalArea": "",
-                "SPLC": null,
+                "City": "Alliance",
                 "State": "NE",
                 "StateName": "Nebraska",
-                "StreetAddress": "2093 NE-87",
-                "Zip": "69301"
+                "Zip": "69301",
+                "County": "Box Butte",
+                "Country": "US",
+                "CountryFullName": "United States",
+                "SPLC": null
             },
             "Coords": {
                 "Lat": "42.14228",
                 "Lon": "-102.85796"
             },
+            "StreetCoords": {
+                "Lat": "42.142238",
+                "Lon": "-102.859302"
+            },
+            "Region": 4,
             "POITypeID": 0,
             "PersistentPOIID": -1,
-            "Region": 4,
+            "SiteID": -1,
             "ResultType": 14,
             "ShortString": "2093 NE-87, Alliance, NE, US, Box Butte 69301",
-            "SiteID": -1,
+            "GridID": 666788,
+            "LinkID": 1334,
+            "Percent": 4865,
             "TimeZone": "GMT-6:00 MDT"
         }
     ]

--- a/test/fixtures/pc_miler_times_square
+++ b/test/fixtures/pc_miler_times_square
@@ -1,0 +1,331 @@
+{
+    "Err": 0,
+    "ErrString": "OK",
+    "QueryConfidence": 3,
+    "TimeInMilliseconds": 31,
+    "GridDataVersion": "GRD_ALK.NA.2023.01.18.29.1.1",
+    "CommitID": "pcmws-22.08.11.0-1778-g586da49bd1b: 05/30/2023 20:14",
+    "Locations": [
+        {
+            "Address": {
+                "StreetAddress": "",
+                "LocalArea": "",
+                "City": "Times Square",
+                "State": "NY",
+                "StateName": "New York",
+                "Zip": "",
+                "County": "New York",
+                "Country": "US",
+                "CountryFullName": "United States",
+                "SPLC": null
+            },
+            "Coords": {
+                "Lat": "40.756939",
+                "Lon": "-73.986384"
+            },
+            "StreetCoords": {
+                "Lat": "40.756904",
+                "Lon": "-73.986299"
+            },
+            "Region": 4,
+            "POITypeID": 0,
+            "PersistentPOIID": -1,
+            "SiteID": -1,
+            "ResultType": 3,
+            "ShortString": "Times Square, NY, US, New York",
+            "GridID": 19445260,
+            "LinkID": 839,
+            "Percent": 3337,
+            "TimeZone": "GMT-4:00 EDT"
+        },
+        {
+            "Address": {
+                "StreetAddress": "",
+                "LocalArea": "",
+                "City": "Times Square",
+                "State": "WA",
+                "StateName": "Washington",
+                "Zip": "",
+                "County": "King",
+                "Country": "US",
+                "CountryFullName": "United States",
+                "SPLC": null
+            },
+            "Coords": {
+                "Lat": "47.595224",
+                "Lon": "-122.209237"
+            },
+            "StreetCoords": {
+                "Lat": "47.596301",
+                "Lon": "-122.209631"
+            },
+            "Region": 4,
+            "POITypeID": 0,
+            "PersistentPOIID": -1,
+            "SiteID": -1,
+            "ResultType": 3,
+            "ShortString": "Times Square, WA, US, King",
+            "GridID": 59017072,
+            "LinkID": 41,
+            "Percent": 0,
+            "TimeZone": "GMT-7:00 PDT"
+        },
+        {
+            "Address": {
+                "StreetAddress": "Times Square",
+                "LocalArea": "",
+                "City": "Detroit",
+                "State": "MI",
+                "StateName": "Michigan",
+                "Zip": "48226",
+                "County": "Wayne",
+                "Country": "US",
+                "CountryFullName": "United States",
+                "SPLC": null
+            },
+            "Coords": {
+                "Lat": "42.332863",
+                "Lon": "-83.052886"
+            },
+            "StreetCoords": {
+                "Lat": "42.332863",
+                "Lon": "-83.052886"
+            },
+            "Region": 4,
+            "POITypeID": 0,
+            "PersistentPOIID": -1,
+            "SiteID": -1,
+            "ResultType": 6,
+            "ShortString": "Times Square, Detroit, MI, US, Wayne 48226",
+            "GridID": 28268556,
+            "LinkID": 548,
+            "Percent": 5000,
+            "TimeZone": "GMT-4:00 EDT"
+        },
+        {
+            "Address": {
+                "StreetAddress": "Times Square",
+                "LocalArea": "",
+                "City": "New York",
+                "State": "NY",
+                "StateName": "New York",
+                "Zip": "10018",
+                "County": "New York",
+                "Country": "US",
+                "CountryFullName": "United States",
+                "SPLC": null
+            },
+            "Coords": {
+                "Lat": "40.754957",
+                "Lon": "-73.98721"
+            },
+            "StreetCoords": {
+                "Lat": "40.755206",
+                "Lon": "-73.987044"
+            },
+            "Region": 4,
+            "POITypeID": 0,
+            "PersistentPOIID": -1,
+            "SiteID": -1,
+            "ResultType": 6,
+            "ShortString": "Times Square, New York, NY, US, New York 10018",
+            "GridID": 19445260,
+            "LinkID": 823,
+            "Percent": 5118,
+            "TimeZone": "GMT-4:00 EDT"
+        },
+        {
+            "Address": {
+                "StreetAddress": "Times Square",
+                "LocalArea": "",
+                "City": "New York",
+                "State": "NY",
+                "StateName": "New York",
+                "Zip": "10036",
+                "County": "New York",
+                "Country": "US",
+                "CountryFullName": "United States",
+                "SPLC": null
+            },
+            "Coords": {
+                "Lat": "40.759616",
+                "Lon": "-73.984567"
+            },
+            "StreetCoords": {
+                "Lat": "40.759548",
+                "Lon": "-73.984374"
+            },
+            "Region": 4,
+            "POITypeID": 0,
+            "PersistentPOIID": -1,
+            "SiteID": -1,
+            "ResultType": 6,
+            "ShortString": "Times Square, New York, NY, US, New York 10036",
+            "GridID": 2668044,
+            "LinkID": 236,
+            "Percent": 5637,
+            "TimeZone": "GMT-4:00 EDT"
+        },
+        {
+            "Address": {
+                "StreetAddress": "Times Square",
+                "LocalArea": "",
+                "City": "Elgin",
+                "State": "IL",
+                "StateName": "Illinois",
+                "Zip": "60120",
+                "County": "Kane",
+                "Country": "US",
+                "CountryFullName": "United States",
+                "SPLC": null
+            },
+            "Coords": {
+                "Lat": "42.026895",
+                "Lon": "-88.275893"
+            },
+            "StreetCoords": {
+                "Lat": "42.026895",
+                "Lon": "-88.275893"
+            },
+            "Region": 4,
+            "POITypeID": 0,
+            "PersistentPOIID": -1,
+            "SiteID": -1,
+            "ResultType": 6,
+            "ShortString": "Times Square, Elgin, IL, US, Kane 60120",
+            "GridID": 66094092,
+            "LinkID": 155,
+            "Percent": 5000,
+            "TimeZone": "GMT-5:00 CDT"
+        },
+        {
+            "Address": {
+                "StreetAddress": "Times Square",
+                "LocalArea": "",
+                "City": "Tuscaloosa",
+                "State": "AL",
+                "StateName": "Alabama",
+                "Zip": "35405",
+                "County": "Tuscaloosa",
+                "Country": "US",
+                "CountryFullName": "United States",
+                "SPLC": null
+            },
+            "Coords": {
+                "Lat": "33.174866",
+                "Lon": "-87.513441"
+            },
+            "StreetCoords": {
+                "Lat": "33.174866",
+                "Lon": "-87.513441"
+            },
+            "Region": 4,
+            "POITypeID": 0,
+            "PersistentPOIID": -1,
+            "SiteID": -1,
+            "ResultType": 6,
+            "ShortString": "Times Square, Tuscaloosa, AL, US, Tuscaloosa 35405",
+            "GridID": 5210188,
+            "LinkID": 729,
+            "Percent": 5000,
+            "TimeZone": "GMT-5:00 CDT"
+        },
+        {
+            "Address": {
+                "StreetAddress": "Times Square",
+                "LocalArea": "",
+                "City": "Harlingen",
+                "State": "TX",
+                "StateName": "Texas",
+                "Zip": "78552",
+                "County": "Cameron",
+                "Country": "US",
+                "CountryFullName": "United States",
+                "SPLC": null
+            },
+            "Coords": {
+                "Lat": "26.193921",
+                "Lon": "-97.732277"
+            },
+            "StreetCoords": {
+                "Lat": "26.193921",
+                "Lon": "-97.732277"
+            },
+            "Region": 4,
+            "POITypeID": 0,
+            "PersistentPOIID": -1,
+            "SiteID": -1,
+            "ResultType": 6,
+            "ShortString": "Times Square, Harlingen, TX, US, Cameron 78552",
+            "GridID": 22229988,
+            "LinkID": 41,
+            "Percent": 5000,
+            "TimeZone": "GMT-5:00 CDT"
+        },
+        {
+            "Address": {
+                "StreetAddress": "2602 W Deer Valley Rd",
+                "LocalArea": "",
+                "City": "Phoenix",
+                "State": "AZ",
+                "StateName": "Arizona",
+                "Zip": "85027-2407",
+                "County": "Maricopa",
+                "Country": "US",
+                "CountryFullName": "United States",
+                "SPLC": null
+            },
+            "Coords": {
+                "Lat": "33.684249",
+                "Lon": "-112.116323"
+            },
+            "StreetCoords": {
+                "Lat": "33.684251",
+                "Lon": "-112.116072"
+            },
+            "Region": 4,
+            "POITypeID": 435,
+            "PersistentPOIID": 593718596,
+            "SiteID": -1,
+            "ResultType": 9,
+            "ShortString": "Times Square",
+            "TrimblePlaceId": "0xA4-W-6_eqlOZ1pO_pdHpKg",
+            "GridID": 4718820,
+            "LinkID": 346,
+            "Percent": 2506,
+            "TimeZone": "GMT-7:00 MST"
+        },
+        {
+            "Address": {
+                "StreetAddress": "718 E Union Hills Dr",
+                "LocalArea": "",
+                "City": "Phoenix",
+                "State": "AZ",
+                "StateName": "Arizona",
+                "Zip": "85024-2997",
+                "County": "Maricopa",
+                "Country": "US",
+                "CountryFullName": "United States",
+                "SPLC": null
+            },
+            "Coords": {
+                "Lat": "33.654949",
+                "Lon": "-112.063936"
+            },
+            "StreetCoords": {
+                "Lat": "33.654852",
+                "Lon": "-112.063936"
+            },
+            "Region": 4,
+            "POITypeID": 435,
+            "PersistentPOIID": -1,
+            "SiteID": -1,
+            "ResultType": 9,
+            "ShortString": "Times Square",
+            "GridID": 35127524,
+            "LinkID": 1517,
+            "Percent": 4704,
+            "TimeZone": "GMT-7:00 MST"
+        }
+    ]
+}

--- a/test/fixtures/pc_miler_wall_drug
+++ b/test/fixtures/pc_miler_wall_drug
@@ -1,54 +1,73 @@
 {
     "Err": 0,
+    "ErrString": "OK",
+    "QueryConfidence": 3,
+    "TimeInMilliseconds": 16,
+    "GridDataVersion": "GRD_ALK.NA.2023.01.18.29.1.1",
+    "CommitID": "pcmws-22.08.11.0-1778-g586da49bd1b: 05/30/2023 20:14",
     "Locations": [
         {
             "Address": {
-                "City": "Wall",
-                "Country": "US",
-                "CountryFullName": "United States",
-                "County": "Pennington",
+                "StreetAddress": "510 Main St",
                 "LocalArea": "",
-                "SPLC": null,
+                "City": "Wall",
                 "State": "SD",
                 "StateName": "South Dakota",
-                "StreetAddress": "510 Main St",
-                "Zip": "57790-9501"
+                "Zip": "57790-9501",
+                "County": "Pennington",
+                "Country": "US",
+                "CountryFullName": "United States",
+                "SPLC": null
             },
             "Coords": {
                 "Lat": "44.0632",
                 "Lon": "-102.2151"
             },
+            "StreetCoords": {
+                "Lat": "44.066916",
+                "Lon": "-102.215056"
+            },
+            "Region": 4,
             "POITypeID": 402,
             "PersistentPOIID": -1,
-            "Region": 4,
+            "SiteID": -1,
             "ResultType": 9,
             "ShortString": "Wall Drug Store",
-            "SiteID": -1,
+            "GridID": 845988,
+            "LinkID": 400,
+            "Percent": 6485,
             "TimeZone": "GMT-6:00 MDT"
         },
         {
             "Address": {
-                "City": "Johnsonville",
-                "Country": "US",
-                "CountryFullName": "United States",
-                "County": "Florence",
+                "StreetAddress": "239 Stuckey St",
                 "LocalArea": "",
-                "SPLC": null,
+                "City": "Johnsonville",
                 "State": "SC",
                 "StateName": "South Carolina",
-                "StreetAddress": "239 Stuckey St",
-                "Zip": "29555-6448"
+                "Zip": "29555-6448",
+                "County": "Florence",
+                "Country": "US",
+                "CountryFullName": "United States",
+                "SPLC": null
             },
             "Coords": {
                 "Lat": "33.809771",
                 "Lon": "-79.443093"
             },
+            "StreetCoords": {
+                "Lat": "33.809734",
+                "Lon": "-79.442453"
+            },
+            "Region": 4,
             "POITypeID": 128,
             "PersistentPOIID": -1,
-            "Region": 4,
+            "SiteID": -1,
             "ResultType": 9,
             "ShortString": "Wall Drugs of Johnsonville",
-            "SiteID": -1,
+            "GridID": 1572108,
+            "LinkID": 107,
+            "Percent": 5946,
             "TimeZone": "GMT-4:00 EDT"
         }
     ]

--- a/test/unit/lookups/pc_miler_test.rb
+++ b/test/unit/lookups/pc_miler_test.rb
@@ -12,14 +12,14 @@ class TrimbleMapsTest < GeocoderTestCase
     query = Geocoder::Query.new('wall drug')
     lookup = Geocoder::Lookup.get(:pc_miler)
     res = lookup.query_url(query)
-    assert_equal 'https://singlesearch.alk.com/NA/api/search?query=wall%2Bdrug', res
+    assert_equal 'https://singlesearch.alk.com/NA/api/search?include=Meta&query=wall%2Bdrug', res
   end
 
   def test_query_for_reverse_geocode
     query = Geocoder::Query.new([43.99255, -102.24127])
     lookup = Geocoder::Lookup.get(:pc_miler)
     res = lookup.query_url(query)
-    assert_equal 'https://singlesearch.alk.com/NA/api/search?query=43.99255%2C-102.24127', res
+    assert_equal 'https://singlesearch.alk.com/NA/api/search?include=Meta&query=43.99255%2C-102.24127', res
   end
 
   def test_not_authorized
@@ -35,7 +35,7 @@ class TrimbleMapsTest < GeocoderTestCase
     query = Geocoder::Query.new('Sydney')
     lookup = Geocoder::Lookup.get(:pc_miler)
     res = lookup.query_url(query)
-    assert_equal 'https://singlesearch.alk.com/NA/api/search?query=Sydney', res
+    assert_equal 'https://singlesearch.alk.com/NA/api/search?include=Meta&query=Sydney', res
   end
 
   def test_query_region_can_be_given_in_global_config
@@ -43,7 +43,7 @@ class TrimbleMapsTest < GeocoderTestCase
     query = Geocoder::Query.new('Sydney')
     lookup = Geocoder::Lookup.get(:pc_miler)
     res = lookup.query_url(query)
-    assert_equal 'https://singlesearch.alk.com/EU/api/search?query=Sydney', res
+    assert_equal 'https://singlesearch.alk.com/EU/api/search?include=Meta&query=Sydney', res
   end
 
   # option given in query takes precedence over global option
@@ -52,7 +52,7 @@ class TrimbleMapsTest < GeocoderTestCase
     query = Geocoder::Query.new('Sydney', region: 'OC')
     lookup = Geocoder::Lookup.get(:pc_miler)
     res = lookup.query_url(query)
-    assert_equal 'https://singlesearch.alk.com/OC/api/search?query=Sydney', res
+    assert_equal 'https://singlesearch.alk.com/OC/api/search?include=Meta&query=Sydney', res
   end
 
   def test_query_raises_if_region_is_invalid

--- a/test/unit/lookups/pc_miler_test.rb
+++ b/test/unit/lookups/pc_miler_test.rb
@@ -125,4 +125,14 @@ class TrimbleMapsTest < GeocoderTestCase
     assert_equal -102.85796, result.longitude
     assert_equal([42.14228, -102.85796], result.coordinates)
   end
+
+  def test_results_metadata
+    results = Geocoder.search("Times Square")
+
+    assert_equal 10, results.size
+
+    results.map do |result|
+      assert_equal 3, result.data["QueryConfidence"]
+    end
+  end
 end


### PR DESCRIPTION
To add useful metadata to the response data for Trimble maps single search integration we need to add the
[`include` url parameter with value 'Meta'](https://developer.trimblemaps.com/restful-apis/location/single-search/single-search-api/).

This PR takes care of such addition.

example call
``` https://singlesearch.alk.com/na/api/search?authToken=<TOKEN>&include=Meta&query=Feasterville Trevose, Pennsylvania 19053, United States```

response:
```{
    "Err": 0,
    "ErrString": "OK",
    "QueryConfidence": 1,
    "TimeInMilliseconds": 125,
    "GridDataVersion": "GRD_ALK.NA.2023.01.18.29.1.1",
    "CommitID": "pcmws-22.08.11.0-1778-g586da49bd1b: 05/30/2023 20:14",
    "Locations": [
        {
            "Address": {
                "StreetAddress": "",
                "LocalArea": "",
                "City": "Feasterville Trevose",
                "State": "PA",
                "StateName": "Pennsylvania",
                "Zip": "19053",
                "County": "Bucks",
                "Country": "US",
                "CountryFullName": "United States",
                "SPLC": null
            },
            "Coords": {
                "Lat": "40.150025",
                "Lon": "-75.002511"
            },
            "StreetCoords": {
                "Lat": "40.150098",
                "Lon": "-75.002827"
            },
            "Region": 4,
            "POITypeID": 0,
            "PersistentPOIID": -1,
            "SiteID": -1,
            "ResultType": 4,
            "ShortString": "Feasterville Trevose, PA, US, Bucks 19053",
            "GridID": 37172748,
            "LinkID": 188,
            "Percent": 6291,
            "TimeZone": "GMT-4:00 EDT"
        }
    ]
}
```
Important Note:
- Top level metadata "QueryConfidence" from the above would **need** to be inserted in the results array that would include the Result object (in this case Geocoder::Result::PcMiler) with service specific data, so that it could be available for the user. This PR also takes care of that.

- all Fixtures are also updated for consistency sake

