### PR TITLE
Add place_id as a result attribute from amazon_location_service

### DIFF
--- a/lib/geocoder/lookups/amazon_location_service.rb
+++ b/lib/geocoder/lookups/amazon_location_service.rb
@@ -19,7 +19,7 @@ module Geocoder::Lookup
         client.search_place_index_for_text(params.merge(text: query.text))
       end
       
-      resp.results.map(&:place)
+      resp.results
     end
 
     private

--- a/lib/geocoder/results/amazon_location_service.rb
+++ b/lib/geocoder/results/amazon_location_service.rb
@@ -3,7 +3,8 @@ require 'geocoder/results/base'
 module Geocoder::Result
   class AmazonLocationService < Base
     def initialize(result)
-      @place = result
+      @place = result.place
+      super
     end
 
     def coordinates
@@ -52,6 +53,10 @@ module Geocoder::Result
 
     def country_code
       @place.country
+    end
+
+    def place_id
+      data.place_id if data.respond_to?(:place_id)
     end
   end
 end

--- a/test/fixtures/amazon_location_service_madison_square_garden
+++ b/test/fixtures/amazon_location_service_madison_square_garden
@@ -1,4 +1,5 @@
 [
+  "AQABAFMAf5Cj6ApTW9YHMA3COqc3G1_dNHr1qtFl-W36hTyQd_Jw0f-t-7oaBxmbWd9vNecT3rIiH6O6DJ36qPk7seUIuIp8tOOZDoQnuweFUE5fHjvl15sTbn1PREQwp_66LjvkkubhQ3seXgBrCMZT3rt_dBzubg",
   nil,
   "USA",
   MockAWSPlaceGeometry.new([-74.15434739412053, 40.61681535865544]),

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -553,11 +553,7 @@ module Geocoder
     MockAWSPlace = Struct.new(*%i[
       address_number country geometry label municipality neighborhood postal_code region street sub_region
     ])
-    class MockAWSPlace
-      def place
-        self
-      end
-    end
+    MockAWSResult = Struct.new(:place_id, :place)
 
     class MockAmazonLocationServiceClient
       def search_place_index_for_position(params = {}, options = {})
@@ -578,7 +574,10 @@ module Geocoder
       end
 
       def mock_results
-        MockResults.new([MockAWSPlace.new(*fixture)])
+        fixture_copy = fixture.dup
+        place_id = fixture_copy.shift
+        place = MockAWSPlace.new(*fixture_copy)
+        MockResults.new([MockAWSResult.new(place_id, place)])
       end
 
       def mock_no_results

--- a/test/unit/result_test.rb
+++ b/test/unit/result_test.rb
@@ -16,6 +16,7 @@ class ResultTest < GeocoderTestCase
       set_api_key!(l)
       result = Geocoder.search("Madison Square Garden").first
       assert_result_has_required_attributes(result)
+      assert_aws_result_supports_place_id(result) if l == :amazon_location_service
     end
   end
 
@@ -55,5 +56,9 @@ class ResultTest < GeocoderTestCase
     assert result.country.is_a?(String),       m % "country"
     assert result.country_code.is_a?(String),  m % "country_code"
     assert_not_nil result.address,             m % "address"
+  end
+
+  def assert_aws_result_supports_place_id(result)
+    assert result.place_id.is_a?(String)
   end
 end


### PR DESCRIPTION
Place_id is a really useful unique location identifier. Since at least 2 of Amazon Location Service's place providers return this attribute, we would like to return it as a an attribute in the geocoder response as well.