### PR TITLE
Update pg gem version in the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ group :test do
   gem 'webmock'
 
   platforms :ruby do
-    gem 'pg', '~> 0.11'
+    gem 'pg', '~> 1.5'
     gem 'mysql2', '~> 0.5.4'
   end
 


### PR DESCRIPTION
This PR updates the pg gem version in the Gemfile for developing this project.

## Details

While setting up my local environment for this project, I encountered an error during `bundle install` related to the installation of the pg gem:

```
pg_binary_decoder.c:115:20: error: call to undeclared function 'rb_tainted_str_new'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
```

This error was resolved by updating the pg gem to the latest version (1.5.x) from the old version (0.11.x). This allowed me to successfully run `bundle install`.
Additionally, I could run `bundle exec rake` and see all the tests pass.

How about this change?

## Environment

I have tested this change with the following environment:

### gcc

```
gcc -v
Apple clang version 14.0.3 (clang-1403.0.22.14.1)
Target: x86_64-apple-darwin22.5.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```

### postgresql

```
psql --version psql
psql (PostgreSQL) 14.11 (Homebrew)
```

#### Ruby

```
ruby -v
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-darwin22]
```