### PR TITLE
Fix dependency warning in Ruby 3.3 and prepare for Ruby 3.4

### DIFF
--- a/geocoder.gemspec
+++ b/geocoder.gemspec
@@ -22,4 +22,6 @@ Gem::Specification.new do |s|
     'source_code_uri' => 'https://github.com/alexreisner/geocoder',
     'changelog_uri'   => 'https://github.com/alexreisner/geocoder/blob/master/CHANGELOG.md'
   }
+  s.add_dependency("base64", ">= 0.1.0") # for :google_premier lookup
+  s.add_dependency("csv", ">= 3.0.0") # for :maxmind lookup
 end


### PR DESCRIPTION
Fix https://github.com/alexreisner/geocoder/issues/1642