### PR TITLE
Remove references to legacy Google Places Search fields

### DIFF
--- a/lib/geocoder/lookups/google_places_search.rb
+++ b/lib/geocoder/lookups/google_places_search.rb
@@ -49,12 +49,11 @@ module Geocoder
       end
 
       def default_fields
-        legacy = %w[id reference]
         basic = %w[business_status formatted_address geometry icon name 
           photos place_id plus_code types]
         contact = %w[opening_hours]
         atmosphere = %W[price_level rating user_ratings_total]
-        format_fields(legacy, basic, contact, atmosphere)
+        format_fields(basic, contact, atmosphere)
       end
 
       def format_fields(*fields)

--- a/test/unit/lookups/google_places_search_test.rb
+++ b/test/unit/lookups/google_places_search_test.rb
@@ -51,7 +51,7 @@ class GooglePlacesSearchTest < GeocoderTestCase
 
   def test_google_places_search_query_url_contains_every_field_available_by_default
     url = lookup.query_url(Geocoder::Query.new("some-address"))
-    fields = %w[id reference business_status formatted_address geometry icon name 
+    fields = %w[business_status formatted_address geometry icon name 
       photos place_id plus_code types opening_hours price_level rating 
       user_ratings_total]
     assert_match(/fields=#{fields.join('%2C')}/, url)


### PR DESCRIPTION
Removes legacy `id` and `reference` fields from Google Places Search results.

Closes #1627.