### PR TITLE
Add Language support for AWS Locations service

### DIFF
--- a/lib/geocoder/lookups/amazon_location_service.rb
+++ b/lib/geocoder/lookups/amazon_location_service.rb
@@ -10,6 +10,9 @@ module Geocoder::Lookup
       # Aws::ParamValidator raises ArgumentError on missing required keys
       params.merge!(index_name: configuration[:index_name])
 
+      # Inherit language from configuration
+      params.merge!(language: configuration[:language])
+
       # Aws::ParamValidator raises ArgumentError on unexpected keys
       params.delete(:lookup) 
       

--- a/lib/geocoder/lookups/amazon_location_service.rb
+++ b/lib/geocoder/lookups/amazon_location_service.rb
@@ -10,18 +10,18 @@ module Geocoder::Lookup
       # Aws::ParamValidator raises ArgumentError on missing required keys
       params.merge!(index_name: configuration[:index_name])
 
+      # Aws::ParamValidator raises ArgumentError on unexpected keys
+      params.delete(:lookup)
+
       # Inherit language from configuration
       params.merge!(language: configuration[:language])
 
-      # Aws::ParamValidator raises ArgumentError on unexpected keys
-      params.delete(:lookup) 
-      
       resp = if query.reverse_geocode?
         client.search_place_index_for_position(params.merge(position: query.coordinates.reverse))
       else
         client.search_place_index_for_text(params.merge(text: query.text))
       end
-      
+
       resp.results
     end
 


### PR DESCRIPTION
This change will use `language` option from the config. Example: 
`language: :en`
Before this PR:
```
  label = "ทางหลวงชนบทภก. 4018 ตำบลเชิงทะเล อำเภอถลาง จังหวัดภูเก็ต 83110",
  municipality = "ตำบลเชิงทะเล",
  postal_code = "83110",
  region = "จังหวัดภูเก็ต",
  sub_region = "อำเภอถลาง",
```

after:
```
  label = "Phuket 4018 Rural Rd, Choeng Thale, Thalang, Phuket 83110, THA",
  municipality = "Choeng Thale",
  postal_code = "83110",
  region = "Phuket",
  sub_region = "Thalang",
```