### PR TITLE
Force https on BAN lookup

### DIFF
--- a/lib/geocoder/lookups/ban_data_gouv_fr.rb
+++ b/lib/geocoder/lookups/ban_data_gouv_fr.rb
@@ -14,6 +14,10 @@ module Geocoder::Lookup
       "https://www.openstreetmap.org/#map=19/#{coordinates.join('/')}"
     end
 
+    def supported_protocols
+      [:https]
+    end
+
     private # ---------------------------------------------------------------
 
     def base_query_url(query)


### PR DESCRIPTION
Following https://github.com/alexreisner/geocoder/pull/1694 (more info written there)

The BAN endpoint does not respond to http requests on port 80, which triggers a timeout. It works well when using https.

So I think we should force https when using the BAN instead of relying on the config