### PR TITLE
Remove double encoding

### DIFF
--- a/lib/geocoder/lookups/pc_miler.rb
+++ b/lib/geocoder/lookups/pc_miler.rb
@@ -52,14 +52,14 @@ module Geocoder::Lookup
     def query_url_params(query)
       if query.reverse_geocode?
         lat,lon = query.coordinates
-        escaped_query = "#{CGI.escape(lat)},#{CGI.escape(lon)}"
+        formatted_query = "#{CGI.escape(lat)},#{CGI.escape(lon)}"
       else
-        escaped_query = CGI.escape(query.text.to_s)
+        formatted_query = query.text.to_s
       end
 
       {
         authToken: configuration.api_key,
-        query: escaped_query,
+        query: formatted_query,
         # to add additional metadata to response such as QueryConfidence
         include: 'Meta'
       }.merge(super(query))

--- a/test/unit/lookups/pc_miler_test.rb
+++ b/test/unit/lookups/pc_miler_test.rb
@@ -12,14 +12,14 @@ class TrimbleMapsTest < GeocoderTestCase
     query = Geocoder::Query.new('wall drug')
     lookup = Geocoder::Lookup.get(:pc_miler)
     res = lookup.query_url(query)
-    assert_equal 'https://singlesearch.alk.com/NA/api/search?include=Meta&query=wall%2Bdrug', res
+    assert_equal 'https://singlesearch.alk.com/NA/api/search?include=Meta&query=wall+drug', res
   end
 
   def test_query_for_geocode_with_commas
     query = Geocoder::Query.new('Fair Lawn, NJ, US')
     lookup = Geocoder::Lookup.get(:pc_miler)
     res = lookup.query_url(query)
-    assert_equal 'https://singlesearch.alk.com/NA/api/search?authToken=5830B19FA9B6C24F9EEC3F5CA4B7742A&include=Meta&query=Fair+Lawn%2C+NJ%2C+US', res
+    assert_equal 'https://singlesearch.alk.com/NA/api/search?include=Meta&query=Fair+Lawn%2C+NJ%2C+US', res
   end
 
   def test_query_for_reverse_geocode

--- a/test/unit/lookups/pc_miler_test.rb
+++ b/test/unit/lookups/pc_miler_test.rb
@@ -15,6 +15,13 @@ class TrimbleMapsTest < GeocoderTestCase
     assert_equal 'https://singlesearch.alk.com/NA/api/search?include=Meta&query=wall%2Bdrug', res
   end
 
+  def test_query_for_geocode_with_commas
+    query = Geocoder::Query.new('Fair Lawn, NJ, US')
+    lookup = Geocoder::Lookup.get(:pc_miler)
+    res = lookup.query_url(query)
+    assert_equal 'https://singlesearch.alk.com/NA/api/search?authToken=5830B19FA9B6C24F9EEC3F5CA4B7742A&include=Meta&query=Fair+Lawn%2C+NJ%2C+US', res
+  end
+
   def test_query_for_reverse_geocode
     query = Geocoder::Query.new([43.99255, -102.24127])
     lookup = Geocoder::Lookup.get(:pc_miler)


### PR DESCRIPTION
Remove double encoding because `hash_to_query` already does this in the base class.