### PR TITLE
Update domain for ban_data_gouv_fr adapter

### DIFF
--- a/lib/geocoder/lookups/ban_data_gouv_fr.rb
+++ b/lib/geocoder/lookups/ban_data_gouv_fr.rb
@@ -18,7 +18,7 @@ module Geocoder::Lookup
 
     def base_query_url(query)
       method = query.reverse_geocode? ? "reverse" : "search"
-      "#{protocol}://api-adresse.data.gouv.fr/#{method}/?"
+      "#{protocol}://data.geopf.fr/geocodage/#{method}/?"
     end
 
     def any_result?(doc)

--- a/test/unit/lookups/ban_data_gouv_fr_test.rb
+++ b/test/unit/lookups/ban_data_gouv_fr_test.rb
@@ -12,21 +12,21 @@ class BanDataGouvFrTest < GeocoderTestCase
     query = Geocoder::Query.new('13 rue yves toudic, 75010 Paris')
     lookup = Geocoder::Lookup.get(:ban_data_gouv_fr)
     res = lookup.query_url(query)
-    assert_equal 'https://api-adresse.data.gouv.fr/search/?q=13+rue+yves+toudic%2C+75010+Paris', res
+    assert_equal 'https://data.geopf.fr/geocodage/search/?q=13+rue+yves+toudic%2C+75010+Paris', res
   end
 
   def test_query_for_geocode_with_geographic_priority
     query = Geocoder::Query.new('13 rue yves toudic, 75010 Paris', lat: 48.789, lon: 2.789)
     lookup = Geocoder::Lookup.get(:ban_data_gouv_fr)
     res = lookup.query_url(query)
-    assert_equal 'https://api-adresse.data.gouv.fr/search/?lat=48.789&lon=2.789&q=13+rue+yves+toudic%2C+75010+Paris', res
+    assert_equal 'https://data.geopf.fr/geocodage/search/?lat=48.789&lon=2.789&q=13+rue+yves+toudic%2C+75010+Paris', res
   end
 
   def test_query_for_reverse_geocode
     query = Geocoder::Query.new([48.770639, 2.364375])
     lookup = Geocoder::Lookup.get(:ban_data_gouv_fr)
     res = lookup.query_url(query)
-    assert_equal 'https://api-adresse.data.gouv.fr/reverse/?lat=48.770639&lon=2.364375', res
+    assert_equal 'https://data.geopf.fr/geocodage/reverse/?lat=48.770639&lon=2.364375', res
   end
 
   def test_results_component


### PR DESCRIPTION
The official domain has changed a while ago, the old one was still working but yesterday there was an incident affecting only the old domain. It's back up again but it is probably best to use the official domain.

Reference: https://geoservices.ign.fr/documentation/services/services-geoplateforme/geocodage