### PR TITLE
Fix nil values in mapbox result

### DIFF
--- a/lib/geocoder/results/mapbox.rb
+++ b/lib/geocoder/results/mapbox.rb
@@ -16,33 +16,43 @@ module Geocoder::Result
     end
 
     def city
-      context_part('place')
+      data_part('place') || context_part('place')
     end
 
     def state
-      context_part('region')
+      data_part('region') || context_part('region')
     end
 
     def state_code
-      value = context_part('region', 'short_code')
+      if id_matches_name?(data['id'], 'region')
+        value = data['properties']['short_code']
+      else
+        value = context_part('region', 'short_code')
+      end
+
       value.split('-').last unless value.nil?
     end
 
     def postal_code
-      context_part('postcode')
+      data_part('postcode') || context_part('postcode')
     end
 
     def country
-      context_part('country')
+      data_part('country') || context_part('country')
     end
 
     def country_code
-      value = context_part('country', 'short_code')
+      if id_matches_name?(data['id'], 'country')
+        value = data['properties']['short_code']
+      else
+        value = context_part('country', 'short_code')
+      end
+
       value.upcase unless value.nil?
     end
 
     def neighborhood
-      context_part('neighborhood')
+      data_part('neighborhood') || context_part('neighborhood')
     end
 
     def address
@@ -51,8 +61,16 @@ module Geocoder::Result
 
     private
 
+    def id_matches_name?(id, name)
+      id =~ Regexp.new(name)
+    end
+
+    def data_part(name)
+      data['text'] if id_matches_name?(data['id'], name)
+    end
+
     def context_part(name, key = 'text')
-      (context.detect { |c| c['id'] =~ Regexp.new(name) } || {})[key]
+      (context.detect { |c| id_matches_name?(c['id'], name) } || {})[key]
     end
 
     def context


### PR DESCRIPTION
## Summary

Fixes `nil` return in the following `Geocoder::Result::Mapbox` methods: `city`, `state`, `state_code`, `postal_code`, `country`, `country_code`, and `neighborhood`. 

## Explanation

Given the following example of a "region" type response, the `Geocoder::Result::Mapbox` class will not return a value for the `state` or `state_code` methods despite the necessary data existing in the payload: 

```json
  {
    "id": "region.107756",
    "type": "Feature",
    "place_type": [
      "region"
    ],
    "relevance": 1,
    "properties": {
      "mapbox_id": "dXJuOm1ieHBsYzpBYVRz",
      "wikidata": "Q1384",
      "short_code": "US-NY"
    },
    "text": "New York",
    "place_name": "New York, United States",
    "bbox": [
      -79.8046875,
      40.4771401,
      -71.763627,
      45.0239467
    ],
    "center": [
      -75.4652471468304,
      42.751210955038
    ],
    "geometry": {
      "type": "Point",
      "coordinates": [
        -75.4652471468304,
        42.751210955038
      ]
    },
    "context": [
      {
        "id": "country.8940",
        "mapbox_id": "dXJuOm1ieHBsYzpJdXc",
        "wikidata": "Q30",
        "short_code": "us",
        "text": "United States"
      }
    ]
}
```

The incumbent logic assumes that there is an array item in `context` that will have an `id` containing the "region" string. Since there isn't one, `nil` is returned from the `state` and `state_code` methods. However, the `id` in the top-level of the object does contain the "region" string because it is a region type response. This means that the top-level `text` property is the value that should be returned in the `state` method, and the top-level `properties.short_code` should be returned as `state_code`.

This same pattern holds true for the other types of responses. The base payload "type" (id) determines whether or not values for certain methods should be pulled from a `context` list item or from the base `text`/`properties`. 