### PR TITLE
update valid_region_codes for trimble to include new regions for Mexico and Middle East

### DIFF
--- a/lib/geocoder/lookups/pc_miler.rb
+++ b/lib/geocoder/lookups/pc_miler.rb
@@ -10,10 +10,12 @@ module Geocoder::Lookup
       # AF: Africa
       # AS: Asia
       # EU: Europe
+      # ME: Middle East
+      # MX: Mexico
       # NA: North America
       # OC: Oceania
       # SA: South America
-      %w[AF AS EU NA OC SA]
+      %w[AF AS EU ME MX NA OC SA]
     end
 
     def name


### PR DESCRIPTION
According to the [trimble api documentation](https://developer.trimblemaps.com/restful-apis/location/single-search/single-search-api/#test-the-api-now) (which is also currently referenced in this codebase), There are now 2 additional regions supported which are currently not included in the set

The two additional ones are 
1. Mexico (MX)
2. Middle East (ME)

Making the full set to be the following:

1. North America (NA)
4. Europe (EU)
5. Asia (AS)
6. Africa (AF)
7. South America (SA)
8. Oceania (OC)
9. Mexico (MX)
10. Middle East (ME)