### PR TITLE
Update mapbox result to use place_name as address

### DIFF
--- a/lib/geocoder/results/mapbox.rb
+++ b/lib/geocoder/results/mapbox.rb
@@ -56,7 +56,7 @@ module Geocoder::Result
     end
 
     def address
-      [place_name, street, city, state, postal_code, country].compact.join(', ')
+      data['place_name']
     end
 
     private

--- a/test/fixtures/mapbox_chicago_il
+++ b/test/fixtures/mapbox_chicago_il
@@ -1,0 +1,44 @@
+{
+  "type": "FeatureCollection",
+  "query": ["chicago"],
+  "features": [
+    {
+      "id": "place.59328748",
+      "type": "Feature",
+      "place_type": ["place"],
+      "relevance": 1,
+      "properties": {
+        "mapbox_id": "dXJuOm1ieHBsYzpBNGxJN0E",
+        "wikidata": "Q1297"
+      },
+      "text": "Chicago",
+      "place_name": "Chicago, Illinois, United States",
+      "bbox": [-87.869226, 41.6326524, -87.4969592, 42.0348953],
+      "center": [-87.63236, 41.881954],
+      "geometry": {"type": "Point", "coordinates": [-87.63236, 41.881954]},
+      "context": [
+        {
+          "id": "district.5162732",
+          "mapbox_id": "dXJuOm1ieHBsYzpUc2Jz",
+          "wikidata": "Q108418",
+          "text": "Cook County"
+        },
+        {
+          "id": "region.17644",
+          "mapbox_id": "dXJuOm1ieHBsYzpST3c",
+          "wikidata": "Q1204",
+          "short_code": "US-IL",
+          "text": "Illinois"
+        },
+        {
+          "id": "country.8940",
+          "mapbox_id": "dXJuOm1ieHBsYzpJdXc",
+          "wikidata": "Q30",
+          "short_code": "us",
+          "text": "United States"
+        }
+      ]
+    }
+  ],
+  "attribution": "NOTICE: © 2024 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service (https://www.mapbox.com/about/maps/). This response and the information it contains may not be retained. POI(s) provided by Foursquare."
+}

--- a/test/fixtures/mapbox_chicago_il_60647
+++ b/test/fixtures/mapbox_chicago_il_60647
@@ -1,0 +1,47 @@
+{
+  "type": "FeatureCollection",
+  "query": ["60647"],
+  "features": [
+    {
+      "id": "postcode.208334572",
+      "type": "Feature",
+      "place_type": ["postcode"],
+      "relevance": 1,
+      "properties": {"mapbox_id": "dXJuOm1ieHBsYzpER3J1N0E"},
+      "text": "60647",
+      "place_name": "Chicago, Illinois 60647, United States",
+      "bbox": [-87.727075, 41.909191, -87.6752, 41.933705],
+      "center": [-87.700436, 41.924799],
+      "geometry": {"type": "Point", "coordinates": [-87.700436, 41.924799]},
+      "context": [
+        {
+          "id": "place.59328748",
+          "mapbox_id": "dXJuOm1ieHBsYzpBNGxJN0E",
+          "wikidata": "Q1297",
+          "text": "Chicago"
+        },
+        {
+          "id": "district.5162732",
+          "mapbox_id": "dXJuOm1ieHBsYzpUc2Jz",
+          "wikidata": "Q108418",
+          "text": "Cook County"
+        },
+        {
+          "id": "region.17644",
+          "mapbox_id": "dXJuOm1ieHBsYzpST3c",
+          "wikidata": "Q1204",
+          "short_code": "US-IL",
+          "text": "Illinois"
+        },
+        {
+          "id": "country.8940",
+          "mapbox_id": "dXJuOm1ieHBsYzpJdXc",
+          "wikidata": "Q30",
+          "short_code": "us",
+          "text": "United States"
+        }
+      ]
+    }
+  ],
+  "attribution": "NOTICE: © 2024 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service (https://www.mapbox.com/about/maps/). This response and the information it contains may not be retained. POI(s) provided by Foursquare."
+}

