### PR TITLE
Update readme Rails compatibility to include version 8.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Compatibility:
 
 * Ruby versions: 2.5+ and JRuby.
 * Databases: MySQL, PostgreSQL, SQLite, and MongoDB.
-* Rails: 5.x, 6.x, and 7.x.
+* Rails: 5.x, 6.x, 7.x and 8.x.
 * Works outside of Rails with the `json` (for MRI) or `json_pure` (for JRuby) gem.
 
 


### PR DESCRIPTION
From what I could read in the gemspec and my tests geocoder is compatible with Rails 8.x. This PR makes it straight forward in the readme