### PR TITLE
Add `street_address` to nominatim result

### DIFF
--- a/lib/geocoder/results/nominatim.rb
+++ b/lib/geocoder/results/nominatim.rb
@@ -16,6 +16,10 @@ module Geocoder::Result
       @data['display_name']
     end
 
+    def street_address
+      [house_number, street].compact.join(' ')
+    end
+
     def street
       %w[road pedestrian highway].each do |key|
         return address_data[key] if address_data.key?(key)


### PR DESCRIPTION
# Description

We're using nominatim and Google as backends for Geocoder. We'd like to be able to get the address, including street number. This adds a `street_address` method in the same style as the one for Google.

https://github.com/alexreisner/geocoder/blob/8143fce1820539cdaf6344c3400edf5690ec1611/lib/geocoder/results/google.rb#L86-L88
