### PR TITLE
bug: Fixed unexpected error with invalid api key when exception-raising is not configured

### DIFF
--- a/lib/geocoder/lookups/mapbox.rb
+++ b/lib/geocoder/lookups/mapbox.rb
@@ -20,6 +20,7 @@ module Geocoder::Lookup
         sort_relevant_feature(data['features'])
       elsif data['message'] =~ /Invalid\sToken/
         raise_error(Geocoder::InvalidApiKey, data['message'])
+        []
       else
         []
       end

--- a/test/unit/lookups/mapbox_test.rb
+++ b/test/unit/lookups/mapbox_test.rb
@@ -47,6 +47,10 @@ class MapboxTest < GeocoderTestCase
     end
   end
 
+  def test_empty_array_on_invalid_api_key
+    assert_equal [], Geocoder.search("invalid api key")
+  end
+
   def test_truncates_query_at_semicolon
     result = Geocoder.search("Madison Square Garden, New York, NY;123 Another St").first
     assert_equal [40.750755, -73.993710125], result.coordinates


### PR DESCRIPTION
This PR fix the open bug issue https://github.com/alexreisner/geocoder/issues/1657 .

## Bug
If geocoder is configured with MapBox and invalid api key and `always_raise` doesn't contain `Geocoder::InvalidApiKey`, `Geocoder.search` will throw the following error.
```
/usr/local/bundle/gems/geocoder-1.8.3/lib/geocoder/lookups/base.rb:46:in `search': undefined method `map' for false:FalseClass (NoMethodError)

        results(query).map{ |r|
                      ^^^^
Did you mean?  tap
```

## Why this happened
`results(query)` is evaluated as `false` in https://github.com/alexreisner/geocoder/blob/5b379a5f626bcd6b2e932627996ef6ba22761afc/lib/geocoder/lookups/base.rb#L46
because `raise_error` is called in the `results` method, and `results` returns `false` if `always_raise` doesn't contain the argument error.