--- a/test/fixtures/mapbox_illinois
+++ b/test/fixtures/mapbox_illinois
@@ -1,0 +1,35 @@
+{
+  "type": "FeatureCollection",
+  "query": ["illinois"],
+  "features": [
+    {
+      "id": "region.17644",
+      "type": "Feature",
+      "place_type": ["region"],
+      "relevance": 1,
+      "properties": {
+        "mapbox_id": "dXJuOm1ieHBsYzpST3c",
+        "wikidata": "Q1204",
+        "short_code": "US-IL"
+      },
+      "text": "Illinois",
+      "place_name": "Illinois, United States",
+      "bbox": [-91.513079, 36.970298, -87.0117187, 42.5854443],
+      "center": [-89.2749461071049, 40.1492928594374],
+      "geometry": {
+        "type": "Point",
+        "coordinates": [-89.2749461071049, 40.1492928594374]
+      },
+      "context": [
+        {
+          "id": "country.8940",
+          "mapbox_id": "dXJuOm1ieHBsYzpJdXc",
+          "wikidata": "Q30",
+          "short_code": "us",
+          "text": "United States"
+        }
+      ]
+    }
+  ],
+  "attribution": "NOTICE: © 2024 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service (https://www.mapbox.com/about/maps/). This response and the information it contains may not be retained. POI(s) provided by Foursquare."
+}

--- a/test/fixtures/mapbox_logan_square_chicago_il
+++ b/test/fixtures/mapbox_logan_square_chicago_il
@@ -1,0 +1,55 @@
+{
+  "type": "FeatureCollection",
+  "query": ["logan", "square", "chicago"],
+  "features": [
+    {
+      "id": "neighborhood.368872684",
+      "type": "Feature",
+      "place_type": ["neighborhood"],
+      "relevance": 1,
+      "properties": {
+        "mapbox_id": "dXJuOm1ieHBsYzpGZnlNN0E",
+        "wikidata": "Q3257855"
+      },
+      "text": "Logan Square",
+      "place_name": "Logan Square, Chicago, Illinois, United States",
+      "bbox": [-87.7314573, 41.9136391, -87.687314, 41.9321823],
+      "center": [-87.70235, 41.92597],
+      "geometry": {"type": "Point", "coordinates": [-87.70235, 41.92597]},
+      "context": [
+        {
+          "id": "postcode.208334572",
+          "mapbox_id": "dXJuOm1ieHBsYzpER3J1N0E",
+          "text": "60647"
+        },
+        {
+          "id": "place.59328748",
+          "mapbox_id": "dXJuOm1ieHBsYzpBNGxJN0E",
+          "wikidata": "Q1297",
+          "text": "Chicago"
+        },
+        {
+          "id": "district.5162732",
+          "mapbox_id": "dXJuOm1ieHBsYzpUc2Jz",
+          "wikidata": "Q108418",
+          "text": "Cook County"
+        },
+        {
+          "id": "region.17644",
+          "mapbox_id": "dXJuOm1ieHBsYzpST3c",
+          "wikidata": "Q1204",
+          "short_code": "US-IL",
+          "text": "Illinois"
+        },
+        {
+          "id": "country.8940",
+          "mapbox_id": "dXJuOm1ieHBsYzpJdXc",
+          "wikidata": "Q30",
+          "short_code": "us",
+          "text": "United States"
+        }
+      ]
+    }
+  ],
+  "attribution": "NOTICE: © 2024 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service (https://www.mapbox.com/about/maps/). This response and the information it contains may not be retained. POI(s) provided by Foursquare."
+}

--- a/test/fixtures/mapbox_united_states
+++ b/test/fixtures/mapbox_united_states
@@ -1,0 +1,26 @@
+{
+  "type": "FeatureCollection",
+  "query": ["united", "states"],
+  "features": [
+    {
+      "id": "country.8940",
+      "type": "Feature",
+      "place_type": ["country"],
+      "relevance": 1,
+      "properties": {
+        "mapbox_id": "dXJuOm1ieHBsYzpJdXc",
+        "wikidata": "Q30",
+        "short_code": "us"
+      },
+      "text": "United States",
+      "place_name": "United States",
+      "bbox": [-179.9, 18.8164227, -66.8847656, 71.420291],
+      "center": [-97.9222112121185, 39.3812661305678],
+      "geometry": {
+        "type": "Point",
+        "coordinates": [-97.9222112121185, 39.3812661305678]
+      }
+    }
+  ],
+  "attribution": "NOTICE: © 2024 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service (https://www.mapbox.com/about/maps/). This response and the information it contains may not be retained. POI(s) provided by Foursquare."
+}

