### PR TITLE
Radius column can be an instance of Arel.sql

### DIFF
--- a/lib/geocoder/stores/active_record.rb
+++ b/lib/geocoder/stores/active_record.rb
@@ -132,7 +132,8 @@ module Geocoder::Store
         # If radius is a DB column name, bounding box should include
         # all rows within the maximum radius appearing in that column.
         # Note: performance is dependent on variability of radii.
-        bb_radius = radius.is_a?(Symbol) ? maximum(radius) : radius
+        radius_is_column = radius.is_a?(Symbol) || (defined?(Arel::Nodes::SqlLiteral) && radius.is_a?(Arel::Nodes::SqlLiteral))
+        bb_radius = radius_is_column ? maximum(radius) : radius
         b = Geocoder::Calculations.bounding_box([latitude, longitude], bb_radius, options)
         args = b + [
           full_column_name(latitude_attribute),
@@ -146,7 +147,7 @@ module Geocoder::Store
           min_radius = options.fetch(:min_radius, 0).to_f
           # if radius is a DB column name,
           # find rows between min_radius and value in column
-          if radius.is_a?(Symbol)
+          if radius_is_column
             c = "BETWEEN ? AND #{radius}"
             a = [min_radius]
           else

--- a/test/unit/near_test.rb
+++ b/test/unit/near_test.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require 'test_helper'
+require 'arel'
 
 class NearTest < GeocoderTestCase
 

--- a/test/unit/near_test.rb
+++ b/test/unit/near_test.rb
@@ -25,6 +25,13 @@ class NearTest < GeocoderTestCase
     assert_match(/BETWEEN \? AND radius_column$/, result[:conditions][0])
   end
 
+  def test_near_scope_options_includes_radius_column_max_radius_arel
+    omit("Not applicable to unextended SQLite") if using_unextended_sqlite?
+
+    result = Place.send(:near_scope_options, 1.0, 2.0, Arel.sql('CASE WHEN TRUE THEN radius_column ELSE 0 END'))
+    assert_match(/BETWEEN \? AND CASE WHEN TRUE THEN radius_column ELSE 0 END$/, result[:conditions][0])
+  end
+
   def test_near_scope_options_includes_radius_default_min_radius
     omit("Not applicable to unextended SQLite") if using_unextended_sqlite?
 
@@ -45,7 +52,7 @@ class NearTest < GeocoderTestCase
 
   def test_near_scope_options_includes_radius_bogus_min_radius
     omit("Not applicable to unextended SQLite") if using_unextended_sqlite?
-    
+
     result = Place.send(:near_scope_options, 1.0, 2.0, 5, :min_radius => 'bogus')
 
     assert_equal(0, result[:conditions][1])


### PR DESCRIPTION
With older Rails versions and Geocoder you could do something like:
```ruby
Person.near(city.coordinates, :"COALESCE(distance_preference, 100)")
# or
Person.near(city.coordinates, :"CASE WHEN travels_by_foot THEN foot_travel_distance ELSE car_travel_distance END")
```

But with newer Rails versions (well, by newer I mean like 6.1 or something) the query ends up looking like

```sql
SELECT MAX("COALESCE(distance_preference, 100)") FROM people
```

(there's no column `"COALESCE(distance_preference, 100)"`)

So usually within Rails you would do `Person.maximum(Arel("COALESCE(distance_preference, 100)"))`

But with Geocoder due to the `radius.is_a?(Symbol)` check it's not possible,
so with this PR I am extending the logic to work with Arel SQL literals.

After this change the following code works:
```ruby
Person.near(city.coordinates, Arel.sql("COALESCE(distance_preference, 100)"))
# or
Person.near(city.coordinates, Arel.sql("CASE WHEN travels_by_foot THEN foot_travel_distance ELSE car_travel_distance END"))
```