### PR TITLE
Update doc : add quota for Base Adresse Nationale FR (`:ban_data_gouv_fr`)

### DIFF
--- a/README_API_GUIDE.md
+++ b/README_API_GUIDE.md
@@ -425,7 +425,7 @@ Regional Street Address Lookups
 ### Base Adresse Nationale FR (`:ban_data_gouv_fr`)
 
 * **API key**: none
-* **Quota**: none
+* **Quota**: 50 requests/second
 * **Region**: France
 * **SSL support**: yes
 * **Languages**: en / fr


### PR DESCRIPTION
source: https://adresse.data.gouv.fr/outils/api-doc/adresse

> Si le script sollicite l'API de géocodage sans précaution particulière, avec une fréquence qui dépasse la limite d'usage de 50 requêtes par seconde et par IP, alors :
>
> Les 50 premiers appels sont traités normalement ;
Le 51ème appel et les suivants sont bloqués tant que le script continue à solliciter l'API de géocodage au-delà de la limite de 50 requêtes par seconde et que le délai de 5 secondes qui s'en suit n'est pas écoulé.

Translation: 

>If the script calls the geocoding API without any particular precautions, with a frequency that exceeds the usage limit of 50 requests per second per IP, then:
>
>The first 50 calls are processed normally; The 51st call and subsequent calls are blocked as long as the script continues to request the geocoding API beyond the limit of 50 requests per second and the following 5-second delay has not elapsed.