--- a/test/unit/lookups/mapbox_test.rb
+++ b/test/unit/lookups/mapbox_test.rb
@@ -33,7 +33,7 @@ class MapboxTest < GeocoderTestCase
     assert_equal "United States", result.country
     assert_equal "US", result.country_code
     assert_equal "Garment District", result.neighborhood
-    assert_equal "Madison Square Garden, 4 Penn Plz, New York, New York, 10119, United States", result.address
+    assert_equal "Madison Square Garden, 4 Penn Plz, New York, New York 10119, United States", result.address
   end
 
   def test_no_results
@@ -57,5 +57,80 @@ class MapboxTest < GeocoderTestCase
       result = Geocoder.search("Shanghai, China")[0]
       assert_equal nil, result.city
     end
+  end
+
+  def test_neighborhood_result
+    result = Geocoder.search("Logan Square, Chicago, IL").first
+    assert_equal [41.92597, -87.70235], result.coordinates
+    assert_equal "Logan Square", result.place_name
+    assert_equal nil, result.street
+    assert_equal "Chicago", result.city
+    assert_equal "Illinois", result.state
+    assert_equal "60647", result.postal_code
+    assert_equal "IL", result.state_code
+    assert_equal "United States", result.country
+    assert_equal "US", result.country_code
+    assert_equal "Logan Square", result.neighborhood
+    assert_equal "Logan Square, Chicago, Illinois, United States", result.address
+  end
+
+  def test_postcode_result
+    result = Geocoder.search("Chicago, IL 60647").first
+    assert_equal [41.924799, -87.700436], result.coordinates
+    assert_equal "60647", result.place_name
+    assert_equal nil, result.street
+    assert_equal "Chicago", result.city
+    assert_equal "Illinois", result.state
+    assert_equal "60647", result.postal_code
+    assert_equal "IL", result.state_code
+    assert_equal "United States", result.country
+    assert_equal "US", result.country_code
+    assert_equal nil, result.neighborhood
+    assert_equal "Chicago, Illinois 60647, United States", result.address
+  end
+
+  def test_place_result
+    result = Geocoder.search("Chicago, IL").first
+    assert_equal [41.881954, -87.63236], result.coordinates
+    assert_equal "Chicago", result.place_name
+    assert_equal nil, result.street
+    assert_equal "Chicago", result.city
+    assert_equal "Illinois", result.state
+    assert_equal nil, result.postal_code
+    assert_equal "IL", result.state_code
+    assert_equal "United States", result.country
+    assert_equal "US", result.country_code
+    assert_equal nil, result.neighborhood
+    assert_equal "Chicago, Illinois, United States", result.address
+  end
+
+  def test_region_result
+    result = Geocoder.search("Illinois").first
+    assert_equal [40.1492928594374, -89.2749461071049], result.coordinates
+    assert_equal "Illinois", result.place_name
+    assert_equal nil, result.street
+    assert_equal nil, result.city
+    assert_equal "Illinois", result.state
+    assert_equal nil, result.postal_code
+    assert_equal "IL", result.state_code
+    assert_equal "United States", result.country
+    assert_equal "US", result.country_code
+    assert_equal nil, result.neighborhood
+    assert_equal "Illinois, United States", result.address
+  end
+
+  def test_country_result
+    result = Geocoder.search("United States").first
+    assert_equal [39.3812661305678, -97.9222112121185], result.coordinates
+    assert_equal "United States", result.place_name
+    assert_equal nil, result.street
+    assert_equal nil, result.city
+    assert_equal nil, result.state
+    assert_equal nil, result.postal_code
+    assert_equal nil, result.state_code
+    assert_equal "United States", result.country
+    assert_equal "US", result.country_code
+    assert_equal nil, result.neighborhood
+    assert_equal "United States", result.address
   end
 end


### PR DESCRIPTION
Follow up to https://github.com/alexreisner/geocoder/pull/1655

Non-nil values are now being returned (when appropriate) for the `city`, `state`, `state_code`, `postal_code`, `country`, `country_code`, and `neighborhood` methods. However, as a result the `Geocoder::Result::Mapbox#address` method needs to be updated otherwise the returned value will contain duplicated text. 

Example: Given that the `city` method now returns a value for "place" type results, a search result for "Chicago, IL" will return "Chicago, Chicago, Illinois, United States". This is because `.place_name` and `.city` return the same value, and both are being used to build the address. 

To solve this, we can simply use the `place_name` property on the Mapbox payload as the address rather than building our own. 

Specs and fixtures have been added to test the different types of results you can get with Mapbox. 