### PR TITLE
Fix : param type in ban_data_gouv_fr lookup

### DIFF
--- a/README_API_GUIDE.md
+++ b/README_API_GUIDE.md
@@ -429,8 +429,8 @@ Regional Street Address Lookups
 * **Region**: France
 * **SSL support**: yes
 * **Languages**: en / fr
-* **Documentation**: https://adresse.data.gouv.fr/api/ (in french)
-* **Terms of Service**: https://adresse.data.gouv.fr/faq/ (in french)
+* **Documentation**: https://adresse.data.gouv.fr/api-doc/adresse (in french)
+* **Terms of Service**: https://doc.adresse.data.gouv.fr/ (in french)
 * **Limitations**: [Data licensed under Open Database License (ODbL) (you must provide attribution).](http://openstreetmap.fr/ban)
 
 ### Geocoder.ca (`:geocoder_ca`)

--- a/lib/geocoder/lookups/ban_data_gouv_fr.rb
+++ b/lib/geocoder/lookups/ban_data_gouv_fr.rb
@@ -125,7 +125,7 @@ module Geocoder::Lookup
     end
 
     def type_param_is_valid?(param)
-      %w(housenumber street locality village town city).include?(param.downcase)
+      %w(housenumber street locality municipality).include?(param.downcase)
     end
 
     def code_param_is_valid?(param)

--- a/lib/geocoder/results/ban_data_gouv_fr.rb
+++ b/lib/geocoder/results/ban_data_gouv_fr.rb
@@ -275,7 +275,7 @@ module Geocoder::Result
     private
 
     def city?(result_type)
-      %w(village town city).include?(result_type)
+      result_type == 'municipality'
     end
 
   end

--- a/test/fixtures/ban_data_gouv_fr_montpellier
+++ b/test/fixtures/ban_data_gouv_fr_montpellier
@@ -24,7 +24,7 @@
         "score": 0.9785090909090908,
         "label": "Montpellier",
         "id": "34172_34080",
-        "type": "city",
+        "type": "municipality",
         "population": "255.1"
       },
       "type": "Feature"
@@ -47,7 +47,7 @@
         "score": 0.9785090909090908,
         "label": "Montpellier",
         "id": "34172",
-        "type": "city",
+        "type": "municipality",
         "population": "255.1"
       },
       "type": "Feature"
@@ -70,7 +70,7 @@
         "score": 0.9785090909090908,
         "label": "Montpellier",
         "id": "34172_34090",
-        "type": "city",
+        "type": "municipality",
         "population": "255.1"
       },
       "type": "Feature"
@@ -93,7 +93,7 @@
         "score": 0.9785090909090908,
         "label": "Montpellier",
         "id": "34172_34070",
-        "type": "city",
+        "type": "municipality",
         "population": "255.1"
       },
       "type": "Feature"

--- a/test/fixtures/ban_data_gouv_fr_paris
+++ b/test/fixtures/ban_data_gouv_fr_paris
@@ -24,7 +24,7 @@
         "score": 1,
         "label": "Paris",
         "id": "75056",
-        "type": "city",
+        "type": "municipality",
         "population": "2244"
       },
       "type": "Feature"

--- a/test/unit/lookups/ban_data_gouv_fr_test.rb
+++ b/test/unit/lookups/ban_data_gouv_fr_test.rb
@@ -57,7 +57,7 @@ class BanDataGouvFrTest < GeocoderTestCase
 
   def test_paris_special_business_logic
     result = Geocoder.search('paris').first
-    assert_equal 'city', result.result_type
+    assert_equal 'municipality', result.result_type
     assert_equal '75000', result.postal_code
     assert_equal 'France', result.country
     assert_equal 'FR', result.country_code
@@ -75,8 +75,8 @@ class BanDataGouvFrTest < GeocoderTestCase
   end
 
   def test_city_result_methods
-    result = Geocoder.search('montpellier').first
-    assert_equal 'city', result.result_type
+    result = Geocoder.search('montpellier', type: 'municipality').first
+    assert_equal 'municipality', result.result_type
     assert_equal '34080', result.postal_code
     assert_equal '34172', result.city_code
     assert_equal 'France', result.country


### PR DESCRIPTION
Updates for the ban_data_gouv_fr lookup : 
- Remove the old `village`, `town` and `city` (result) types which are no longer used
- Add the new `municipality` type (replacing old types)
- Update API Guide urls

Doc : https://adresse.data.gouv.fr/api-doc/adresse

<img width="630" alt="Capture d’écran 2023-06-14 à 01 08 34" src="https://github.com/alexreisner/geocoder/assets/3688468/a25cad83-7f3e-4297-8000-fc1fad88a11d">
