### PR TITLE
Allow using http with photon. Helpful when self-hosting.

### DIFF
--- a/lib/geocoder/lookups/photon.rb
+++ b/lib/geocoder/lookups/photon.rb
@@ -10,7 +10,7 @@ module Geocoder::Lookup
     private # ---------------------------------------------------------------
 
     def supported_protocols
-      [:https]
+      [:http, :https]
     end
 
     def base_query_url(query)


### PR DESCRIPTION
I would like to be able to use `http` protocol with my self-hosted Photon instance that is not exposed to the Internet, but the existing code prevents that.

Thank you.