### PR TITLE
Add error handling case for HTTP 405

### DIFF
--- a/lib/geocoder/exceptions.rb
+++ b/lib/geocoder/exceptions.rb
@@ -37,4 +37,7 @@ module Geocoder
   class NetworkError < Error
   end
 
+  class MethodNotAllowed < Error
+  end
+
 end

--- a/lib/geocoder/lookups/base.rb
+++ b/lib/geocoder/lookups/base.rb
@@ -281,6 +281,9 @@ module Geocoder
         elsif response.code.to_i == 402
           raise_error(Geocoder::OverQueryLimitError) ||
             Geocoder.log(:warn, "Geocoding API error: 402 Payment Required")
+        elsif response.code.to_i == 405
+          raise_error(Geocoder::MethodNotAllowed) ||
+            Geocoder.log(:warn, "Geocoding API error: 405 Method Not Allowed")
         elsif response.code.to_i == 429
           raise_error(Geocoder::OverQueryLimitError) ||
             Geocoder.log(:warn, "Geocoding API error: 429 Too Many Requests")

--- a/test/unit/lookups/nominatim_test.rb
+++ b/test/unit/lookups/nominatim_test.rb
@@ -48,4 +48,13 @@ class NominatimTest < GeocoderTestCase
       l.send(:results, Geocoder::Query.new("over limit"))
     end
   end
+
+  def test_raises_exception_when_method_not_allowed
+    Geocoder.configure(:always_raise => [Geocoder::MethodNotAllowed])
+    l = Geocoder::Lookup.get(:nominatim)
+    assert_raises Geocoder::MethodNotAllowed do
+      response = MockHttpResponse.new(code: 405)
+      l.send(:check_response_for_errors!, response)
+    end
+  end
 end


### PR DESCRIPTION
Adds HTTP 405 error handling case as discussed in [this](https://github.com/alexreisner/geocoder/issues/1692) issue thread.