### PR TITLE
Fix documented coordinates return format

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ Every `Geocoder::Result` object, `result`, provides the following data:
 
 * `result.latitude` - float
 * `result.longitude` - float
-* `result.coordinates` - array of the above two in the form of `[lat,lon]`
+* `result.coordinates` - array of the above two in the form of `[lon,lat]`
 * `result.address` - string
 * `result.city` - string
 * `result.state` - string


### PR DESCRIPTION
Currently, the readme shows `coordinates` returning an array with latitude `lat` first, and longitude `lon` last. These values should be flipped.

```ruby
user.lonlat
=> #<RGeo::Geographic::SphericalPointImpl:0x8c2d0 "POINT (-73.9973543 40.7208361)">

user.lonlat.latitude
=> 40.7208361

user.lonlat.longitude
=> -73.9973543

user.lonlat.coordinates
=> [
  -73.9973543,
  40.7208361
]
```